### PR TITLE
test: add desktop shell UI coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ melos run test
 melos run format-check
 ```
 
+Отдельные manual smoke шаги для desktop baseline описаны в [`docs/testing.md`](docs/testing.md).
+
 Смысл команд:
 
 - `bootstrap` - подтянуть зависимости по всем пакетам.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,13 @@
+# Testing
+
+## Windows Smoke Checklist
+
+Use this checklist on the developer Windows machine after building or running the desktop app.
+
+1. Start the desktop application.
+2. Verify that the main window opens with the title `ПО Расписание Бочки`.
+3. Verify that the window can be resized and does not collapse below the intended minimum layout.
+4. Open the `Справочники` menu in the header.
+5. Select `Тренеры` and verify that the trainers placeholder screen is shown.
+6. Open `Справочники` again, select `Участники`, and verify that the participants placeholder screen is shown.
+7. Verify that the application stays responsive and does not crash during those actions.

--- a/packages/bochki_schedule_app/integration_test/app_shell_test.dart
+++ b/packages/bochki_schedule_app/integration_test/app_shell_test.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+
+import 'package:bochki_schedule_app/bochki_schedule_app.dart';
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('desktop shell opens menu and switches sections', (tester) async {
+    final services = AppServices(
+      appDataDirectory: Directory('/tmp/bochki_schedule_test'),
+      logger: const _NoopLogger(),
+      projectDocumentStore: const _NoopProjectDocumentStore(),
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: services));
+
+    expect(find.text('ПО Расписание Бочки'), findsOneWidget);
+    expect(find.text('Справочники'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('directories_menu_button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Тренеры').last);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('placeholder_trainers')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('directories_menu_button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Участники').last);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('placeholder_participants')), findsOneWidget);
+  });
+}
+
+final class _NoopLogger implements AppLogger {
+  const _NoopLogger();
+
+  @override
+  Future<void> error(
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+  }) async {}
+
+  @override
+  Future<void> info(String message) async {}
+}
+
+final class _NoopProjectDocumentStore implements ProjectDocumentStore {
+  const _NoopProjectDocumentStore();
+
+  @override
+  Future<ProjectDocument?> read(File file) async => null;
+
+  @override
+  Future<void> write(File file, ProjectDocument document) async {}
+}

--- a/packages/bochki_schedule_app/pubspec.lock
+++ b/packages/bochki_schedule_app/pubspec.lock
@@ -63,8 +63,21 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   flutter:
     dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -77,6 +90,16 @@ packages:
     source: hosted
     version: "4.0.0"
   flutter_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  integration_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
@@ -153,6 +176,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -161,6 +192,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   screen_retriever:
     dependency: transitive
     description:
@@ -238,6 +277,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -270,6 +317,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.2.5"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
   window_manager:
     dependency: "direct main"
     description:

--- a/packages/bochki_schedule_app/pubspec.yaml
+++ b/packages/bochki_schedule_app/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
   window_manager: ^0.4.3
 
 dev_dependencies:
+  integration_test:
+    sdk: flutter
   flutter_test:
     sdk: flutter
   flutter_lints: ^4.0.0


### PR DESCRIPTION
Closes #4

## Summary
- add integration_test coverage for the desktop shell menu flow
- add a Windows manual smoke checklist document
- link testing guidance from the root README

## Verification
- melos bootstrap
- melos run analyze
- melos run test
- melos run format-check
- flutter test packages/bochki_schedule_app/integration_test/app_shell_test.dart (blocked in this Ubuntu environment by missing Linux desktop system prerequisite: pkg-config/GTK toolchain)