### PR TITLE
feat(app): redesign participants dialog editing UI

### DIFF
--- a/packages/bochki_schedule_app/integration_test/app_shell_test.dart
+++ b/packages/bochki_schedule_app/integration_test/app_shell_test.dart
@@ -43,7 +43,9 @@ void main() {
       find.byKey(const Key('participants_directory_dialog')),
       findsOneWidget,
     );
-    expect(find.byKey(const Key('participant_name_field')), findsOneWidget);
+    expect(find.text('Список участников'), findsOneWidget);
+    expect(find.text('Участники (0)'), findsOneWidget);
+    expect(find.text('Добавить новую запись'), findsOneWidget);
   });
 }
 

--- a/packages/bochki_schedule_app/lib/src/features/participants/participants_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/participants/participants_dialog.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 
 import '../../domain/participants/participant.dart';
 import 'participants_view_model.dart';
@@ -19,50 +21,275 @@ class ParticipantsDialog extends StatefulWidget {
 
 class _ParticipantsDialogState extends State<ParticipantsDialog> {
   final TextEditingController _nameController = TextEditingController();
+  final FocusNode _editorFocusNode = FocusNode();
 
+  String? _selectedParticipantId;
   String? _editingParticipantId;
+  bool _isCreating = false;
+  Future<bool>? _pendingSubmit;
+  String? _pendingTransitionParticipantId;
+  bool _pendingTransitionToAddRow = false;
+  bool _ignoreNextTapOutsideSubmit = false;
+  String? _tapDownHandledParticipantId;
+  bool _tapDownHandledAddRow = false;
+
+  bool get _isEditing => _isCreating || _editingParticipantId != null;
 
   @override
   void dispose() {
     _nameController.dispose();
+    _editorFocusNode.dispose();
     super.dispose();
   }
 
-  void _startEditing(Participant participant) {
+  bool _isEditingParticipant(Participant participant) {
+    return _editingParticipantId == participant.id;
+  }
+
+  bool _isSelectedParticipant(Participant participant) {
+    return _selectedParticipantId == participant.id;
+  }
+
+  void _requestEditorFocus() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _editorFocusNode.requestFocus();
+      }
+    });
+  }
+
+  void _startEditingParticipant(Participant participant) {
     setState(() {
+      _selectedParticipantId = participant.id;
       _editingParticipantId = participant.id;
+      _isCreating = false;
       _nameController.text = participant.name;
       _nameController.selection = TextSelection.fromPosition(
         TextPosition(offset: _nameController.text.length),
       );
     });
     widget.viewModel.clearFormError();
+    _requestEditorFocus();
+  }
+
+  void _startCreatingParticipant() {
+    setState(() {
+      _selectedParticipantId = null;
+      _editingParticipantId = null;
+      _isCreating = true;
+      _nameController.clear();
+    });
+    widget.viewModel.clearFormError();
+    _requestEditorFocus();
   }
 
   void _cancelEditing() {
     setState(() {
       _editingParticipantId = null;
+      _isCreating = false;
       _nameController.clear();
     });
     widget.viewModel.clearFormError();
+    _editorFocusNode.unfocus();
   }
 
