### PR TITLE
docs: polish developer workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - `FVM`
 - Flutter SDK версии из `.fvmrc`
 - `melos`
+- для Linux desktop integration: `clang`, `cmake`, `ninja-build`, `pkg-config`, `libgtk-3-dev`
 
 ## Подготовка окружения
 
@@ -54,6 +55,7 @@ dart pub global activate melos
 ```
 
 Если `melos` установлен глобально, убедитесь, что он доступен в `PATH`.
+Альтернатива без глобальной установки: `dart run melos <command>`.
 
 ## Команды workspace
 
@@ -62,6 +64,7 @@ melos bootstrap
 melos run analyze
 melos run test
 melos run format-check
+melos run app-test-integration-linux
 ```
 
 Отдельные manual smoke шаги для desktop baseline описаны в [`docs/testing.md`](docs/testing.md).
@@ -72,6 +75,7 @@ melos run format-check
 - `analyze` - прогнать статический анализ по всем пакетам.
 - `test` - прогнать тесты по всем пакетам.
 - `format-check` - проверить форматирование без автоматической правки.
+- `app-test-integration-linux` - прогнать integration test shell на Linux desktop runner.
 
 ## Процесс разработки
 
@@ -91,6 +95,12 @@ melos run format-check
 
 Для merge в `main` должны быть зелеными все обязательные checks.
 macOS артефакт на текущем этапе неподписан и не notarized.
+
+## Troubleshooting
+
+- Если `melos bootstrap` падает, сначала выполните `dart pub get` в корне репозитория.
+- Если Linux desktop integration test не стартует локально, проверьте наличие `clang`, `cmake`, `ninja-build`, `pkg-config`, `libgtk-3-dev`.
+- Если `window_manager` требует desktop target, убедитесь, что нужная платформа включена через `flutter config`.
 
 ## Следующие шаги
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,5 +1,11 @@
 # Testing
 
+## Automated Coverage
+
+- `melos run test` покрывает unit и widget tests по всему workspace.
+- `melos run app-test-integration-linux` прогоняет integration test для desktop shell на Linux.
+- В GitHub Actions desktop integration дополнительно гоняется на Windows.
+
 ## Windows Smoke Checklist
 
 Use this checklist on the developer Windows machine after building or running the desktop app.
@@ -11,3 +17,13 @@ Use this checklist on the developer Windows machine after building or running th
 5. Select `Тренеры` and verify that the trainers placeholder screen is shown.
 6. Open `Справочники` again, select `Участники`, and verify that the participants placeholder screen is shown.
 7. Verify that the application stays responsive and does not crash during those actions.
+
+## Linux Integration Prerequisites
+
+For local Linux desktop integration runs, install:
+
+- `clang`
+- `cmake`
+- `ninja-build`
+- `pkg-config`
+- `libgtk-3-dev`

--- a/melos.yaml
+++ b/melos.yaml
@@ -9,6 +9,10 @@ command:
     usePubspecOverrides: true
 
 scripts:
+  clean:
+    description: Clean generated files across the workspace.
+    run: melos exec -- "flutter clean"
+
   analyze:
     description: Run static analysis for every package in the workspace.
     run: dart run melos exec -- "dart analyze ."
@@ -22,3 +26,7 @@ scripts:
   format-check:
     description: Validate formatting for every package in the workspace.
     run: dart run melos exec -- "dart format --output=none --set-exit-if-changed ."
+
+  app-test-integration-linux:
+    description: Run the desktop shell integration test on Linux.
+    run: dart run melos exec --scope="bochki_schedule_app" -- "flutter test integration_test/app_shell_test.dart -r expanded"


### PR DESCRIPTION
Closes #6

## Summary
- add a small melos DX layer for clean and Linux integration test commands
- improve README troubleshooting and current baseline guidance
- expand testing docs with automated coverage and Linux prerequisites

## Verification
- ruby -e "require 'yaml'; YAML.load_file('melos.yaml')"\n- dart run melos run analyze\n- dart run melos run test\n- dart run melos run format-check