### PR TITLE
refactor: introduce participants use case and repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,39 @@
 
 Архитектурные решения фиксируются в [`docs/adr`](docs/adr).
 
+## Текущая архитектура
+
+Сейчас редактирование справочника `Участники` уже разложено по явным слоям и используется в коде.
+Рефакторинг выполнен в рамках issue [`#17`](https://github.com/alekseibq/bochki-schedule-flutter/issues/17) и опирается на ADR про layered architecture и local JSON storage:
+
+- [`docs/adr/0003-use-layered-lasagna-architecture.md`](docs/adr/0003-use-layered-lasagna-architecture.md)
+- [`docs/adr/0004-store-project-data-as-local-json.md`](docs/adr/0004-store-project-data-as-local-json.md)
+
+Цепочка сейчас такая:
+
+```text
+UI
+  -> ParticipantsDirectoryDialog
+  -> ParticipantsDirectoryUseCase
+  -> ProjectDocumentRepository
+  -> JsonProjectDocumentRepository
+  -> project.json
+```
+
+В терминах слоёв:
+
+```text
+Presentation -> Application -> Domain Port -> Infrastructure -> File
+```
+
+Роли на текущий момент:
+
+- `BochkiShell` загружает `ProjectDocument` и открывает диалог участников.
+- `ParticipantsDirectoryDialog` отвечает только за presentation-state.
+- `ParticipantsDirectoryUseCase` содержит бизнес-логику участников.
+- `ProjectDocumentRepository` определяет контракт загрузки и сохранения документа.
+- `JsonProjectDocumentRepository` пишет локальный JSON атомарно через `AtomicFileWriter`.
+
 ## Требования
 
 - `git`

--- a/packages/bochki_schedule_app/integration_test/app_shell_test.dart
+++ b/packages/bochki_schedule_app/integration_test/app_shell_test.dart
@@ -3,8 +3,8 @@ import 'dart:io';
 import 'package:bochki_schedule_app/bochki_schedule_app.dart';
 import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
@@ -15,7 +15,9 @@ void main() {
     final services = AppServices(
       appDataDirectory: Directory('/tmp/bochki_schedule_test'),
       logger: const _NoopLogger(),
-      projectDocumentStore: const _NoopProjectDocumentStore(),
+      participantsDirectoryUseCase: ParticipantsDirectoryUseCase(
+        repository: _MemoryProjectDocumentRepository(ProjectDocument.initial()),
+      ),
     );
 
     await tester.pumpWidget(BochkiScheduleApp(services: services));
@@ -37,7 +39,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-        find.byKey(const Key('participants_directory_dialog')), findsOneWidget);
+      find.byKey(const Key('participants_directory_dialog')),
+      findsOneWidget,
+    );
     expect(find.byKey(const Key('participant_name_field')), findsOneWidget);
   });
 }
@@ -56,12 +60,17 @@ final class _NoopLogger implements AppLogger {
   Future<void> info(String message) async {}
 }
 
