### PR TITLE
fix(app): polish participants dialog ux

### DIFF
--- a/packages/bochki_schedule_app/lib/src/features/participants/participants_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/participants/participants_dialog.dart
@@ -37,6 +37,11 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
 
   bool get _isEditing => _isCreating || _editingParticipantId != null;
 
+  bool _isEnterKey(LogicalKeyboardKey key) {
+    return key == LogicalKeyboardKey.enter ||
+        key == LogicalKeyboardKey.numpadEnter;
+  }
+
   @override
   void initState() {
     super.initState();
@@ -163,7 +168,9 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
     );
   }
 
-  Future<bool> _submitCurrentEditing() {
+  Future<bool> _submitCurrentEditing({
+    bool cancelEmptyCreate = false,
+  }) {
     if (!_isEditing) {
       return Future<bool>.value(true);
     }
@@ -175,12 +182,17 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
     final editingInitialName = _editingInitialName;
     final isCreating = _isCreating;
     final rawName = _nameController.text;
+    final normalizedName = Participant.normalizeName(rawName);
     final viewModel = widget.viewModel;
+
+    if (isCreating && cancelEmptyCreate && normalizedName.isEmpty) {
+      _finishEditing(selectedParticipantId: _selectedParticipantId);
+      return Future<bool>.value(true);
+    }
 
     if (!isCreating &&
         editingParticipantId != null &&
-        Participant.normalizeName(rawName) ==
-            Participant.normalizeName(editingInitialName ?? '')) {
+        normalizedName == Participant.normalizeName(editingInitialName ?? '')) {
       _finishEditing(selectedParticipantId: editingParticipantId);
       return Future<bool>.value(true);
     }
@@ -217,7 +229,21 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
     return submitFuture;
   }
 
+  void _restoreSelectionAfterFailedSubmit({
+    required String? previousEditingParticipantId,
+    required bool previousIsCreating,
+  }) {
+    setState(() {
+      _selectedParticipantId =
+          previousIsCreating ? null : previousEditingParticipantId;
+    });
+    _requestTableFocus();
+  }
+
   Future<void> _selectParticipant(Participant participant) async {
+    final previousEditingParticipantId = _editingParticipantId;
+    final previousIsCreating = _isCreating;
+
     if (_isEditingParticipant(participant)) {
       if (_selectedParticipantId != participant.id) {
         setState(() {
@@ -229,8 +255,12 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
     }
 
     if (_isEditing) {
-      final isSuccess = await _submitCurrentEditing();
+      final isSuccess = await _submitCurrentEditing(cancelEmptyCreate: true);
       if (!mounted || !isSuccess) {
+        _restoreSelectionAfterFailedSubmit(
+          previousEditingParticipantId: previousEditingParticipantId,
+          previousIsCreating: previousIsCreating,
+        );
         return;
       }
     }
@@ -242,9 +272,6 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
   }
 
   void _handleParticipantTapDown(Participant participant) {
-    if (_isEditing && !_isEditingParticipant(participant)) {
-      return;
-    }
     if (_selectedParticipantId == participant.id) {
       _requestTableFocus();
       return;
@@ -262,7 +289,7 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
     }
 
     if (_isEditing) {
-      final isSuccess = await _submitCurrentEditing();
+      final isSuccess = await _submitCurrentEditing(cancelEmptyCreate: true);
       if (!mounted || !isSuccess) {
         return;
       }
@@ -277,7 +304,7 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
     }
 
     if (_isEditing) {
-      final isSuccess = await _submitCurrentEditing();
+      final isSuccess = await _submitCurrentEditing(cancelEmptyCreate: true);
       if (!mounted || !isSuccess) {
         return;
       }
@@ -356,9 +383,23 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
     Participant participant,
     TapDownDetails details,
   ) async {
+    final previousEditingParticipantId = _editingParticipantId;
+    final previousIsCreating = _isCreating;
+
+    if (_selectedParticipantId != participant.id) {
+      setState(() {
+        _selectedParticipantId = participant.id;
+      });
+    }
+    _requestTableFocus();
+
     if (_isEditing && !_isEditingParticipant(participant)) {
-      final isSuccess = await _submitCurrentEditing();
+      final isSuccess = await _submitCurrentEditing(cancelEmptyCreate: true);
       if (!mounted || !isSuccess) {
+        _restoreSelectionAfterFailedSubmit(
+          previousEditingParticipantId: previousEditingParticipantId,
+          previousIsCreating: previousIsCreating,
+        );
         return;
       }
     }
@@ -366,11 +407,6 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
     if (!mounted) {
       return;
     }
-
-    setState(() {
-      _selectedParticipantId = participant.id;
-    });
-    _requestTableFocus();
 
     final overlay = Overlay.of(context).context.findRenderObject();
     if (overlay is! RenderBox) {
@@ -398,6 +434,7 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
           child: Text('Delete'),
         ),
       ],
+      popUpAnimationStyle: AnimationStyle.noAnimation,
     );
 
     if (!mounted || menuAction == null) {
@@ -479,7 +516,7 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
       _moveSelection(-1);
       return true;
     }
-    if (event.logicalKey == LogicalKeyboardKey.enter ||
+    if (_isEnterKey(event.logicalKey) ||
         event.logicalKey == LogicalKeyboardKey.f2) {
       _handleStartEditingShortcut(viewModel);
       return true;
@@ -570,6 +607,12 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
           _cancelEditing();
           return KeyEventResult.handled;
         }
+        if (_isEnterKey(event.logicalKey)) {
+          if (!viewModel.isSaving) {
+            unawaited(_submitCurrentEditing());
+          }
+          return KeyEventResult.handled;
+        }
         return KeyEventResult.ignored;
       },
       child: TextField(
@@ -591,7 +634,9 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
         onChanged: (_) => viewModel.clearFormError(),
         onTapOutside: viewModel.isSaving
             ? null
-            : (_) => unawaited(_submitCurrentEditing()),
+            : (_) => unawaited(
+                  _submitCurrentEditing(cancelEmptyCreate: true),
+                ),
         onSubmitted: viewModel.isSaving
             ? null
             : (_) => unawaited(_submitCurrentEditing()),

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:bochki_schedule_app/bochki_schedule_app.dart';
 import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/widgets.dart';
 
@@ -144,6 +145,58 @@ void main() {
     expect(find.byKey(const Key('participant_name_field')), findsNothing);
   });
 
+  testWidgets('enter commits inline edit and keeps row selected', (
+    tester,
+  ) async {
+    final context = _buildTestContext(
+      participants: [
+        Participant(id: '1', name: 'Анна'),
+      ],
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await _openParticipantsDialog(tester);
+
+    final row = find.byKey(const Key('participant_row_1'));
+    await _mouseClick(tester, row);
+    await tester.pump(const Duration(milliseconds: 50));
+    await _mouseClick(tester, row);
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('participant_name_field')),
+      'Анна Петрова',
+    );
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('participant_name_field')), findsNothing);
+    expect(find.text('Анна Петрова'), findsOneWidget);
+    expect(context.repository.participants.single.name, 'Анна Петрова');
+    expect(find.text('▶'), findsOneWidget);
+  });
+
+  testWidgets('empty add row is cancelled on click outside', (tester) async {
+    final context = _buildTestContext();
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await _openParticipantsDialog(tester);
+
+    await tester.tap(find.byKey(const Key('participant_add_row')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('participant_name_field')), findsOneWidget);
+
+    await tester.tap(find.text('Участники (0)'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('participant_name_field')), findsNothing);
+    expect(context.repository.participants, isEmpty);
+    expect(find.text('Введите имя участника.'), findsNothing);
+  });
+
   testWidgets('double click opens inline edit for row', (
     tester,
   ) async {
@@ -164,6 +217,76 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('participant_name_field')), findsOneWidget);
+  });
+
+  testWidgets('row becomes selected on mouse down while another row is editing',
+      (
+    tester,
+  ) async {
+    final context = _buildTestContext(
+      participants: [
+        Participant(id: '1', name: 'Анна'),
+        Participant(id: '2', name: 'Борис'),
+      ],
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await _openParticipantsDialog(tester);
+
+    final firstRow = find.byKey(const Key('participant_row_1'));
+    await _mouseClick(tester, firstRow);
+    await tester.pump(const Duration(milliseconds: 50));
+    await _mouseClick(tester, firstRow);
+    await tester.pumpAndSettle();
+
+    final secondRow = find.byKey(const Key('participant_row_2'));
+    final gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+      buttons: kPrimaryMouseButton,
+    );
+    final center = tester.getCenter(secondRow);
+    await gesture.addPointer(location: center);
+    await gesture.moveTo(center);
+    await tester.pump();
+    await gesture.down(center);
+    await tester.pump();
+
+    expect(find.text('▶'), findsOneWidget);
+
+    await gesture.up();
+    await gesture.removePointer();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('context menu closes without waiting for animation', (
+    tester,
+  ) async {
+    final context = _buildTestContext(
+      participants: [
+        Participant(id: '1', name: 'Анна'),
+      ],
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await _openParticipantsDialog(tester);
+
+    final row = find.byKey(const Key('participant_row_1'));
+    await _mouseClick(
+      tester,
+      row,
+      buttons: kSecondaryMouseButton,
+    );
+    await tester.pump();
+
+    expect(find.text('Delete'), findsOneWidget);
+
+    await tester.tap(find.text('Delete'));
+    await tester.pump();
+
+    expect(find.text('Delete'), findsNothing);
+    expect(find.text('Удалить участника?'), findsOneWidget);
   });
 }
 


### PR DESCRIPTION
## Summary
- make row selection react immediately on pointer down, including while another row is being edited
- commit inline edits on Enter and cancel empty add-row drafts on click outside
- remove popup menu open/close animation for faster Windows right-click UX and add coverage for the new flows

## Testing
- cd packages/bochki_schedule_app && flutter test test/bochki_schedule_app_test.dart test/features/participants/participants_view_model_test.dart -r expanded