### PR TITLE
feat: add participants directory dialog

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,8 +28,9 @@ Use this checklist on the developer Windows machine after building or running th
 3. Verify that the window can be resized and does not collapse below the intended minimum layout.
 4. Open the `Справочники` menu in the header.
 5. Select `Тренеры` and verify that the trainers placeholder screen is shown.
-6. Open `Справочники` again, select `Участники`, and verify that the participants placeholder screen is shown.
-7. Verify that the application stays responsive and does not crash during those actions.
+6. Open `Справочники` again, select `Участники`, and verify that the participants dialog is shown.
+7. Verify that the dialog contains the participant name field and the add/edit/delete controls.
+8. Verify that the application stays responsive and does not crash during those actions.
 
 ## Linux Integration Prerequisites
 

--- a/packages/bochki_schedule_app/integration_test/app_shell_test.dart
+++ b/packages/bochki_schedule_app/integration_test/app_shell_test.dart
@@ -10,7 +10,8 @@ import 'package:integration_test/integration_test.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('desktop shell opens menu and switches sections', (tester) async {
+  testWidgets('desktop shell opens menu and participant dialog',
+      (tester) async {
     final services = AppServices(
       appDataDirectory: Directory('/tmp/bochki_schedule_test'),
       logger: const _NoopLogger(),
@@ -18,6 +19,7 @@ void main() {
     );
 
     await tester.pumpWidget(BochkiScheduleApp(services: services));
+    await tester.pumpAndSettle();
 
     expect(find.text('ПО Расписание Бочки'), findsOneWidget);
     expect(find.text('Справочники'), findsOneWidget);
@@ -34,7 +36,9 @@ void main() {
     await tester.tap(find.text('Участники').last);
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('placeholder_participants')), findsOneWidget);
+    expect(
+        find.byKey(const Key('participants_directory_dialog')), findsOneWidget);
+    expect(find.byKey(const Key('participant_name_field')), findsOneWidget);
   });
 }
 