-final class _NoopProjectDocumentStore implements ProjectDocumentStore {
-  const _NoopProjectDocumentStore();
+final class _MemoryProjectDocumentRepository
+    implements ProjectDocumentRepository {
+  _MemoryProjectDocumentRepository(this.document);
+
+  ProjectDocument document;
 
   @override
-  Future<ProjectDocument?> read(File file) async => null;
+  Future<ProjectDocument> load() async => document;
 
   @override
-  Future<void> write(File file, ProjectDocument document) async {}
+  Future<void> save(ProjectDocument updatedDocument) async {
+    document = updatedDocument;
+  }
 }

--- a/packages/bochki_schedule_app/lib/bochki_schedule_app.dart
+++ b/packages/bochki_schedule_app/lib/bochki_schedule_app.dart
@@ -3,4 +3,5 @@ library bochki_schedule_app;
 export 'src/app.dart';
 export 'src/app_bootstrap.dart';
 export 'src/app_services.dart';
+export 'src/application/participants_directory_use_case.dart';
 export 'src/presentation/shell/bochki_shell.dart';

--- a/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
+++ b/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
@@ -4,6 +4,7 @@ import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
 import 'package:path/path.dart' as p;
 
 import 'app_services.dart';
+import 'application/participants_directory_use_case.dart';
 
 final class AppBootstrap {
   static const String appDirectoryName = 'bochki_schedule';
@@ -16,8 +17,12 @@ final class AppBootstrap {
     final logger = FileAppLogger(
       logFile: File(p.join(appDataDirectory.path, 'logs', 'app.log')),
     );
-    final projectDocumentStore = JsonProjectDocumentStore(
+    final projectDocumentRepository = JsonProjectDocumentRepository(
+      projectFile: File(p.join(appDataDirectory.path, 'project.json')),
       safeFileWriter: const AtomicFileWriter(),
+    );
+    final participantsDirectoryUseCase = ParticipantsDirectoryUseCase(
+      repository: projectDocumentRepository,
     );
 
     await logger.info(
@@ -27,7 +32,7 @@ final class AppBootstrap {
     return AppServices(
       appDataDirectory: appDataDirectory,
       logger: logger,
-      projectDocumentStore: projectDocumentStore,
+      participantsDirectoryUseCase: participantsDirectoryUseCase,
     );
   }
 }

--- a/packages/bochki_schedule_app/lib/src/app_services.dart
+++ b/packages/bochki_schedule_app/lib/src/app_services.dart
@@ -2,14 +2,16 @@ import 'dart:io';
 
 import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
 
+import 'application/participants_directory_use_case.dart';
+
 final class AppServices {
   const AppServices({
     required this.appDataDirectory,
     required this.logger,
-    required this.projectDocumentStore,
+    required this.participantsDirectoryUseCase,
   });
 
   final Directory appDataDirectory;
   final AppLogger logger;
-  final ProjectDocumentStore projectDocumentStore;
+  final ParticipantsDirectoryUseCase participantsDirectoryUseCase;
 }

--- a/packages/bochki_schedule_app/lib/src/application/participants_directory_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/application/participants_directory_use_case.dart
@@ -1,0 +1,235 @@
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+
+final class ParticipantsDirectoryUseCase {
+  ParticipantsDirectoryUseCase({
+    required ProjectDocumentRepository repository,
+  }) : _repository = repository;
+
+  final ProjectDocumentRepository _repository;
+
+  Future<ProjectDocument> loadDocument() {
+    return _repository.load();
+  }
+
+  List<Map<String, Object?>> activeParticipants(ProjectDocument document) {
+    final activeParticipants = _participantsFromDocument(document)
+        .where((participant) => !participant.deleted)
+        .toList(growable: false);
+    activeParticipants.sort(_compareParticipantsByName);
+    return activeParticipants
+        .map((participant) => participant.toJson())
+        .toList(growable: false);
+  }
+
+  Future<ParticipantsDirectoryMutationResult> addParticipant(
+    ProjectDocument document,
+    String rawName,
+  ) {
+    return _upsertParticipant(
+      document: document,
+      rawName: rawName,
+      editingParticipantId: null,
+    );
+  }
+
+  Future<ParticipantsDirectoryMutationResult> editParticipant(
+    ProjectDocument document,
+    int participantId,
+    String rawName,
+  ) {
+    return _upsertParticipant(
+      document: document,
+      rawName: rawName,
+      editingParticipantId: participantId,
+    );
+  }
+
+  Future<ParticipantsDirectoryMutationResult> deleteParticipant(
+    ProjectDocument document,
+    int participantId,
+  ) async {
+    final participants = _participantsFromDocument(document);
+    final index = participants.indexWhere(
+      (candidate) => candidate.id == participantId,
+    );
+    if (index != -1) {
+      participants[index] = participants[index].copyWith(deleted: true);
+    }
+
+    final updatedDocument = document.copyWith(
+      participants: _sortedParticipantJson(participants),
+    );
+    return _persist(updatedDocument);
+  }
+
+  Future<ParticipantsDirectoryMutationResult> _upsertParticipant({
+    required ProjectDocument document,
+    required String rawName,
+    required int? editingParticipantId,
+  }) async {
+    final normalizedName = _normalizeName(rawName);
+    if (normalizedName.isEmpty) {
+      return const ParticipantsDirectoryMutationResult.failure(
+        'Введите имя участника.',
+      );
+    }
+
+    if (_hasDuplicateName(
+      document: document,
+      normalizedName: normalizedName,
+      editingParticipantId: editingParticipantId,
+    )) {
+      return const ParticipantsDirectoryMutationResult.failure(
+        'Участник с таким именем уже есть.',
+      );
+    }
+
+    final participants = _participantsFromDocument(document);
+    if (editingParticipantId == null) {
+      participants.add(
+        _ParticipantRecord(
+          id: document.nextId,
+          name: normalizedName,
+          deleted: false,
+        ),
+      );
+    } else {
+      final index = participants.indexWhere(
+        (participant) => participant.id == editingParticipantId,
+      );
+      if (index != -1) {
+        participants[index] = participants[index].copyWith(
+          name: normalizedName,
+        );
+      }
+    }
+
+    final updatedDocument = document.copyWith(
+      nextId:
+          editingParticipantId == null ? document.nextId + 1 : document.nextId,
+      participants: _sortedParticipantJson(participants),
+    );
+    return _persist(updatedDocument);
+  }
+
+  Future<ParticipantsDirectoryMutationResult> _persist(
+    ProjectDocument document,
+  ) async {
+    try {
+      await _repository.save(document);
+      return ParticipantsDirectoryMutationResult.success(document);
+    } catch (_) {
+      return const ParticipantsDirectoryMutationResult.failure(
+        'Не удалось сохранить изменения.',
+      );
+    }
+  }
+
+  bool _hasDuplicateName({
+    required ProjectDocument document,
+    required String normalizedName,
+    required int? editingParticipantId,
+  }) {
+    final normalizedCandidate = normalizedName.toLowerCase();
+    return _participantsFromDocument(document).any((participant) {
+      if (participant.deleted) {
+        return false;
+      }
+      if (participant.id == editingParticipantId) {
+        return false;
+      }
+      return _normalizedSortKey(participant.name) == normalizedCandidate;
+    });
+  }
+
+  List<_ParticipantRecord> _participantsFromDocument(
+    ProjectDocument document,
+  ) {
+    return document.participants
+        .map(_ParticipantRecord.fromJson)
+        .toList(growable: true);
+  }
+
+  List<Map<String, Object?>> _sortedParticipantJson(
+    List<_ParticipantRecord> participants,
+  ) {
+    participants.sort(_compareParticipantsByName);
+    return participants
+        .map((participant) => participant.toJson())
+        .toList(growable: false);
+  }
+
+  static int _compareParticipantsByName(
+    _ParticipantRecord left,
+    _ParticipantRecord right,
+  ) {
+    return _normalizedSortKey(left.name)
+        .compareTo(_normalizedSortKey(right.name));
+  }
+
+  static String _normalizedSortKey(String value) {
+    return _normalizeName(value).toLowerCase();
+  }
+
+  static String _normalizeName(String value) {
+    return value.trim().replaceAll(RegExp(r'\s+'), ' ');
+  }
+}
+
+final class ParticipantsDirectoryMutationResult {
+  const ParticipantsDirectoryMutationResult._({
+    this.document,
+    this.errorMessage,
+  });
+
+  const ParticipantsDirectoryMutationResult.success(ProjectDocument document)
+      : this._(document: document);
+
+  const ParticipantsDirectoryMutationResult.failure(String errorMessage)
+      : this._(errorMessage: errorMessage);
+
+  final ProjectDocument? document;
+  final String? errorMessage;
+
+  bool get isSuccess => document != null;
+}
+
+final class _ParticipantRecord {
+  const _ParticipantRecord({
+    required this.id,
+    required this.name,
+    required this.deleted,
+  });
+
+  factory _ParticipantRecord.fromJson(Map<String, Object?> json) {
+    return _ParticipantRecord(
+      id: (json['id'] as num?)?.toInt() ?? 0,
+      name: (json['name'] as String?) ?? '',
+      deleted: json['deleted'] as bool? ?? false,
+    );
+  }
+
+  final int id;
+  final String name;
+  final bool deleted;
+
+  _ParticipantRecord copyWith({
+    int? id,
+    String? name,
+    bool? deleted,
+  }) {
+    return _ParticipantRecord(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      deleted: deleted ?? this.deleted,
+    );
+  }
+
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
+      'id': id,
+      'name': name,
+      'deleted': deleted,
+    };
+  }
+}

--- a/packages/bochki_schedule_app/lib/src/presentation/participants/participants_directory_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/participants/participants_directory_dialog.dart
@@ -1,21 +1,19 @@
 import 'dart:async';
 
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 import 'package:flutter/material.dart';
+
+import '../../application/participants_directory_use_case.dart';
 
 class ParticipantsDirectoryDialog extends StatefulWidget {
   const ParticipantsDirectoryDialog({
-    required this.participants,
-    required this.nextId,
-    required this.onChanged,
+    required this.document,
+    required this.useCase,
     super.key,
   });
 
-  final List<Map<String, Object?>> participants;
-  final int nextId;
-  final Future<void> Function(
-    List<Map<String, Object?>>,
-    int nextId,
-  ) onChanged;
+  final ProjectDocument document;
+  final ParticipantsDirectoryUseCase useCase;
 
   @override
   State<ParticipantsDirectoryDialog> createState() =>
@@ -26,58 +24,20 @@ class _ParticipantsDirectoryDialogState
     extends State<ParticipantsDirectoryDialog> {
   final TextEditingController _nameController = TextEditingController();
 
-  late List<_ParticipantRecord> _participants;
-  late int _nextId;
+  late ProjectDocument _document;
   int? _editingParticipantId;
   String? _nameError;
 
   @override
   void initState() {
     super.initState();
-    _participants = widget.participants
-        .map(_ParticipantRecord.fromJson)
-        .toList(growable: true);
-    _nextId = widget.nextId;
-    _participants.sort(_compareParticipantsByName);
+    _document = widget.document;
   }
 
   @override
   void dispose() {
     _nameController.dispose();
     super.dispose();
-  }
-
-  static int _compareParticipantsByName(
-    _ParticipantRecord left,
-    _ParticipantRecord right,
-  ) {
-    return _normalizedSortKey(left.name)
-        .compareTo(_normalizedSortKey(right.name));
-  }
-
-  static String _normalizedSortKey(String value) {
-    return _normalizeName(value).toLowerCase();
-  }
-
-  static String _normalizeName(String value) {
-    return value.trim().replaceAll(RegExp(r'\s+'), ' ');
-  }
-
-  List<_ParticipantRecord> get _activeParticipants {
-    final activeParticipants = _participants
-        .where((participant) => !participant.deleted)
-        .toList(growable: false);
-    activeParticipants.sort(_compareParticipantsByName);
-    return activeParticipants;
-  }
-
-  Future<void> _persistChanges() async {
-    await widget.onChanged(
-      _participants.map((participant) => participant.toJson()).toList(
-            growable: false,
-          ),
-      _nextId,
-    );
   }
 
   void _startEditing(_ParticipantRecord participant) {
@@ -99,63 +59,41 @@ class _ParticipantsDirectoryDialogState
     });
   }
 
-  bool _hasDuplicateName(String normalizedName) {
-    final normalizedCandidate = normalizedName.toLowerCase();
-    return _participants.any((participant) {
-      if (participant.deleted) {
-        return false;
-      }
-      if (participant.id == _editingParticipantId) {
-        return false;
-      }
-      return _normalizedSortKey(participant.name) == normalizedCandidate;
-    });
-  }
-
-  Future<void> _submitParticipant() async {
-    final normalizedName = _normalizeName(_nameController.text);
-    if (normalizedName.isEmpty) {
-      setState(() {
-        _nameError = 'Введите имя участника.';
-      });
+  Future<void> _showMutationError(String message) async {
+    if (!mounted) {
       return;
     }
 
-    if (_hasDuplicateName(normalizedName)) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  Future<void> _submitParticipant() async {
+    final result = _editingParticipantId == null
+        ? await widget.useCase.addParticipant(
+            _document,
+            _nameController.text,
+          )
+        : await widget.useCase.editParticipant(
+            _document,
+            _editingParticipantId!,
+            _nameController.text,
+          );
+
+    if (!result.isSuccess) {
       setState(() {
-        _nameError = 'Участник с таким именем уже есть.';
+        _nameError = result.errorMessage;
       });
       return;
     }
 
     setState(() {
-      if (_editingParticipantId == null) {
-        _participants.add(
-          _ParticipantRecord(
-            id: _nextId,
-            name: normalizedName,
-            deleted: false,
-          ),
-        );
-        _nextId += 1;
-      } else {
-        final index = _participants.indexWhere(
-          (participant) => participant.id == _editingParticipantId,
-        );
-        if (index != -1) {
-          _participants[index] = _participants[index].copyWith(
-            name: normalizedName,
-          );
-        }
-      }
-
+      _document = result.document!;
       _editingParticipantId = null;
       _nameController.clear();
       _nameError = null;
-      _participants.sort(_compareParticipantsByName);
     });
-
-    await _persistChanges();
   }
 
   Future<void> _deleteParticipant(_ParticipantRecord participant) async {
@@ -185,26 +123,33 @@ class _ParticipantsDirectoryDialogState
       return;
     }
 
-    setState(() {
-      final index = _participants.indexWhere(
-        (candidate) => candidate.id == participant.id,
+    final result = await widget.useCase.deleteParticipant(
+      _document,
+      participant.id,
+    );
+    if (!result.isSuccess) {
+      await _showMutationError(
+        result.errorMessage ?? 'Не удалось удалить участника.',
       );
-      if (index != -1) {
-        _participants[index] = _participants[index].copyWith(deleted: true);
-      }
+      return;
+    }
+
+    setState(() {
+      _document = result.document!;
       if (_editingParticipantId == participant.id) {
         _editingParticipantId = null;
         _nameController.clear();
         _nameError = null;
       }
     });
-
-    await _persistChanges();
   }
 
   @override
   Widget build(BuildContext context) {
-    final activeParticipants = _activeParticipants;
+    final activeParticipants = widget.useCase
+        .activeParticipants(_document)
+        .map(_ParticipantRecord.fromJson)
+        .toList(growable: false);
     final isEditing = _editingParticipantId != null;
 
     return Dialog(

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 import 'package:flutter/material.dart';
-import 'package:path/path.dart' as p;
 
 import '../../app_services.dart';
 import '../participants/participants_directory_dialog.dart';
@@ -31,16 +29,11 @@ class BochkiShell extends StatefulWidget {
 }
 
 class _BochkiShellState extends State<BochkiShell> {
-  static const String _projectFileName = 'project.json';
-
   DirectorySection? _selectedSection;
   ProjectDocument _document = ProjectDocument.initial();
   bool _isLoading = true;
   bool _participantsDialogOpen = false;
   String? _loadErrorMessage;
-
-  File get _projectFile =>
-      File(p.join(widget.services.appDataDirectory.path, _projectFileName));
 
   @override
   void initState() {
@@ -55,15 +48,14 @@ class _BochkiShellState extends State<BochkiShell> {
     });
 
     try {
-      final loadedDocument = await widget.services.projectDocumentStore.read(
-        _projectFile,
-      );
+      final loadedDocument =
+          await widget.services.participantsDirectoryUseCase.loadDocument();
       if (!mounted) {
         return;
       }
 
       setState(() {
-        _document = loadedDocument ?? ProjectDocument.initial();
+        _document = loadedDocument;
         _isLoading = false;
       });
     } catch (error, stackTrace) {
@@ -83,34 +75,24 @@ class _BochkiShellState extends State<BochkiShell> {
     }
   }
 
-  Future<void> _saveProjectDocument() async {
+  Future<void> _refreshProjectDocument() async {
     try {
-      await widget.services.projectDocumentStore.write(_projectFile, _document);
+      final loadedDocument =
+          await widget.services.participantsDirectoryUseCase.loadDocument();
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _document = loadedDocument;
+      });
     } catch (error, stackTrace) {
       await widget.services.logger.error(
-        'Failed to save project document',
+        'Failed to refresh project document',
         error: error,
         stackTrace: stackTrace,
       );
     }
-  }
-
-  Future<void> _updateParticipantsDocument(
-    List<Map<String, Object?>> participants,
-    int nextId,
-  ) async {
-    if (!mounted) {
-      return;
-    }
-
-    setState(() {
-      _document = _document.copyWith(
-        participants: participants,
-        nextId: nextId,
-      );
-    });
-
-    await _saveProjectDocument();
   }
 
   Future<void> _openParticipantsDialog() async {
@@ -129,14 +111,14 @@ class _BochkiShellState extends State<BochkiShell> {
         builder: (context) {
           return ParticipantsDirectoryDialog(
             key: const Key('participants_directory_dialog'),
-            participants: _document.participants,
-            nextId: _document.nextId,
-            onChanged: _updateParticipantsDocument,
+            document: _document,
+            useCase: widget.services.participantsDirectoryUseCase,
           );
         },
       );
     } finally {
       if (mounted) {
+        await _refreshProjectDocument();
         setState(() {
           _participantsDialogOpen = false;
         });

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -12,13 +12,9 @@ void main() {
   });
 
   testWidgets('shell shows top menu and default placeholder', (tester) async {
-    final services = AppServices(
-      appDataDirectory: Directory('/tmp/bochki_schedule_test'),
-      logger: const _NoopLogger(),
-      projectDocumentStore: const _NoopProjectDocumentStore(),
-    );
+    final context = _buildTestContext();
 
-    await tester.pumpWidget(BochkiScheduleApp(services: services));
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
     await tester.pumpAndSettle();
 
     expect(find.text('ПО Расписание Бочки'), findsOneWidget);
@@ -27,13 +23,9 @@ void main() {
   });
 
   testWidgets('shell opens participants dialog from menu', (tester) async {
-    final services = AppServices(
-      appDataDirectory: Directory('/tmp/bochki_schedule_test'),
-      logger: const _NoopLogger(),
-      projectDocumentStore: const _NoopProjectDocumentStore(),
-    );
+    final context = _buildTestContext();
 
-    await tester.pumpWidget(BochkiScheduleApp(services: services));
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const Key('directories_menu_button')));
@@ -42,21 +34,18 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-        find.byKey(const Key('participants_directory_dialog')), findsOneWidget);
+      find.byKey(const Key('participants_directory_dialog')),
+      findsOneWidget,
+    );
     expect(find.byKey(const Key('participant_name_field')), findsOneWidget);
   });
 
   testWidgets('participants dialog adds edits and soft-deletes entries', (
     tester,
   ) async {
-    final store = _MemoryProjectDocumentStore();
-    final services = AppServices(
-      appDataDirectory: Directory('/tmp/bochki_schedule_test'),
-      logger: const _NoopLogger(),
-      projectDocumentStore: store,
-    );
+    final context = _buildTestContext();
 
-    await tester.pumpWidget(BochkiScheduleApp(services: services));
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const Key('directories_menu_button')));
@@ -76,9 +65,12 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Иван Иванов'), findsOneWidget);
-    expect(store.document, isNotNull);
-    expect(store.document!.participants.single['name'], 'Иван Иванов');
-    expect(store.document!.participants.single['deleted'], isFalse);
+    expect(
+        context.repository.document.participants.single['name'], 'Иван Иванов');
+    expect(
+      context.repository.document.participants.single['deleted'],
+      isFalse,
+    );
 
     await tester.enterText(
       find.byKey(const Key('participant_name_field')),
@@ -99,7 +91,8 @@ void main() {
 
     expect(find.text('Иван Петров'), findsOneWidget);
     expect(find.text('Иван Иванов'), findsNothing);
-    expect(store.document!.participants.single['name'], 'Иван Петров');
+    expect(
+        context.repository.document.participants.single['name'], 'Иван Петров');
 
     await tester.tap(find.text('Удалить'));
     await tester.pumpAndSettle();
@@ -107,8 +100,33 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Пока нет ни одного участника.'), findsOneWidget);
-    expect(store.document!.participants.single['deleted'], isTrue);
+    expect(context.repository.document.participants.single['deleted'], isTrue);
   });
+}
+
+_TestContext _buildTestContext() {
+  final repository =
+      _MemoryProjectDocumentRepository(ProjectDocument.initial());
+  final useCase = ParticipantsDirectoryUseCase(repository: repository);
+
+  return _TestContext(
+    services: AppServices(
+      appDataDirectory: Directory('/tmp/bochki_schedule_test'),
+      logger: const _NoopLogger(),
+      participantsDirectoryUseCase: useCase,
+    ),
+    repository: repository,
+  );
+}
+
+final class _TestContext {
+  const _TestContext({
+    required this.services,
+    required this.repository,
+  });
+
+  final AppServices services;
+  final _MemoryProjectDocumentRepository repository;
 }
 
 final class _NoopLogger implements AppLogger {
@@ -125,26 +143,17 @@ final class _NoopLogger implements AppLogger {
   Future<void> info(String message) async {}
 }
 
-final class _NoopProjectDocumentStore implements ProjectDocumentStore {
-  const _NoopProjectDocumentStore();
+final class _MemoryProjectDocumentRepository
+    implements ProjectDocumentRepository {
+  _MemoryProjectDocumentRepository(this.document);
+
+  ProjectDocument document;
 
   @override
-  Future<ProjectDocument?> read(File file) async => null;
+  Future<ProjectDocument> load() async => document;
 
   @override
-  Future<void> write(File file, ProjectDocument document) async {}
-}
-
-final class _MemoryProjectDocumentStore implements ProjectDocumentStore {
-  ProjectDocument? _document;
-
-  ProjectDocument? get document => _document;
-
-  @override
-  Future<ProjectDocument?> read(File file) async => _document;
-
-  @override
-  Future<void> write(File file, ProjectDocument document) async {
-    _document = document;
+  Future<void> save(ProjectDocument updatedDocument) async {
+    document = updatedDocument;
   }
 }

--- a/packages/bochki_schedule_app/test/participants_directory_use_case_test.dart
+++ b/packages/bochki_schedule_app/test/participants_directory_use_case_test.dart
@@ -1,0 +1,129 @@
+import 'package:bochki_schedule_app/src/application/participants_directory_use_case.dart';
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('active participants are sorted and deleted entries are hidden',
+      () async {
+    final repository = _MemoryProjectDocumentRepository(
+      const ProjectDocument(
+        nextId: 4,
+        participants: <Map<String, Object?>>[
+          <String, Object?>{'id': 3, 'name': 'Вася', 'deleted': false},
+          <String, Object?>{'id': 1, 'name': 'Анна', 'deleted': true},
+          <String, Object?>{'id': 2, 'name': 'Борис', 'deleted': false},
+        ],
+      ),
+    );
+    final useCase = ParticipantsDirectoryUseCase(repository: repository);
+
+    final active = useCase.activeParticipants(await useCase.loadDocument());
+
+    expect(active.map((participant) => participant['name']), [
+      'Борис',
+      'Вася',
+    ]);
+  });
+
+  test('add participant normalizes name and increments nextId', () async {
+    final repository =
+        _MemoryProjectDocumentRepository(ProjectDocument.initial());
+    final useCase = ParticipantsDirectoryUseCase(repository: repository);
+
+    final result = await useCase.addParticipant(
+      await useCase.loadDocument(),
+      '  Иван   Иванов  ',
+    );
+
+    expect(result.isSuccess, isTrue);
+    expect(result.document!.nextId, 2);
+    expect(result.document!.participants.single['name'], 'Иван Иванов');
+    expect(repository.document.participants.single['name'], 'Иван Иванов');
+  });
+
+  test('duplicate participant name is rejected', () async {
+    final repository = _MemoryProjectDocumentRepository(
+      const ProjectDocument(
+        nextId: 3,
+        participants: <Map<String, Object?>>[
+          <String, Object?>{'id': 1, 'name': 'Иван Иванов', 'deleted': false},
+          <String, Object?>{'id': 2, 'name': 'Петр Петров', 'deleted': false},
+        ],
+      ),
+    );
+    final useCase = ParticipantsDirectoryUseCase(repository: repository);
+
+    final result = await useCase.addParticipant(
+      await useCase.loadDocument(),
+      'Иван Иванов',
+    );
+
+    expect(result.isSuccess, isFalse);
+    expect(result.errorMessage, 'Участник с таким именем уже есть.');
+    expect(repository.document.participants.length, 2);
+  });
+
+  test('edit participant can keep the same name', () async {
+    final repository = _MemoryProjectDocumentRepository(
+      const ProjectDocument(
+        nextId: 3,
+        participants: <Map<String, Object?>>[
+          <String, Object?>{'id': 1, 'name': 'Иван Иванов', 'deleted': false},
+          <String, Object?>{'id': 2, 'name': 'Петр Петров', 'deleted': false},
+        ],
+      ),
+    );
+    final useCase = ParticipantsDirectoryUseCase(repository: repository);
+
+    final result = await useCase.editParticipant(
+      await useCase.loadDocument(),
+      1,
+      'Иван Иванов',
+    );
+
+    expect(result.isSuccess, isTrue);
+    expect(
+      result.document!.participants.firstWhere(
+        (participant) => participant['id'] == 1,
+      )['name'],
+      'Иван Иванов',
+    );
+    expect(repository.document.participants.length, 2);
+  });
+
+  test('delete participant soft deletes entry', () async {
+    final repository = _MemoryProjectDocumentRepository(
+      const ProjectDocument(
+        nextId: 2,
+        participants: <Map<String, Object?>>[
+          <String, Object?>{'id': 1, 'name': 'Иван Иванов', 'deleted': false},
+        ],
+      ),
+    );
+    final useCase = ParticipantsDirectoryUseCase(repository: repository);
+
+    final result = await useCase.deleteParticipant(
+      await useCase.loadDocument(),
+      1,
+    );
+
+    expect(result.isSuccess, isTrue);
+    expect(result.document!.participants.single['deleted'], isTrue);
+    expect(repository.document.participants.single['deleted'], isTrue);
+  });
+}
+
+final class _MemoryProjectDocumentRepository
+    implements ProjectDocumentRepository {
+  _MemoryProjectDocumentRepository(this.document);
+
+  ProjectDocument document;
+
+  @override
+  Future<ProjectDocument> load() async => document;
+
+  @override
+  Future<void> save(ProjectDocument updatedDocument) async {
+    document = updatedDocument;
+  }
+}

--- a/packages/bochki_schedule_domain/lib/bochki_schedule_domain.dart
+++ b/packages/bochki_schedule_domain/lib/bochki_schedule_domain.dart
@@ -3,4 +3,5 @@ library bochki_schedule_domain;
 export 'src/domain_package_info.dart';
 export 'src/id_generator.dart';
 export 'src/project_document.dart';
+export 'src/project_document_repository.dart';
 export 'src/schema_version.dart';

--- a/packages/bochki_schedule_domain/lib/src/project_document_repository.dart
+++ b/packages/bochki_schedule_domain/lib/src/project_document_repository.dart
@@ -1,0 +1,7 @@
+import 'project_document.dart';
+
+abstract interface class ProjectDocumentRepository {
+  Future<ProjectDocument> load();
+
+  Future<void> save(ProjectDocument document);
+}

--- a/packages/bochki_schedule_infra/lib/src/project_document_store.dart
+++ b/packages/bochki_schedule_infra/lib/src/project_document_store.dart
@@ -5,29 +5,26 @@ import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 
 import 'safe_file_writer.dart';
 
-abstract interface class ProjectDocumentStore {
-  Future<ProjectDocument?> read(File file);
-
-  Future<void> write(File file, ProjectDocument document);
-}
-
-final class JsonProjectDocumentStore implements ProjectDocumentStore {
-  JsonProjectDocumentStore({
+final class JsonProjectDocumentRepository implements ProjectDocumentRepository {
+  JsonProjectDocumentRepository({
+    required File projectFile,
     required SafeFileWriter safeFileWriter,
     JsonEncoder? encoder,
-  })  : _safeFileWriter = safeFileWriter,
+  })  : _projectFile = projectFile,
+        _safeFileWriter = safeFileWriter,
         _encoder = encoder ?? const JsonEncoder.withIndent('  ');
 
+  final File _projectFile;
   final SafeFileWriter _safeFileWriter;
   final JsonEncoder _encoder;
 
   @override
-  Future<ProjectDocument?> read(File file) async {
-    if (!await file.exists()) {
-      return null;
+  Future<ProjectDocument> load() async {
+    if (!await _projectFile.exists()) {
+      return ProjectDocument.initial();
     }
 
-    final raw = await file.readAsString();
+    final raw = await _projectFile.readAsString();
     final decoded = jsonDecode(raw);
     if (decoded is! Map<String, dynamic>) {
       throw const FormatException('Project document must be a JSON object.');
@@ -37,8 +34,8 @@ final class JsonProjectDocumentStore implements ProjectDocumentStore {
   }
 
   @override
-  Future<void> write(File file, ProjectDocument document) {
+  Future<void> save(ProjectDocument document) {
     final serialized = _encoder.convert(document.toJson());
-    return _safeFileWriter.writeString(file, serialized);
+    return _safeFileWriter.writeString(_projectFile, serialized);
   }
 }

--- a/packages/bochki_schedule_infra/test/bochki_schedule_infra_test.dart
+++ b/packages/bochki_schedule_infra/test/bochki_schedule_infra_test.dart
@@ -76,13 +76,14 @@ void main() {
     expect(tempFiles, isEmpty);
   });
 
-  test('json project document store reads and writes document', () async {
+  test('json project document repository reads and writes document', () async {
     final tempDirectory =
         await Directory.systemTemp.createTemp('bochki_store_test');
     addTearDown(() => tempDirectory.delete(recursive: true));
 
     final file = File('${tempDirectory.path}/project.json');
-    final store = JsonProjectDocumentStore(
+    final repository = JsonProjectDocumentRepository(
+      projectFile: file,
       safeFileWriter: const AtomicFileWriter(),
     );
     const document = ProjectDocument(
@@ -100,29 +101,32 @@ void main() {
       ],
     );
 
-    await store.write(file, document);
-    final restored = await store.read(file);
+    await repository.save(document);
+    final restored = await repository.load();
 
     expect(restored, isNotNull);
-    expect(restored!.schemaVersion, 1);
+    expect(restored.schemaVersion, 1);
     expect(restored.nextId, 4);
     expect(restored.trainers.single['name'], 'Trainer One');
     expect(restored.participants.single['name'], 'Participant One');
     expect(restored.participants.single['deleted'], isTrue);
   });
 
-  test('json project document store returns null for missing file', () async {
+  test(
+      'json project document repository returns initial document for missing file',
+      () async {
     final tempDirectory =
         await Directory.systemTemp.createTemp('bochki_store_missing');
     addTearDown(() => tempDirectory.delete(recursive: true));
 
     final file = File('${tempDirectory.path}/missing.json');
-    final store = JsonProjectDocumentStore(
+    final repository = JsonProjectDocumentRepository(
+      projectFile: file,
       safeFileWriter: const AtomicFileWriter(),
     );
 
-    final restored = await store.read(file);
+    final restored = await repository.load();
 
-    expect(restored, isNull);
+    expect(restored, ProjectDocument.initial());
   });
 }


### PR DESCRIPTION
Closes #17\n\nSummary:\n- Introduce an application layer use case for participants editing.\n- Introduce an explicit ProjectDocument repository boundary.\n- Move participant normalization, duplicate checks, sorting, and nextId handling into the use case.\n- Keep atomic local JSON persistence via infra repository and AtomicFileWriter.\n\nChecks:\n- flutter test test/bochki_schedule_app_test.dart\n- flutter test test/participants_directory_use_case_test.dart\n- flutter test test/bochki_schedule_infra_test.dart