-  Future<void> _submitParticipant() async {
+  void _prepareParticipantTransition(Participant participant) {
+    if (_isEditing && !_isEditingParticipant(participant)) {
+      _pendingTransitionParticipantId = participant.id;
+      _pendingTransitionToAddRow = false;
+      _ignoreNextTapOutsideSubmit = true;
+    }
+  }
+
+  void _prepareAddRowTransition() {
+    if (_isEditing && !_isCreating) {
+      _pendingTransitionParticipantId = null;
+      _pendingTransitionToAddRow = true;
+      _ignoreNextTapOutsideSubmit = true;
+    }
+  }
+
+  void _clearPendingTransition() {
+    _pendingTransitionParticipantId = null;
+    _pendingTransitionToAddRow = false;
+  }
+
+  Future<void> _submitAndStartEditing(Participant participant) async {
+    final isSuccess = await _submitCurrentEditing();
+    if (!mounted || !isSuccess) {
+      return;
+    }
+    _startEditingParticipant(participant);
+  }
+
+  Future<void> _submitAndStartCreating() async {
+    final isSuccess = await _submitCurrentEditing();
+    if (!mounted || !isSuccess) {
+      return;
+    }
+    _startCreatingParticipant();
+  }
+
+  void _handleParticipantTapDown(Participant participant) {
+    if (_isEditing && !_isEditingParticipant(participant)) {
+      _tapDownHandledParticipantId = participant.id;
+      _ignoreNextTapOutsideSubmit = true;
+      unawaited(_submitAndStartEditing(participant));
+      return;
+    }
+    _prepareParticipantTransition(participant);
+  }
+
+  void _handleAddRowTapDown() {
+    if (_isEditing && !_isCreating) {
+      _tapDownHandledAddRow = true;
+      _ignoreNextTapOutsideSubmit = true;
+      unawaited(_submitAndStartCreating());
+      return;
+    }
+    _prepareAddRowTransition();
+  }
+
+  void _showActionErrorIfNeeded() {
+    final message = widget.viewModel.actionErrorMessage;
+    if (!mounted || message == null) {
+      return;
+    }
+
+    widget.viewModel.clearActionError();
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  String? _findParticipantIdByName(String name) {
+    final normalizedName = Participant.sortKeyForName(name);
+    for (final participant in widget.viewModel.participants) {
+      if (Participant.sortKeyForName(participant.name) == normalizedName) {
+        return participant.id;
+      }
+    }
+    return null;
+  }
+
+  Future<bool> _submitCurrentEditing() {
+    if (!_isEditing) {
+      return Future<bool>.value(true);
+    }
+    if (_pendingSubmit != null) {
+      return _pendingSubmit!;
+    }
+
+    final editingParticipantId = _editingParticipantId;
+    final isCreating = _isCreating;
+    final rawName = _nameController.text;
     final viewModel = widget.viewModel;
-    final isSuccess = _editingParticipantId == null
-        ? await viewModel.createParticipant(_nameController.text)
-        : await viewModel.updateParticipant(
-            participantId: _editingParticipantId!,
-            rawName: _nameController.text,
-          );
-    if (!isSuccess || !mounted) {
+
+    final submitFuture = () async {
+      final isSuccess = isCreating
+          ? await viewModel.createParticipant(rawName)
+          : await viewModel.updateParticipant(
+              participantId: editingParticipantId!,
+              rawName: rawName,
+            );
+
+      if (!mounted) {
+        return isSuccess;
+      }
+
+      if (isSuccess) {
+        setState(() {
+          _editingParticipantId = null;
+          _isCreating = false;
+          _nameController.clear();
+          _selectedParticipantId = isCreating
+              ? _findParticipantIdByName(rawName)
+              : editingParticipantId;
+        });
+        _editorFocusNode.unfocus();
+      } else {
+        _showActionErrorIfNeeded();
+      }
+
+      return isSuccess;
+    }();
+
+    _pendingSubmit = submitFuture;
+    submitFuture.whenComplete(() {
+      _pendingSubmit = null;
+    });
+    return submitFuture;
+  }
+
+  Future<void> _handleParticipantTap(Participant participant) async {
+    if (_tapDownHandledParticipantId == participant.id) {
+      _tapDownHandledParticipantId = null;
+      return;
+    }
+
+    final shouldTransitionToEdit =
+        _pendingTransitionParticipantId == participant.id;
+    _clearPendingTransition();
+
+    if (_isEditingParticipant(participant)) {
+      setState(() {
+        _selectedParticipantId = participant.id;
+      });
+      return;
+    }
+
+    if (_isEditing || shouldTransitionToEdit) {
+      final isSuccess = await _submitCurrentEditing();
+      if (!mounted || !isSuccess) {
+        return;
+      }
+      _startEditingParticipant(participant);
       return;
     }
 
     setState(() {
-      _editingParticipantId = null;
-      _nameController.clear();
+      _selectedParticipantId = participant.id;
     });
+  }
+
+  Future<void> _handleParticipantDoubleTap(Participant participant) async {
+    _clearPendingTransition();
+
+    if (_isEditingParticipant(participant)) {
+      return;
+    }
+
+    if (_isEditing) {
+      final isSuccess = await _submitCurrentEditing();
+      if (!mounted || !isSuccess) {
+        return;
+      }
+    }
+
+    _startEditingParticipant(participant);
+  }
+
+  Future<void> _handleAddRowTap() async {
+    if (_tapDownHandledAddRow) {
+      _tapDownHandledAddRow = false;
+      return;
+    }
+
+    final shouldTransitionToAddRow = _pendingTransitionToAddRow;
+    _clearPendingTransition();
+
+    if (_isCreating) {
+      return;
+    }
+
+    if (_isEditing || shouldTransitionToAddRow) {
+      final isSuccess = await _submitCurrentEditing();
+      if (!mounted || !isSuccess) {
+        return;
+      }
+    }
+
+    _startCreatingParticipant();
   }
 
   Future<void> _deleteParticipant(Participant participant) async {
@@ -92,23 +319,304 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
       return;
     }
 
-    final viewModel = widget.viewModel;
-    final isSuccess = await viewModel.deleteParticipant(participant.id);
+    final isSuccess = await widget.viewModel.deleteParticipant(participant.id);
     if (!mounted) {
       return;
     }
+
     if (isSuccess) {
       if (_editingParticipantId == participant.id) {
         _cancelEditing();
       }
+      if (_selectedParticipantId == participant.id) {
+        setState(() {
+          _selectedParticipantId = null;
+        });
+      }
       return;
     }
 
-    final message =
-        viewModel.actionErrorMessage ?? 'Не удалось удалить участника.';
-    viewModel.clearActionError();
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(message)),
+    _showActionErrorIfNeeded();
+  }
+
+  Future<void> _showParticipantContextMenu(
+    Participant participant,
+    TapDownDetails details,
+  ) async {
+    if (_isEditing && !_isEditingParticipant(participant)) {
+      final isSuccess = await _submitCurrentEditing();
+      if (!mounted || !isSuccess) {
+        return;
+      }
+    }
+
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _selectedParticipantId = participant.id;
+    });
+
+    final overlay = Overlay.of(context).context.findRenderObject();
+    if (overlay is! RenderBox) {
+      return;
+    }
+
+    final menuAction = await showMenu<_ParticipantMenuAction>(
+      context: context,
+      position: RelativeRect.fromRect(
+        Rect.fromLTWH(
+          details.globalPosition.dx,
+          details.globalPosition.dy,
+          0,
+          0,
+        ),
+        Offset.zero & overlay.size,
+      ),
+      items: const [
+        PopupMenuItem<_ParticipantMenuAction>(
+          value: _ParticipantMenuAction.edit,
+          child: Text('Edit'),
+        ),
+        PopupMenuItem<_ParticipantMenuAction>(
+          value: _ParticipantMenuAction.delete,
+          child: Text('Delete'),
+        ),
+      ],
+    );
+
+    if (!mounted || menuAction == null) {
+      return;
+    }
+
+    switch (menuAction) {
+      case _ParticipantMenuAction.edit:
+        _startEditingParticipant(participant);
+      case _ParticipantMenuAction.delete:
+        unawaited(_deleteParticipant(participant));
+    }
+  }
+
+  Key _rowKey(String value) => Key('participant_row_$value');
+
+  Widget _buildHeaderRow(BuildContext context, int count) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+      decoration: const BoxDecoration(
+        color: Color(0xFFD7E8FB),
+        border: Border(
+          bottom: BorderSide(color: Color(0xFFB6CCE3)),
+        ),
+      ),
+      child: Row(
+        children: [
+          const SizedBox(width: 28),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              'Участники ($count)',
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: const Color(0xFF123A63),
+                  ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildIndicator({
+    required bool isEditing,
+    required bool isAddRow,
+    required bool isSelected,
+  }) {
+    if (isEditing) {
+      return const Icon(Icons.edit, size: 16, color: Color(0xFF1D4F8C));
+    }
+    if (isAddRow) {
+      return const Text(
+        '*',
+        style: TextStyle(
+          color: Color(0xFF56718D),
+          fontWeight: FontWeight.w700,
+        ),
+      );
+    }
+    if (isSelected) {
+      return const Text(
+        '▶',
+        style: TextStyle(
+          color: Color(0xFF1D4F8C),
+          fontSize: 12,
+          fontWeight: FontWeight.w700,
+        ),
+      );
+    }
+    return const SizedBox.shrink();
+  }
+
+  Widget _buildNameEditor(ParticipantsViewModel viewModel) {
+    return Focus(
+      onKeyEvent: (node, event) {
+        if (event is! KeyDownEvent) {
+          return KeyEventResult.ignored;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.escape) {
+          _cancelEditing();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: TextField(
+        key: const Key('participant_name_field'),
+        focusNode: _editorFocusNode,
+        controller: _nameController,
+        autofocus: true,
+        decoration: InputDecoration(
+          isDense: true,
+          hintText: 'Введите имя участника',
+          errorText: viewModel.formErrorMessage,
+          border: const OutlineInputBorder(),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 10,
+            vertical: 10,
+          ),
+        ),
+        textInputAction: TextInputAction.done,
+        onChanged: (_) => viewModel.clearFormError(),
+        onTapOutside: viewModel.isSaving
+            ? null
+            : (_) {
+                if (_ignoreNextTapOutsideSubmit) {
+                  _ignoreNextTapOutsideSubmit = false;
+                  return;
+                }
+                if (_pendingTransitionParticipantId != null ||
+                    _pendingTransitionToAddRow) {
+                  return;
+                }
+                unawaited(_submitCurrentEditing());
+              },
+        onSubmitted: viewModel.isSaving
+            ? null
+            : (_) => unawaited(_submitCurrentEditing()),
+      ),
+    );
+  }
+
+  Widget _buildParticipantRow(
+    BuildContext context,
+    ParticipantsViewModel viewModel,
+    Participant participant,
+  ) {
+    final isEditing = _isEditingParticipant(participant);
+    final isSelected = _isSelectedParticipant(participant);
+    final backgroundColor = isEditing
+        ? const Color(0xFFE3F0FF)
+        : isSelected
+            ? const Color(0xFFF0F7FF)
+            : Colors.white;
+
+    return GestureDetector(
+      key: _rowKey(participant.id),
+      behavior: HitTestBehavior.opaque,
+      onTapDown: viewModel.isSaving
+          ? null
+          : (_) => _handleParticipantTapDown(participant),
+      onTap: viewModel.isSaving
+          ? null
+          : () => unawaited(_handleParticipantTap(participant)),
+      onDoubleTap: viewModel.isSaving
+          ? null
+          : () => unawaited(_handleParticipantDoubleTap(participant)),
+      onSecondaryTapDown: viewModel.isSaving
+          ? null
+          : (details) => unawaited(
+                _showParticipantContextMenu(participant, details),
+              ),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          border: const Border(
+            bottom: BorderSide(color: Color(0xFFD8E1EA)),
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            SizedBox(
+              width: 28,
+              child: Align(
+                alignment: Alignment.center,
+                child: _buildIndicator(
+                  isEditing: isEditing,
+                  isAddRow: false,
+                  isSelected: isSelected,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: isEditing
+                  ? _buildNameEditor(viewModel)
+                  : Text(
+                      participant.name,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAddRow(BuildContext context, ParticipantsViewModel viewModel) {
+    final isEditing = _isCreating;
+
+    return GestureDetector(
+      key: const Key('participant_add_row'),
+      behavior: HitTestBehavior.opaque,
+      onTapDown: viewModel.isSaving ? null : (_) => _handleAddRowTapDown(),
+      onTap: viewModel.isSaving ? null : () => unawaited(_handleAddRowTap()),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: const BoxDecoration(
+          color: Color(0xFFE8F0F6),
+          border: Border(
+            bottom: BorderSide(color: Color(0xFFD8E1EA)),
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            SizedBox(
+              width: 28,
+              child: Align(
+                alignment: Alignment.center,
+                child: _buildIndicator(
+                  isEditing: isEditing,
+                  isAddRow: true,
+                  isSelected: false,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: isEditing
+                  ? _buildNameEditor(viewModel)
+                  : Text(
+                      'Добавить новую запись',
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                            color: const Color(0xFF60758B),
+                          ),
+                    ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 
@@ -118,27 +626,32 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
       animation: widget.viewModel,
       builder: (context, child) {
         final viewModel = widget.viewModel;
-        final isEditing = _editingParticipantId != null;
 
         return Dialog(
           key: const Key('participants_directory_dialog'),
           insetPadding: const EdgeInsets.all(24),
+          clipBehavior: Clip.antiAlias,
           child: SizedBox(
-            width: 760,
-            height: 600,
-            child: Padding(
-              padding: const EdgeInsets.all(24),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Row(
+            width: 720,
+            height: 560,
+            child: Column(
+              children: [
+                Container(
+                  padding: const EdgeInsets.fromLTRB(20, 14, 8, 14),
+                  decoration: const BoxDecoration(
+                    color: Color(0xFFF4F7FA),
+                    border: Border(
+                      bottom: BorderSide(color: Color(0xFFD0D7DE)),
+                    ),
+                  ),
+                  child: Row(
                     children: [
                       Expanded(
                         child: Text(
-                          'Участники',
+                          'Список участников',
                           style: Theme.of(context)
                               .textTheme
-                              .headlineSmall
+                              .titleLarge
                               ?.copyWith(fontWeight: FontWeight.w700),
                         ),
                       ),
@@ -149,163 +662,74 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
                       ),
                     ],
                   ),
-                  const SizedBox(height: 16),
-                  Expanded(
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        color: const Color(0xFFF8FAFC),
-                        borderRadius: BorderRadius.circular(16),
-                        border: Border.all(color: const Color(0xFFD0D7DE)),
-                      ),
-                      child: viewModel.isLoading
-                          ? const Center(child: CircularProgressIndicator())
-                          : viewModel.loadErrorMessage != null
-                              ? _ParticipantsLoadError(
-                                  message: viewModel.loadErrorMessage!,
-                                  onRetry: viewModel.loadParticipants,
-                                )
-                              : viewModel.participants.isEmpty
-                                  ? const Center(
-                                      child: Text(
-                                        'Пока нет ни одного участника.',
-                                      ),
-                                    )
-                                  : ListView.separated(
-                                      padding: const EdgeInsets.all(16),
-                                      itemCount: viewModel.participants.length,
-                                      separatorBuilder: (context, index) =>
-                                          const SizedBox(height: 12),
-                                      itemBuilder: (context, index) {
-                                        final participant =
-                                            viewModel.participants[index];
-                                        return Container(
-                                          padding: const EdgeInsets.symmetric(
-                                            horizontal: 16,
-                                            vertical: 14,
+                ),
+                Expanded(
+                  child: DecoratedBox(
+                    decoration: const BoxDecoration(
+                      color: Color(0xFFF9FBFD),
+                    ),
+                    child: viewModel.isLoading
+                        ? const Center(child: CircularProgressIndicator())
+                        : viewModel.loadErrorMessage != null
+                            ? _ParticipantsLoadError(
+                                message: viewModel.loadErrorMessage!,
+                                onRetry: viewModel.loadParticipants,
+                              )
+                            : Column(
+                                children: [
+                                  _buildHeaderRow(
+                                    context,
+                                    viewModel.participants.length,
+                                  ),
+                                  Expanded(
+                                    child: ListView(
+                                      padding: EdgeInsets.zero,
+                                      children: [
+                                        for (final participant
+                                            in viewModel.participants)
+                                          _buildParticipantRow(
+                                            context,
+                                            viewModel,
+                                            participant,
                                           ),
-                                          decoration: BoxDecoration(
-                                            color: Colors.white,
-                                            borderRadius:
-                                                BorderRadius.circular(12),
-                                            border: Border.all(
-                                              color: const Color(0xFFD8DEE4),
-                                            ),
-                                          ),
-                                          child: Row(
-                                            children: [
-                                              Expanded(
-                                                child: Text(
-                                                  participant.name,
-                                                  style: Theme.of(context)
-                                                      .textTheme
-                                                      .titleMedium,
-                                                ),
-                                              ),
-                                              const SizedBox(width: 12),
-                                              TextButton(
-                                                onPressed: viewModel.isSaving
-                                                    ? null
-                                                    : () => _startEditing(
-                                                          participant,
-                                                        ),
-                                                child: const Text(
-                                                  'Редактировать',
-                                                ),
-                                              ),
-                                              const SizedBox(width: 8),
-                                              TextButton(
-                                                onPressed: viewModel.isSaving
-                                                    ? null
-                                                    : () => unawaited(
-                                                          _deleteParticipant(
-                                                            participant,
-                                                          ),
-                                                        ),
-                                                style: TextButton.styleFrom(
-                                                  foregroundColor:
-                                                      Theme.of(context)
-                                                          .colorScheme
-                                                          .error,
-                                                ),
-                                                child: const Text('Удалить'),
-                                              ),
-                                            ],
-                                          ),
-                                        );
-                                      },
+                                        _buildAddRow(context, viewModel),
+                                      ],
                                     ),
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  DecoratedBox(
-                    decoration: BoxDecoration(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(color: const Color(0xFFD0D7DE)),
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          Text(
-                            isEditing
-                                ? 'Редактировать участника'
-                                : 'Новый участник',
-                            style: Theme.of(context)
-                                .textTheme
-                                .titleMedium
-                                ?.copyWith(fontWeight: FontWeight.w600),
-                          ),
-                          const SizedBox(height: 12),
-                          TextField(
-                            key: const Key('participant_name_field'),
-                            controller: _nameController,
-                            decoration: InputDecoration(
-                              labelText: 'Имя',
-                              errorText: viewModel.formErrorMessage,
-                            ),
-                            textInputAction: TextInputAction.done,
-                            onChanged: (_) => viewModel.clearFormError(),
-                            onSubmitted: viewModel.isSaving
-                                ? null
-                                : (_) => unawaited(_submitParticipant()),
-                          ),
-                          const SizedBox(height: 12),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.end,
-                            children: [
-                              if (isEditing) ...[
-                                TextButton(
-                                  onPressed: viewModel.isSaving
-                                      ? null
-                                      : _cancelEditing,
-                                  child: const Text('Отменить редактирование'),
-                                ),
-                                const SizedBox(width: 8),
-                              ],
-                              FilledButton(
-                                onPressed: viewModel.isSaving
-                                    ? null
-                                    : () => unawaited(_submitParticipant()),
-                                child: Text(
-                                  isEditing ? 'Сохранить' : 'Добавить',
-                                ),
+                                  ),
+                                ],
                               ),
-                            ],
-                          ),
-                        ],
-                      ),
+                  ),
+                ),
+                Container(
+                  padding: const EdgeInsets.all(16),
+                  decoration: const BoxDecoration(
+                    color: Color(0xFFF4F7FA),
+                    border: Border(
+                      top: BorderSide(color: Color(0xFFD0D7DE)),
                     ),
                   ),
-                ],
-              ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      FilledButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: const Text('Ok'),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             ),
           ),
         );
       },
     );
   }
+}
+
+enum _ParticipantMenuAction {
+  edit,
+  delete,
 }
 
 class _ParticipantsLoadError extends StatelessWidget {
@@ -320,13 +744,17 @@ class _ParticipantsLoadError extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 320),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(message, textAlign: TextAlign.center),
-            const SizedBox(height: 16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 12),
             FilledButton(
               onPressed: () => unawaited(onRetry()),
               child: const Text('Повторить'),

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:bochki_schedule_app/bochki_schedule_app.dart';
 import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
@@ -36,10 +37,13 @@ void main() {
       find.byKey(const Key('participants_directory_dialog')),
       findsOneWidget,
     );
-    expect(find.byKey(const Key('participant_name_field')), findsOneWidget);
+    expect(find.text('Список участников'), findsOneWidget);
+    expect(find.text('Участники (0)'), findsOneWidget);
+    expect(find.text('Добавить новую запись'), findsOneWidget);
+    expect(find.text('Ok'), findsOneWidget);
   });
 
-  testWidgets('participants dialog adds edits and soft-deletes entries', (
+  testWidgets('participants dialog supports inline add edit and delete', (
     tester,
   ) async {
     final context = _buildTestContext();
@@ -52,49 +56,90 @@ void main() {
     await tester.tap(find.text('Участники').last);
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Добавить'));
+    await tester.tap(find.byKey(const Key('participant_add_row')));
     await tester.pumpAndSettle();
-    expect(find.text('Введите имя участника.'), findsOneWidget);
+    expect(find.byKey(const Key('participant_name_field')), findsOneWidget);
 
     await tester.enterText(
       find.byKey(const Key('participant_name_field')),
       '  Иван   Иванов  ',
     );
-    await tester.tap(find.text('Добавить'));
+    await tester.tap(find.text('Участники (0)'));
     await tester.pumpAndSettle();
 
     expect(find.text('Иван Иванов'), findsOneWidget);
     expect(context.repository.participants.single.name, 'Иван Иванов');
+    expect(find.text('Участники (1)'), findsOneWidget);
 
+    await tester.tap(find.byKey(const Key('participant_add_row')));
+    await tester.pumpAndSettle();
     await tester.enterText(
       find.byKey(const Key('participant_name_field')),
-      'Иван Иванов',
+      'Борис',
     );
-    await tester.tap(find.text('Добавить'));
+    await tester.tap(find.text('Участники (1)'));
     await tester.pumpAndSettle();
-    expect(find.text('Участник с таким именем уже есть.'), findsOneWidget);
 
-    await tester.tap(find.text('Редактировать'));
+    expect(
+      context.repository.participants.map((participant) => participant.name),
+      ['Иван Иванов', 'Борис'],
+    );
+
+    final firstRow = find.byKey(const Key('participant_row_1'));
+    await _mouseClick(tester, firstRow);
+    await tester.pump(const Duration(milliseconds: 50));
+    await _mouseClick(tester, firstRow);
     await tester.pumpAndSettle();
     await tester.enterText(
       find.byKey(const Key('participant_name_field')),
       'Иван Петров',
     );
-    await tester.tap(find.text('Сохранить'));
+
+    await _mouseClick(tester, find.byKey(const Key('participant_row_2')));
     await tester.pumpAndSettle();
 
     expect(find.text('Иван Петров'), findsOneWidget);
     expect(find.text('Иван Иванов'), findsNothing);
-    expect(context.repository.participants.single.name, 'Иван Петров');
+    expect(context.repository.participants.first.name, 'Иван Петров');
 
-    await tester.tap(find.text('Удалить'));
+    final borisRow = find.byKey(const Key('participant_row_2'));
+    await _mouseClick(
+      tester,
+      borisRow,
+      buttons: kSecondaryMouseButton,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Delete'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Удалить').last);
     await tester.pumpAndSettle();
 
-    expect(find.text('Пока нет ни одного участника.'), findsOneWidget);
-    expect(context.repository.participants, isEmpty);
+    expect(
+        context.repository.participants.map((participant) => participant.name),
+        [
+          'Иван Петров',
+        ]);
+    expect(find.text('Участники (1)'), findsOneWidget);
   });
+}
+
+Future<void> _mouseClick(
+  WidgetTester tester,
+  Finder finder, {
+  int buttons = kPrimaryMouseButton,
+}) async {
+  final gesture = await tester.createGesture(
+    kind: PointerDeviceKind.mouse,
+    buttons: buttons,
+  );
+  final center = tester.getCenter(finder);
+  await gesture.addPointer(location: center);
+  await gesture.moveTo(center);
+  await tester.pump();
+  await gesture.down(center);
+  await gesture.up();
+  await gesture.removePointer();
 }
 
 _TestContext _buildTestContext() {


### PR DESCRIPTION
## Summary
- replace the participants editor with a table-like dialog and inline editing flow
- add row selection, context menu actions, and an inline add row at the bottom
- update widget coverage for the new desktop-style interaction model

## Testing
- flutter test test/features/participants/participants_view_model_test.dart test/bochki_schedule_app_test.dart