--- a/packages/bochki_schedule_app/lib/src/presentation/participants/participants_directory_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/participants/participants_directory_dialog.dart
@@ -1,0 +1,401 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+class ParticipantsDirectoryDialog extends StatefulWidget {
+  const ParticipantsDirectoryDialog({
+    required this.participants,
+    required this.nextId,
+    required this.onChanged,
+    super.key,
+  });
+
+  final List<Map<String, Object?>> participants;
+  final int nextId;
+  final Future<void> Function(
+    List<Map<String, Object?>>,
+    int nextId,
+  ) onChanged;
+
+  @override
+  State<ParticipantsDirectoryDialog> createState() =>
+      _ParticipantsDirectoryDialogState();
+}
+
+class _ParticipantsDirectoryDialogState
+    extends State<ParticipantsDirectoryDialog> {
+  final TextEditingController _nameController = TextEditingController();
+
+  late List<_ParticipantRecord> _participants;
+  late int _nextId;
+  int? _editingParticipantId;
+  String? _nameError;
+
+  @override
+  void initState() {
+    super.initState();
+    _participants = widget.participants
+        .map(_ParticipantRecord.fromJson)
+        .toList(growable: true);
+    _nextId = widget.nextId;
+    _participants.sort(_compareParticipantsByName);
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  static int _compareParticipantsByName(
+    _ParticipantRecord left,
+    _ParticipantRecord right,
+  ) {
+    return _normalizedSortKey(left.name)
+        .compareTo(_normalizedSortKey(right.name));
+  }
+
+  static String _normalizedSortKey(String value) {
+    return _normalizeName(value).toLowerCase();
+  }
+
+  static String _normalizeName(String value) {
+    return value.trim().replaceAll(RegExp(r'\s+'), ' ');
+  }
+
+  List<_ParticipantRecord> get _activeParticipants {
+    final activeParticipants = _participants
+        .where((participant) => !participant.deleted)
+        .toList(growable: false);
+    activeParticipants.sort(_compareParticipantsByName);
+    return activeParticipants;
+  }
+
+  Future<void> _persistChanges() async {
+    await widget.onChanged(
+      _participants.map((participant) => participant.toJson()).toList(
+            growable: false,
+          ),
+      _nextId,
+    );
+  }
+
+  void _startEditing(_ParticipantRecord participant) {
+    setState(() {
+      _editingParticipantId = participant.id;
+      _nameController.text = participant.name;
+      _nameController.selection = TextSelection.fromPosition(
+        TextPosition(offset: _nameController.text.length),
+      );
+      _nameError = null;
+    });
+  }
+
+  void _cancelEditing() {
+    setState(() {
+      _editingParticipantId = null;
+      _nameController.clear();
+      _nameError = null;
+    });
+  }
+
+  bool _hasDuplicateName(String normalizedName) {
+    final normalizedCandidate = normalizedName.toLowerCase();
+    return _participants.any((participant) {
+      if (participant.deleted) {
+        return false;
+      }
+      if (participant.id == _editingParticipantId) {
+        return false;
+      }
+      return _normalizedSortKey(participant.name) == normalizedCandidate;
+    });
+  }
+
+  Future<void> _submitParticipant() async {
+    final normalizedName = _normalizeName(_nameController.text);
+    if (normalizedName.isEmpty) {
+      setState(() {
+        _nameError = 'Введите имя участника.';
+      });
+      return;
+    }
+
+    if (_hasDuplicateName(normalizedName)) {
+      setState(() {
+        _nameError = 'Участник с таким именем уже есть.';
+      });
+      return;
+    }
+
+    setState(() {
+      if (_editingParticipantId == null) {
+        _participants.add(
+          _ParticipantRecord(
+            id: _nextId,
+            name: normalizedName,
+            deleted: false,
+          ),
+        );
+        _nextId += 1;
+      } else {
+        final index = _participants.indexWhere(
+          (participant) => participant.id == _editingParticipantId,
+        );
+        if (index != -1) {
+          _participants[index] = _participants[index].copyWith(
+            name: normalizedName,
+          );
+        }
+      }
+
+      _editingParticipantId = null;
+      _nameController.clear();
+      _nameError = null;
+      _participants.sort(_compareParticipantsByName);
+    });
+
+    await _persistChanges();
+  }
+
+  Future<void> _deleteParticipant(_ParticipantRecord participant) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Удалить участника?'),
+          content: Text(
+            'Участник "${participant.name}" будет скрыт из списка.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Отмена'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('Удалить'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (confirmed != true) {
+      return;
+    }
+
+    setState(() {
+      final index = _participants.indexWhere(
+        (candidate) => candidate.id == participant.id,
+      );
+      if (index != -1) {
+        _participants[index] = _participants[index].copyWith(deleted: true);
+      }
+      if (_editingParticipantId == participant.id) {
+        _editingParticipantId = null;
+        _nameController.clear();
+        _nameError = null;
+      }
+    });
+
+    await _persistChanges();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final activeParticipants = _activeParticipants;
+    final isEditing = _editingParticipantId != null;
+
+    return Dialog(
+      insetPadding: const EdgeInsets.all(24),
+      child: SizedBox(
+        width: 760,
+        height: 600,
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Участники',
+                      style:
+                          Theme.of(context).textTheme.headlineSmall?.copyWith(
+                                fontWeight: FontWeight.w700,
+                              ),
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: 'Закрыть',
+                    onPressed: () => Navigator.of(context).pop(),
+                    icon: const Icon(Icons.close),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Expanded(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFF8FAFC),
+                    borderRadius: BorderRadius.circular(16),
+                    border: Border.all(color: const Color(0xFFD0D7DE)),
+                  ),
+                  child: activeParticipants.isEmpty
+                      ? const Center(
+                          child: Text('Пока нет ни одного участника.'),
+                        )
+                      : ListView.separated(
+                          padding: const EdgeInsets.all(16),
+                          itemCount: activeParticipants.length,
+                          separatorBuilder: (context, index) =>
+                              const SizedBox(height: 12),
+                          itemBuilder: (context, index) {
+                            final participant = activeParticipants[index];
+                            return Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 16,
+                                vertical: 14,
+                              ),
+                              decoration: BoxDecoration(
+                                color: Colors.white,
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: const Color(0xFFD8DEE4),
+                                ),
+                              ),
+                              child: Row(
+                                children: [
+                                  Expanded(
+                                    child: Text(
+                                      participant.name,
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .titleMedium,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  TextButton(
+                                    onPressed: () => _startEditing(participant),
+                                    child: const Text('Редактировать'),
+                                  ),
+                                  const SizedBox(width: 8),
+                                  TextButton(
+                                    onPressed: () => unawaited(
+                                      _deleteParticipant(participant),
+                                    ),
+                                    style: TextButton.styleFrom(
+                                      foregroundColor:
+                                          Theme.of(context).colorScheme.error,
+                                    ),
+                                    child: const Text('Удалить'),
+                                  ),
+                                ],
+                              ),
+                            );
+                          },
+                        ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: const Color(0xFFD0D7DE)),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Text(
+                        isEditing
+                            ? 'Редактировать участника'
+                            : 'Новый участник',
+                        style:
+                            Theme.of(context).textTheme.titleMedium?.copyWith(
+                                  fontWeight: FontWeight.w600,
+                                ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        key: const Key('participant_name_field'),
+                        controller: _nameController,
+                        decoration: InputDecoration(
+                          labelText: 'Имя',
+                          errorText: _nameError,
+                        ),
+                        textInputAction: TextInputAction.done,
+                        onSubmitted: (_) => unawaited(_submitParticipant()),
+                      ),
+                      const SizedBox(height: 12),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          if (isEditing) ...[
+                            TextButton(
+                              onPressed: _cancelEditing,
+                              child: const Text('Отменить редактирование'),
+                            ),
+                            const SizedBox(width: 8),
+                          ],
+                          FilledButton(
+                            onPressed: () => unawaited(_submitParticipant()),
+                            child: Text(isEditing ? 'Сохранить' : 'Добавить'),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+final class _ParticipantRecord {
+  const _ParticipantRecord({
+    required this.id,
+    required this.name,
+    required this.deleted,
+  });
+
+  factory _ParticipantRecord.fromJson(Map<String, Object?> json) {
+    return _ParticipantRecord(
+      id: (json['id'] as num?)?.toInt() ?? 0,
+      name: (json['name'] as String?) ?? '',
+      deleted: json['deleted'] as bool? ?? false,
+    );
+  }
+
+  final int id;
+  final String name;
+  final bool deleted;
+
+  _ParticipantRecord copyWith({
+    int? id,
+    String? name,
+    bool? deleted,
+  }) {
+    return _ParticipantRecord(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      deleted: deleted ?? this.deleted,
+    );
+  }
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'id': id,
+      'name': name,
+      'deleted': deleted,
+    };
+  }
+}

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -1,10 +1,16 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
 
 import '../../app_services.dart';
+import '../participants/participants_directory_dialog.dart';
 
 enum DirectorySection {
   trainers('Тренеры', 'Раздел тренеров находится в разработке.'),
-  participants('Участники', 'Раздел участников находится в разработке.');
+  participants('Участники', 'Откройте диалог участников для редактирования.');
 
   const DirectorySection(this.title, this.description);
 
@@ -25,85 +31,252 @@ class BochkiShell extends StatefulWidget {
 }
 
 class _BochkiShellState extends State<BochkiShell> {
+  static const String _projectFileName = 'project.json';
+
   DirectorySection? _selectedSection;
+  ProjectDocument _document = ProjectDocument.initial();
+  bool _isLoading = true;
+  bool _participantsDialogOpen = false;
+  String? _loadErrorMessage;
+
+  File get _projectFile =>
+      File(p.join(widget.services.appDataDirectory.path, _projectFileName));
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_loadProjectDocument());
+  }
+
+  Future<void> _loadProjectDocument() async {
+    setState(() {
+      _isLoading = true;
+      _loadErrorMessage = null;
+    });
+
+    try {
+      final loadedDocument = await widget.services.projectDocumentStore.read(
+        _projectFile,
+      );
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _document = loadedDocument ?? ProjectDocument.initial();
+        _isLoading = false;
+      });
+    } catch (error, stackTrace) {
+      await widget.services.logger.error(
+        'Failed to load project document',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _isLoading = false;
+        _loadErrorMessage = 'Не удалось загрузить проектный документ.';
+      });
+    }
+  }
+
+  Future<void> _saveProjectDocument() async {
+    try {
+      await widget.services.projectDocumentStore.write(_projectFile, _document);
+    } catch (error, stackTrace) {
+      await widget.services.logger.error(
+        'Failed to save project document',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> _updateParticipantsDocument(
+    List<Map<String, Object?>> participants,
+    int nextId,
+  ) async {
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _document = _document.copyWith(
+        participants: participants,
+        nextId: nextId,
+      );
+    });
+
+    await _saveProjectDocument();
+  }
+
+  Future<void> _openParticipantsDialog() async {
+    if (_participantsDialogOpen) {
+      return;
+    }
+
+    setState(() {
+      _participantsDialogOpen = true;
+    });
+
+    try {
+      await showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) {
+          return ParticipantsDirectoryDialog(
+            key: const Key('participants_directory_dialog'),
+            participants: _document.participants,
+            nextId: _document.nextId,
+            onChanged: _updateParticipantsDocument,
+          );
+        },
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _participantsDialogOpen = false;
+        });
+      }
+    }
+  }
+
+  void _selectDirectorySection(DirectorySection section) {
+    if (section == DirectorySection.trainers) {
+      setState(() {
+        _selectedSection = section;
+      });
+      return;
+    }
+
+    unawaited(_openParticipantsDialog());
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
     return Scaffold(
-      body: Column(
-        children: [
-          Container(
-            height: 56,
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            decoration: const BoxDecoration(
-              color: Color(0xFFE9EEF2),
-              border: Border(
-                bottom: BorderSide(
-                  color: Color(0xFFD0D7DE),
-                ),
-              ),
-            ),
-            child: Row(
-              children: [
-                Text(
-                  'ПО Расписание Бочки',
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                const SizedBox(width: 20),
-                PopupMenuButton<DirectorySection>(
-                  key: const Key('directories_menu_button'),
-                  tooltip: 'Справочники',
-                  onSelected: (section) {
-                    setState(() {
-                      _selectedSection = section;
-                    });
-                  },
-                  itemBuilder: (context) => const [
-                    PopupMenuItem<DirectorySection>(
-                      value: DirectorySection.trainers,
-                      child: Text('Тренеры'),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _loadErrorMessage != null
+              ? _ProjectLoadErrorView(
+                  message: _loadErrorMessage!,
+                  onRetry: _loadProjectDocument,
+                )
+              : Column(
+                  children: [
+                    Container(
+                      height: 56,
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      decoration: const BoxDecoration(
+                        color: Color(0xFFE9EEF2),
+                        border: Border(
+                          bottom: BorderSide(
+                            color: Color(0xFFD0D7DE),
+                          ),
+                        ),
+                      ),
+                      child: Row(
+                        children: [
+                          Text(
+                            'ПО Расписание Бочки',
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(width: 20),
+                          PopupMenuButton<DirectorySection>(
+                            key: const Key('directories_menu_button'),
+                            tooltip: 'Справочники',
+                            onSelected: _selectDirectorySection,
+                            itemBuilder: (context) => const [
+                              PopupMenuItem<DirectorySection>(
+                                value: DirectorySection.trainers,
+                                child: Text('Тренеры'),
+                              ),
+                              PopupMenuItem<DirectorySection>(
+                                value: DirectorySection.participants,
+                                child: Text('Участники'),
+                              ),
+                            ],
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 10,
+                                vertical: 6,
+                              ),
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(6),
+                                color: Colors.white.withOpacity(0.72),
+                                border: Border.all(
+                                  color: const Color(0xFFD0D7DE),
+                                ),
+                              ),
+                              child: const Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Text('Справочники'),
+                                  SizedBox(width: 6),
+                                  Icon(Icons.arrow_drop_down, size: 18),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
-                    PopupMenuItem<DirectorySection>(
-                      value: DirectorySection.participants,
-                      child: Text('Участники'),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: _selectedSection == null
+                            ? const _HomePlaceholder()
+                            : _SectionPlaceholder(section: _selectedSection!),
+                      ),
                     ),
                   ],
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 10,
-                      vertical: 6,
-                    ),
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(6),
-                      color: Colors.white.withOpacity(0.72),
-                      border: Border.all(color: const Color(0xFFD0D7DE)),
-                    ),
-                    child: const Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text('Справочники'),
-                        SizedBox(width: 6),
-                        Icon(Icons.arrow_drop_down, size: 18),
-                      ],
-                    ),
-                  ),
+                ),
+    );
+  }
+}
+
+class _ProjectLoadErrorView extends StatelessWidget {
+  const _ProjectLoadErrorView({
+    required this.message,
+    required this.onRetry,
+  });
+
+  final String message;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 420),
+        child: Card(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.error_outline, size: 40),
+                const SizedBox(height: 12),
+                Text(
+                  message,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 16),
+                FilledButton(
+                  onPressed: () => unawaited(onRetry()),
+                  child: const Text('Повторить'),
                 ),
               ],
             ),
           ),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.all(24),
-              child: _selectedSection == null
-                  ? const _HomePlaceholder()
-                  : _SectionPlaceholder(section: _selectedSection!),
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -1,9 +1,10 @@
+import 'dart:io';
+
 import 'package:bochki_schedule_app/bochki_schedule_app.dart';
 import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
-import 'dart:io';
 
 void main() {
   test('package exports compile', () {
@@ -18,13 +19,14 @@ void main() {
     );
 
     await tester.pumpWidget(BochkiScheduleApp(services: services));
+    await tester.pumpAndSettle();
 
     expect(find.text('ПО Расписание Бочки'), findsOneWidget);
     expect(find.text('Справочники'), findsOneWidget);
     expect(find.text('В разработке'), findsOneWidget);
   });
 
-  testWidgets('shell switches between directory placeholders', (tester) async {
+  testWidgets('shell opens participants dialog from menu', (tester) async {
     final services = AppServices(
       appDataDirectory: Directory('/tmp/bochki_schedule_test'),
       logger: const _NoopLogger(),
@@ -32,22 +34,80 @@ void main() {
     );
 
     await tester.pumpWidget(BochkiScheduleApp(services: services));
-
-    await tester.tap(find.byKey(const Key('directories_menu_button')));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Тренеры').last);
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const Key('placeholder_trainers')), findsOneWidget);
-    expect(find.text('Тренеры'), findsWidgets);
 
     await tester.tap(find.byKey(const Key('directories_menu_button')));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Участники').last);
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('placeholder_participants')), findsOneWidget);
-    expect(find.text('Участники'), findsWidgets);
+    expect(
+        find.byKey(const Key('participants_directory_dialog')), findsOneWidget);
+    expect(find.byKey(const Key('participant_name_field')), findsOneWidget);
+  });
+
+  testWidgets('participants dialog adds edits and soft-deletes entries', (
+    tester,
+  ) async {
+    final store = _MemoryProjectDocumentStore();
+    final services = AppServices(
+      appDataDirectory: Directory('/tmp/bochki_schedule_test'),
+      logger: const _NoopLogger(),
+      projectDocumentStore: store,
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: services));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('directories_menu_button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Участники').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Добавить'));
+    await tester.pumpAndSettle();
+    expect(find.text('Введите имя участника.'), findsOneWidget);
+
+    await tester.enterText(
+      find.byKey(const Key('participant_name_field')),
+      '  Иван   Иванов  ',
+    );
+    await tester.tap(find.text('Добавить'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Иван Иванов'), findsOneWidget);
+    expect(store.document, isNotNull);
+    expect(store.document!.participants.single['name'], 'Иван Иванов');
+    expect(store.document!.participants.single['deleted'], isFalse);
+
+    await tester.enterText(
+      find.byKey(const Key('participant_name_field')),
+      'Иван Иванов',
+    );
+    await tester.tap(find.text('Добавить'));
+    await tester.pumpAndSettle();
+    expect(find.text('Участник с таким именем уже есть.'), findsOneWidget);
+
+    await tester.tap(find.text('Редактировать'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('participant_name_field')),
+      'Иван Петров',
+    );
+    await tester.tap(find.text('Сохранить'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Иван Петров'), findsOneWidget);
+    expect(find.text('Иван Иванов'), findsNothing);
+    expect(store.document!.participants.single['name'], 'Иван Петров');
+
+    await tester.tap(find.text('Удалить'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Удалить').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Пока нет ни одного участника.'), findsOneWidget);
+    expect(store.document!.participants.single['deleted'], isTrue);
   });
 }
 
@@ -73,4 +133,18 @@ final class _NoopProjectDocumentStore implements ProjectDocumentStore {
 
   @override
   Future<void> write(File file, ProjectDocument document) async {}
+}
+
+final class _MemoryProjectDocumentStore implements ProjectDocumentStore {
+  ProjectDocument? _document;
+
+  ProjectDocument? get document => _document;
+
+  @override
+  Future<ProjectDocument?> read(File file) async => _document;
+
+  @override
+  Future<void> write(File file, ProjectDocument document) async {
+    _document = document;
+  }
 }

--- a/packages/bochki_schedule_domain/test/bochki_schedule_domain_test.dart
+++ b/packages/bochki_schedule_domain/test/bochki_schedule_domain_test.dart
@@ -38,7 +38,11 @@ void main() {
         <String, Object?>{'id': 1, 'name': 'Trainer One'},
       ],
       participants: const [
-        <String, Object?>{'id': 2, 'name': 'Participant One'},
+        <String, Object?>{
+          'id': 2,
+          'name': 'Participant One',
+          'deleted': true,
+        },
       ],
     );
 
@@ -51,5 +55,6 @@ void main() {
     expect(restored.nextId, 7);
     expect(restored.trainers.single['name'], 'Trainer One');
     expect(restored.participants.single['name'], 'Participant One');
+    expect(restored.participants.single['deleted'], isTrue);
   });
 }

--- a/packages/bochki_schedule_infra/test/bochki_schedule_infra_test.dart
+++ b/packages/bochki_schedule_infra/test/bochki_schedule_infra_test.dart
@@ -92,7 +92,11 @@ void main() {
         <String, Object?>{'id': 1, 'name': 'Trainer One'},
       ],
       participants: <Map<String, Object?>>[
-        <String, Object?>{'id': 2, 'name': 'Participant One'},
+        <String, Object?>{
+          'id': 2,
+          'name': 'Participant One',
+          'deleted': true,
+        },
       ],
     );
 
@@ -104,6 +108,7 @@ void main() {
     expect(restored.nextId, 4);
     expect(restored.trainers.single['name'], 'Trainer One');
     expect(restored.participants.single['name'], 'Participant One');
+    expect(restored.participants.single['deleted'], isTrue);
   });
 
   test('json project document store returns null for missing file', () async {


### PR DESCRIPTION
Closes #15\n\nSummary:\n- Replaced the participants placeholder with a modal dialog.\n- Added add/edit/delete flows with soft-delete.\n- Wired the dialog to local project document persistence.\n- Updated tests and smoke docs.