### PR TITLE
feat(participants): model table interactions as state machine

### DIFF
--- a/packages/bochki_schedule_app/lib/src/features/participants/participants_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/participants/participants_dialog.dart
@@ -1,16 +1,19 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 
 import '../../domain/participants/participant.dart';
+import 'participants_table_state.dart';
 import 'participants_view_model.dart';
 
 const double _indicatorColumnWidth = 40;
 const Color _tableDividerColor = Color(0xFFD7DFE8);
 const Color _rowBorderColor = Color(0xFFD8E1EA);
 const Key _tableDividerKey = Key('participants_table_divider');
+const double _contextMenuWidth = 144;
+const double _contextMenuHeight = 88;
 
 class ParticipantsDialog extends StatefulWidget {
   const ParticipantsDialog({
@@ -28,14 +31,19 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
   final TextEditingController _nameController = TextEditingController();
   final FocusNode _editorFocusNode = FocusNode();
   final FocusNode _tableFocusNode = FocusNode();
+  final GlobalKey _tableAreaKey = GlobalKey();
+  final ParticipantsTableReducer _reducer = const ParticipantsTableReducer();
 
-  String? _selectedParticipantId;
-  String? _editingParticipantId;
-  String? _editingInitialName;
-  bool _isCreating = false;
+  ParticipantsTableState _tableState = const ParticipantsTableNoSelection();
   Future<bool>? _pendingSubmit;
 
-  bool get _isEditing => _isCreating || _editingParticipantId != null;
+  List<ParticipantsTableRowData> get _rows => [
+        for (final participant in widget.viewModel.participants)
+          ParticipantsTableRowData(
+            id: participant.id,
+            name: participant.name,
+          ),
+      ];
 
   bool _isEnterKey(LogicalKeyboardKey key) {
     return key == LogicalKeyboardKey.enter ||
@@ -43,14 +51,7 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
   }
 
   @override
-  void initState() {
-    super.initState();
-    HardwareKeyboard.instance.addHandler(_handleHardwareKeyEvent);
-  }
-
-  @override
   void dispose() {
-    HardwareKeyboard.instance.removeHandler(_handleHardwareKeyEvent);
     _nameController.dispose();
     _editorFocusNode.dispose();
     _tableFocusNode.dispose();
@@ -58,19 +59,16 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
   }
 
   bool _isEditingParticipant(Participant participant) {
-    return _editingParticipantId == participant.id;
+    final tableState = _tableState;
+    return tableState is ParticipantsTableEditDataRow &&
+        tableState.participantId == participant.id;
   }
 
   bool _isSelectedParticipant(Participant participant) {
-    return _selectedParticipantId == participant.id;
+    return _tableState.selectedParticipantId == participant.id;
   }
 
   void _requestEditorFocus() {
-    if (_editorFocusNode.context != null) {
-      _editorFocusNode.requestFocus();
-      return;
-    }
-
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         _editorFocusNode.requestFocus();
@@ -79,11 +77,6 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
   }
 
   void _requestTableFocus() {
-    if (_tableFocusNode.context != null) {
-      _tableFocusNode.requestFocus();
-      return;
-    }
-
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         _tableFocusNode.requestFocus();
@@ -91,50 +84,46 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
     });
   }
 
-  void _startEditingParticipant(Participant participant) {
-    setState(() {
-      _selectedParticipantId = participant.id;
-      _editingParticipantId = participant.id;
-      _editingInitialName = participant.name;
-      _isCreating = false;
-      _nameController.text = participant.name;
-      _nameController.selection = TextSelection.fromPosition(
-        TextPosition(offset: _nameController.text.length),
-      );
-    });
-    widget.viewModel.clearFormError();
-    _requestEditorFocus();
+  void _syncControllerFromState(ParticipantsTableState state) {
+    final nextText = switch (state) {
+      ParticipantsTableEditDataRow(:final currentValue) => currentValue,
+      ParticipantsTableEditNewRow(:final currentValue) => currentValue,
+      _ => '',
+    };
+
+    if (_nameController.text == nextText) {
+      return;
+    }
+
+    _nameController.value = TextEditingValue(
+      text: nextText,
+      selection: TextSelection.collapsed(offset: nextText.length),
+    );
   }
 
-  void _startCreatingParticipant() {
-    setState(() {
-      _selectedParticipantId = null;
-      _editingParticipantId = null;
-      _editingInitialName = null;
-      _isCreating = true;
-      _nameController.clear();
-    });
-    widget.viewModel.clearFormError();
-    _requestEditorFocus();
-  }
-
-  void _finishEditing({
-    required String? selectedParticipantId,
+  void _setTableState(
+    ParticipantsTableState nextState, {
+    bool clearFormError = false,
   }) {
-    setState(() {
-      _selectedParticipantId = selectedParticipantId;
-      _editingParticipantId = null;
-      _editingInitialName = null;
-      _isCreating = false;
-      _nameController.clear();
-    });
-    widget.viewModel.clearFormError();
-    _editorFocusNode.unfocus();
-    _requestTableFocus();
-  }
+    if (!mounted) {
+      return;
+    }
 
-  void _cancelEditing() {
-    _finishEditing(selectedParticipantId: _editingParticipantId);
+    setState(() {
+      _tableState = nextState;
+      _syncControllerFromState(nextState);
+    });
+
+    if (clearFormError) {
+      widget.viewModel.clearFormError();
+    }
+
+    if (nextState.isEditing) {
+      _requestEditorFocus();
+    } else {
+      _editorFocusNode.unfocus();
+      _requestTableFocus();
+    }
   }
 
   Participant? _findParticipantById(String participantId) {
@@ -168,55 +157,43 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
     );
   }
 
-  Future<bool> _submitCurrentEditing({
-    bool cancelEmptyCreate = false,
-  }) {
-    if (!_isEditing) {
-      return Future<bool>.value(true);
-    }
+  Future<bool> _submit(
+    ParticipantsTableSubmitRequest request,
+  ) {
     if (_pendingSubmit != null) {
       return _pendingSubmit!;
     }
 
-    final editingParticipantId = _editingParticipantId;
-    final editingInitialName = _editingInitialName;
-    final isCreating = _isCreating;
-    final rawName = _nameController.text;
-    final normalizedName = Participant.normalizeName(rawName);
     final viewModel = widget.viewModel;
-
-    if (isCreating && cancelEmptyCreate && normalizedName.isEmpty) {
-      _finishEditing(selectedParticipantId: _selectedParticipantId);
-      return Future<bool>.value(true);
-    }
-
-    if (!isCreating &&
-        editingParticipantId != null &&
-        normalizedName == Participant.normalizeName(editingInitialName ?? '')) {
-      _finishEditing(selectedParticipantId: editingParticipantId);
-      return Future<bool>.value(true);
-    }
-
     final submitFuture = () async {
-      final isSuccess = isCreating
-          ? await viewModel.createParticipant(rawName)
-          : await viewModel.updateParticipant(
-              participantId: editingParticipantId!,
-              rawName: rawName,
-            );
+      final isSuccess = switch (request.mode) {
+        ParticipantsTableSubmitMode.create =>
+          await viewModel.createParticipant(request.rawValue),
+        ParticipantsTableSubmitMode.update => await viewModel.updateParticipant(
+            participantId: request.participantId!,
+            rawName: request.rawValue,
+          ),
+      };
 
       if (!mounted) {
         return isSuccess;
       }
 
       if (isSuccess) {
-        _finishEditing(
-          selectedParticipantId: isCreating
-              ? _findParticipantIdByName(rawName)
-              : editingParticipantId,
+        _setTableState(
+          _reducer.resolveSubmitSuccess(
+            target: request.successTarget,
+            rows: _rows,
+            createdParticipantId:
+                request.mode == ParticipantsTableSubmitMode.create
+                    ? _findParticipantIdByName(request.rawValue)
+                    : null,
+          ),
+          clearFormError: true,
         );
       } else {
         _showActionErrorIfNeeded();
+        _requestEditorFocus();
       }
 
       return isSuccess;
@@ -229,88 +206,55 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
     return submitFuture;
   }
 
-  void _restoreSelectionAfterFailedSubmit({
-    required String? previousEditingParticipantId,
-    required bool previousIsCreating,
+  void _dispatch(
+    ParticipantsTableEvent event, {
+    bool clearFormError = false,
   }) {
-    setState(() {
-      _selectedParticipantId =
-          previousIsCreating ? null : previousEditingParticipantId;
-    });
-    _requestTableFocus();
-  }
-
-  Future<void> _selectParticipant(Participant participant) async {
-    final previousEditingParticipantId = _editingParticipantId;
-    final previousIsCreating = _isCreating;
-
-    if (_isEditingParticipant(participant)) {
-      if (_selectedParticipantId != participant.id) {
-        setState(() {
-          _selectedParticipantId = participant.id;
-        });
-      }
-      _requestTableFocus();
+    final viewModel = widget.viewModel;
+    if (viewModel.isLoading || viewModel.isSaving) {
       return;
     }
 
-    if (_isEditing) {
-      final isSuccess = await _submitCurrentEditing(cancelEmptyCreate: true);
-      if (!mounted || !isSuccess) {
-        _restoreSelectionAfterFailedSubmit(
-          previousEditingParticipantId: previousEditingParticipantId,
-          previousIsCreating: previousIsCreating,
-        );
-        return;
-      }
-    }
+    final transition = _reducer.reduce(
+      state: _tableState,
+      event: event,
+      rows: _rows,
+    );
 
-    setState(() {
-      _selectedParticipantId = participant.id;
-    });
-    _requestTableFocus();
+    _setTableState(
+      transition.state,
+      clearFormError: clearFormError,
+    );
+
+    final submitRequest = transition.submitRequest;
+    if (submitRequest != null) {
+      unawaited(_submit(submitRequest));
+    }
+  }
+
+  Offset _toTableLocalPosition(Offset globalPosition) {
+    final renderObject = _tableAreaKey.currentContext?.findRenderObject();
+    if (renderObject is! RenderBox) {
+      return globalPosition;
+    }
+    return renderObject.globalToLocal(globalPosition);
   }
 
   void _handleParticipantTapDown(Participant participant) {
-    if (_selectedParticipantId == participant.id) {
-      _requestTableFocus();
+    if (_tableState.isEditing) {
       return;
     }
 
-    setState(() {
-      _selectedParticipantId = participant.id;
-    });
-    _requestTableFocus();
-  }
-
-  Future<void> _handleParticipantDoubleTap(Participant participant) async {
-    if (_isEditingParticipant(participant)) {
+    final tableState = _tableState;
+    if (tableState is ParticipantsTableSelectedDataRow &&
+        tableState.participantId == participant.id &&
+        !tableState.isContextMenuOpen) {
       return;
     }
 
-    if (_isEditing) {
-      final isSuccess = await _submitCurrentEditing(cancelEmptyCreate: true);
-      if (!mounted || !isSuccess) {
-        return;
-      }
-    }
-
-    _startEditingParticipant(participant);
-  }
-
-  Future<void> _handleAddRowTap() async {
-    if (_isCreating) {
-      return;
-    }
-
-    if (_isEditing) {
-      final isSuccess = await _submitCurrentEditing(cancelEmptyCreate: true);
-      if (!mounted || !isSuccess) {
-        return;
-      }
-    }
-
-    _startCreatingParticipant();
+    _setTableState(
+      ParticipantsTableSelectedDataRow(participantId: participant.id),
+    );
   }
 
   Future<void> _deleteParticipant(Participant participant) async {
@@ -350,175 +294,46 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
       return;
     }
 
-    if (isSuccess) {
-      final nextParticipants = widget.viewModel.participants;
-      final nextSelectionIndex = nextParticipants.isEmpty
-          ? null
-          : deletedIndex.clamp(0, nextParticipants.length - 1) as int;
-      final nextSelectedParticipantId = nextParticipants.isEmpty
-          ? null
-          : nextParticipants[nextSelectionIndex!].id;
-
-      setState(() {
-        if (_editingParticipantId == participant.id) {
-          _editingParticipantId = null;
-          _editingInitialName = null;
-          _isCreating = false;
-          _nameController.clear();
-          _editorFocusNode.unfocus();
-        }
-
-        if (_selectedParticipantId == participant.id) {
-          _selectedParticipantId = nextSelectedParticipantId;
-        }
-      });
-      _requestTableFocus();
+    if (!isSuccess) {
+      _showActionErrorIfNeeded();
       return;
     }
 
-    _showActionErrorIfNeeded();
-  }
-
-  Future<void> _showParticipantContextMenu(
-    Participant participant,
-    TapDownDetails details,
-  ) async {
-    final previousEditingParticipantId = _editingParticipantId;
-    final previousIsCreating = _isCreating;
-
-    if (_selectedParticipantId != participant.id) {
-      setState(() {
-        _selectedParticipantId = participant.id;
-      });
-    }
-    _requestTableFocus();
-
-    if (_isEditing && !_isEditingParticipant(participant)) {
-      final isSuccess = await _submitCurrentEditing(cancelEmptyCreate: true);
-      if (!mounted || !isSuccess) {
-        _restoreSelectionAfterFailedSubmit(
-          previousEditingParticipantId: previousEditingParticipantId,
-          previousIsCreating: previousIsCreating,
-        );
-        return;
-      }
-    }
-
-    if (!mounted) {
+    final nextParticipants = widget.viewModel.participants;
+    if (nextParticipants.isEmpty) {
+      _setTableState(const ParticipantsTableNoSelection());
       return;
     }
 
-    final overlay = Overlay.of(context).context.findRenderObject();
-    if (overlay is! RenderBox) {
-      return;
-    }
-
-    final menuAction = await showMenu<_ParticipantMenuAction>(
-      context: context,
-      position: RelativeRect.fromRect(
-        Rect.fromLTWH(
-          details.globalPosition.dx,
-          details.globalPosition.dy,
-          0,
-          0,
-        ),
-        Offset.zero & overlay.size,
+    final nextSelectionIndex =
+        deletedIndex.clamp(0, nextParticipants.length - 1);
+    _setTableState(
+      ParticipantsTableSelectedDataRow(
+        participantId: nextParticipants[nextSelectionIndex].id,
       ),
-      items: const [
-        PopupMenuItem<_ParticipantMenuAction>(
-          value: _ParticipantMenuAction.edit,
-          child: Text('Edit'),
-        ),
-        PopupMenuItem<_ParticipantMenuAction>(
-          value: _ParticipantMenuAction.delete,
-          child: Text('Delete'),
-        ),
-      ],
-      popUpAnimationStyle: AnimationStyle.noAnimation,
     );
-
-    if (!mounted || menuAction == null) {
-      return;
-    }
-
-    switch (menuAction) {
-      case _ParticipantMenuAction.edit:
-        _startEditingParticipant(participant);
-      case _ParticipantMenuAction.delete:
-        unawaited(_deleteParticipant(participant));
-    }
   }
 
-  void _moveSelection(int offset) {
-    final participants = widget.viewModel.participants;
-    if (participants.isEmpty) {
-      return;
-    }
-
-    final currentIndex = _selectedParticipantId == null
-        ? -1
-        : participants.indexWhere(
-            (participant) => participant.id == _selectedParticipantId,
-          );
-    final targetIndex = (currentIndex == -1
-        ? (offset > 0 ? 0 : participants.length - 1)
-        : (currentIndex + offset).clamp(0, participants.length - 1)) as int;
-
-    setState(() {
-      _selectedParticipantId = participants[targetIndex].id;
-    });
-    _requestTableFocus();
-  }
-
-  void _handleMoveSelectionShortcut(
-    ParticipantsViewModel viewModel,
-    int offset,
-  ) {
-    if (viewModel.isLoading || viewModel.isSaving || _isEditing) {
-      return;
-    }
-    _moveSelection(offset);
-  }
-
-  void _handleStartEditingShortcut(ParticipantsViewModel viewModel) {
-    if (viewModel.isLoading || viewModel.isSaving || _isEditing) {
-      return;
-    }
-
-    final selectedParticipantId = _selectedParticipantId;
-    if (selectedParticipantId == null) {
-      return;
-    }
-
-    final participant = _findParticipantById(selectedParticipantId);
-    if (participant == null) {
-      return;
-    }
-
-    _startEditingParticipant(participant);
-  }
-
-  bool _handleHardwareKeyEvent(KeyEvent event) {
-    if (!mounted || event is! KeyDownEvent || _editorFocusNode.hasFocus) {
-      return false;
-    }
-
-    final viewModel = widget.viewModel;
-    if (viewModel.isLoading || viewModel.isSaving || _isEditing) {
+  bool _handleTableKeyEvent(KeyEvent event) {
+    if (event is! KeyDownEvent || widget.viewModel.isSaving) {
       return false;
     }
 
     if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-      _moveSelection(1);
+      _dispatch(const ParticipantsTableEvent.pressArrowDown());
       return true;
     }
     if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-      _moveSelection(-1);
+      _dispatch(const ParticipantsTableEvent.pressArrowUp());
+      return true;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.escape) {
+      _dispatch(const ParticipantsTableEvent.pressEscape());
       return true;
     }
     if (_isEnterKey(event.logicalKey) ||
         event.logicalKey == LogicalKeyboardKey.f2) {
-      _handleStartEditingShortcut(viewModel);
+      _dispatch(const ParticipantsTableEvent.pressEnter());
       return true;
     }
 
@@ -541,28 +356,33 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
   }
 
   Widget _buildHeaderRow(BuildContext context, int count) {
-    return Container(
-      color: const Color(0xFFD7E8FB),
-      padding: const EdgeInsets.symmetric(vertical: 10),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          _buildIndicatorCell(
-            child: const SizedBox(key: _tableDividerKey),
-          ),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
-              child: Text(
-                'Участники ($count)',
-                style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.w700,
-                      color: const Color(0xFF123A63),
-                    ),
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => _dispatch(const ParticipantsTableEvent.clickOutside()),
+      child: Container(
+        color: const Color(0xFFD7E8FB),
+        padding: const EdgeInsets.symmetric(vertical: 10),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            _buildIndicatorCell(
+              child: const SizedBox(key: _tableDividerKey),
+            ),
+            Expanded(
+              child: Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+                child: Text(
+                  'Участники ($count)',
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: const Color(0xFF123A63),
+                      ),
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -604,13 +424,19 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
           return KeyEventResult.ignored;
         }
         if (event.logicalKey == LogicalKeyboardKey.escape) {
-          _cancelEditing();
+          _dispatch(const ParticipantsTableEvent.pressEscape());
           return KeyEventResult.handled;
         }
         if (_isEnterKey(event.logicalKey)) {
-          if (!viewModel.isSaving) {
-            unawaited(_submitCurrentEditing());
-          }
+          _dispatch(const ParticipantsTableEvent.pressEnter());
+          return KeyEventResult.handled;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+          _dispatch(const ParticipantsTableEvent.pressArrowUp());
+          return KeyEventResult.handled;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+          _dispatch(const ParticipantsTableEvent.pressArrowDown());
           return KeyEventResult.handled;
         }
         return KeyEventResult.ignored;
@@ -631,15 +457,12 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
           ),
         ),
         textInputAction: TextInputAction.done,
-        onChanged: (_) => viewModel.clearFormError(),
-        onTapOutside: viewModel.isSaving
-            ? null
-            : (_) => unawaited(
-                  _submitCurrentEditing(cancelEmptyCreate: true),
-                ),
-        onSubmitted: viewModel.isSaving
-            ? null
-            : (_) => unawaited(_submitCurrentEditing()),
+        onChanged: (value) => _dispatch(
+          ParticipantsTableEvent.textChanged(value),
+          clearFormError: true,
+        ),
+        onSubmitted: (_) =>
+            _dispatch(const ParticipantsTableEvent.pressEnter()),
       ),
     );
   }
@@ -665,14 +488,22 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
           : (_) => _handleParticipantTapDown(participant),
       onTap: viewModel.isSaving
           ? null
-          : () => unawaited(_selectParticipant(participant)),
+          : () => _dispatch(
+                ParticipantsTableEvent.clickDataRow(participant.id),
+              ),
       onDoubleTap: viewModel.isSaving
           ? null
-          : () => unawaited(_handleParticipantDoubleTap(participant)),
+          : () => _dispatch(
+                ParticipantsTableEvent.doubleClickDataRow(participant.id),
+                clearFormError: true,
+              ),
       onSecondaryTapDown: viewModel.isSaving
           ? null
-          : (details) => unawaited(
-                _showParticipantContextMenu(participant, details),
+          : (details) => _dispatch(
+                ParticipantsTableEvent.rightClickDataRow(
+                  participantId: participant.id,
+                  position: _toTableLocalPosition(details.globalPosition),
+                ),
               ),
       child: Container(
         decoration: const BoxDecoration(
@@ -714,14 +545,22 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
   }
 
   Widget _buildAddRow(BuildContext context, ParticipantsViewModel viewModel) {
-    final isEditing = _isCreating;
+    final isEditing = _tableState is ParticipantsTableEditNewRow;
     final backgroundColor =
         isEditing ? const Color(0xFFDDEAF8) : const Color(0xFFE8F0F6);
 
     return GestureDetector(
       key: const Key('participant_add_row'),
       behavior: HitTestBehavior.opaque,
-      onTap: viewModel.isSaving ? null : () => unawaited(_handleAddRowTap()),
+      onTap: viewModel.isSaving
+          ? null
+          : () => _dispatch(
+                const ParticipantsTableEvent.clickNewRow(),
+                clearFormError: true,
+              ),
+      onSecondaryTapDown: viewModel.isSaving
+          ? null
+          : (_) => _dispatch(const ParticipantsTableEvent.rightClickNewRow()),
       child: Container(
         decoration: const BoxDecoration(
           border: Border(
@@ -764,6 +603,113 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
     );
   }
 
+  Widget _buildContextMenu(Size size) {
+    final tableState = _tableState;
+    if (tableState is ParticipantsTableSelectedDataRow &&
+        tableState.contextMenuPosition != null) {
+      final participantId = tableState.participantId;
+      final contextMenuPosition = tableState.contextMenuPosition!;
+      final participant = _findParticipantById(participantId);
+      if (participant == null) {
+        return const SizedBox.shrink();
+      }
+
+      final left = math.min<double>(
+        math.max(contextMenuPosition.dx, 0),
+        math.max(size.width - _contextMenuWidth, 0),
+      );
+      final top = math.min<double>(
+        math.max(contextMenuPosition.dy, 0),
+        math.max(size.height - _contextMenuHeight, 0),
+      );
+
+      return Positioned(
+        left: left,
+        top: top,
+        child: Material(
+          elevation: 8,
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(8),
+          child: SizedBox(
+            width: _contextMenuWidth,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _ContextMenuButton(
+                  label: 'Edit',
+                  onTap: () {
+                    _setTableState(
+                      _reducer.resolveSubmitSuccess(
+                        target: ParticipantsTableSuccessTarget.editRow(
+                          participantId,
+                        ),
+                        rows: _rows,
+                      ),
+                      clearFormError: true,
+                    );
+                  },
+                ),
+                const Divider(height: 1),
+                _ContextMenuButton(
+                  label: 'Delete',
+                  onTap: () {
+                    _setTableState(
+                      ParticipantsTableSelectedDataRow(
+                        participantId: participantId,
+                      ),
+                    );
+                    unawaited(_deleteParticipant(participant));
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+
+  Widget _buildTableArea(
+    BuildContext context,
+    ParticipantsViewModel viewModel,
+  ) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return Stack(
+          key: _tableAreaKey,
+          children: [
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () =>
+                    _dispatch(const ParticipantsTableEvent.clickOutside()),
+                child: const DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: Color(0xFFF9FBFD),
+                  ),
+                ),
+              ),
+            ),
+            SingleChildScrollView(
+              padding: EdgeInsets.zero,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  for (final participant in viewModel.participants)
+                    _buildParticipantRow(context, viewModel, participant),
+                  _buildAddRow(context, viewModel),
+                ],
+              ),
+            ),
+            _buildContextMenu(constraints.biggest),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return AnimatedBuilder(
@@ -778,33 +724,29 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
           child: Focus(
             autofocus: true,
             focusNode: _tableFocusNode,
-            child: CallbackShortcuts(
-              bindings: <ShortcutActivator, VoidCallback>{
-                const SingleActivator(LogicalKeyboardKey.arrowDown): () =>
-                    _handleMoveSelectionShortcut(viewModel, 1),
-                const SingleActivator(LogicalKeyboardKey.arrowUp): () =>
-                    _handleMoveSelectionShortcut(viewModel, -1),
-                const SingleActivator(LogicalKeyboardKey.enter): () =>
-                    _handleStartEditingShortcut(viewModel),
-                const SingleActivator(LogicalKeyboardKey.f2): () =>
-                    _handleStartEditingShortcut(viewModel),
-              },
-              child: SizedBox(
-                width: 720,
-                height: 560,
-                child: Column(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.fromLTRB(20, 14, 8, 14),
-                      decoration: const BoxDecoration(
-                        color: Color(0xFFF4F7FA),
-                        border: Border(
-                          bottom: BorderSide(color: Color(0xFFD0D7DE)),
-                        ),
+            onKeyEvent: (node, event) => _handleTableKeyEvent(event)
+                ? KeyEventResult.handled
+                : KeyEventResult.ignored,
+            child: SizedBox(
+              width: 720,
+              height: 560,
+              child: Column(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.fromLTRB(20, 14, 8, 14),
+                    decoration: const BoxDecoration(
+                      color: Color(0xFFF4F7FA),
+                      border: Border(
+                        bottom: BorderSide(color: Color(0xFFD0D7DE)),
                       ),
-                      child: Row(
-                        children: [
-                          Expanded(
+                    ),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.opaque,
+                            onTap: () => _dispatch(
+                                const ParticipantsTableEvent.clickOutside()),
                             child: Text(
                               'Список участников',
                               style: Theme.of(context)
@@ -813,52 +755,40 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
                                   ?.copyWith(fontWeight: FontWeight.w700),
                             ),
                           ),
-                          IconButton(
-                            tooltip: 'Закрыть',
-                            onPressed: () => Navigator.of(context).pop(),
-                            icon: const Icon(Icons.close),
-                          ),
-                        ],
-                      ),
-                    ),
-                    Expanded(
-                      child: DecoratedBox(
-                        decoration: const BoxDecoration(
-                          color: Color(0xFFF9FBFD),
                         ),
-                        child: viewModel.isLoading
-                            ? const Center(child: CircularProgressIndicator())
-                            : viewModel.loadErrorMessage != null
-                                ? _ParticipantsLoadError(
-                                    message: viewModel.loadErrorMessage!,
-                                    onRetry: viewModel.loadParticipants,
-                                  )
-                                : Column(
-                                    children: [
-                                      _buildHeaderRow(
-                                        context,
-                                        viewModel.participants.length,
-                                      ),
-                                      Expanded(
-                                        child: ListView(
-                                          padding: EdgeInsets.zero,
-                                          children: [
-                                            for (final participant
-                                                in viewModel.participants)
-                                              _buildParticipantRow(
-                                                context,
-                                                viewModel,
-                                                participant,
-                                              ),
-                                            _buildAddRow(context, viewModel),
-                                          ],
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                      ),
+                        IconButton(
+                          tooltip: 'Закрыть',
+                          onPressed: () => Navigator.of(context).pop(),
+                          icon: const Icon(Icons.close),
+                        ),
+                      ],
                     ),
-                    Container(
+                  ),
+                  Expanded(
+                    child: viewModel.isLoading
+                        ? const Center(child: CircularProgressIndicator())
+                        : viewModel.loadErrorMessage != null
+                            ? _ParticipantsLoadError(
+                                message: viewModel.loadErrorMessage!,
+                                onRetry: viewModel.loadParticipants,
+                              )
+                            : Column(
+                                children: [
+                                  _buildHeaderRow(
+                                    context,
+                                    viewModel.participants.length,
+                                  ),
+                                  Expanded(
+                                    child: _buildTableArea(context, viewModel),
+                                  ),
+                                ],
+                              ),
+                  ),
+                  GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: () =>
+                        _dispatch(const ParticipantsTableEvent.clickOutside()),
+                    child: Container(
                       padding: const EdgeInsets.all(16),
                       decoration: const BoxDecoration(
                         color: Color(0xFFF4F7FA),
@@ -876,8 +806,8 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
                         ],
                       ),
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
             ),
           ),
@@ -887,9 +817,28 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
   }
 }
 
-enum _ParticipantMenuAction {
-  edit,
-  delete,
+class _ContextMenuButton extends StatelessWidget {
+  const _ContextMenuButton({
+    required this.label,
+    required this.onTap,
+  });
+
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        child: Align(
+          alignment: Alignment.centerLeft,
+          child: Text(label),
+        ),
+      ),
+    );
+  }
 }
 
 class _ParticipantsLoadError extends StatelessWidget {

--- a/packages/bochki_schedule_app/lib/src/features/participants/participants_table_state.dart
+++ b/packages/bochki_schedule_app/lib/src/features/participants/participants_table_state.dart
@@ -1,0 +1,902 @@
+import 'dart:ui';
+
+sealed class ParticipantsTableState {
+  const ParticipantsTableState();
+
+  String? get selectedParticipantId => null;
+  bool get isEditing => false;
+}
+
+final class ParticipantsTableNoSelection extends ParticipantsTableState {
+  const ParticipantsTableNoSelection();
+}
+
+final class ParticipantsTableSelectedDataRow extends ParticipantsTableState {
+  const ParticipantsTableSelectedDataRow({
+    required this.participantId,
+    this.contextMenuPosition,
+  });
+
+  final String participantId;
+  final Offset? contextMenuPosition;
+
+  bool get isContextMenuOpen => contextMenuPosition != null;
+
+  @override
+  String? get selectedParticipantId => participantId;
+}
+
+final class ParticipantsTableEditDataRow extends ParticipantsTableState {
+  const ParticipantsTableEditDataRow({
+    required this.participantId,
+    required this.initialValue,
+    required this.currentValue,
+  });
+
+  final String participantId;
+  final String initialValue;
+  final String currentValue;
+
+  bool get isDirty => currentValue != initialValue;
+
+  @override
+  bool get isEditing => true;
+
+  @override
+  String? get selectedParticipantId => participantId;
+
+  ParticipantsTableEditDataRow copyWith({
+    String? currentValue,
+  }) {
+    return ParticipantsTableEditDataRow(
+      participantId: participantId,
+      initialValue: initialValue,
+      currentValue: currentValue ?? this.currentValue,
+    );
+  }
+}
+
+final class ParticipantsTableEditNewRow extends ParticipantsTableState {
+  const ParticipantsTableEditNewRow({
+    required this.currentValue,
+  });
+
+  final String currentValue;
+
+  bool get isDirty => currentValue.isNotEmpty;
+
+  @override
+  bool get isEditing => true;
+}
+
+final class ParticipantsTableRowData {
+  const ParticipantsTableRowData({
+    required this.id,
+    required this.name,
+  });
+
+  final String id;
+  final String name;
+}
+
+sealed class ParticipantsTableEvent {
+  const ParticipantsTableEvent();
+
+  const factory ParticipantsTableEvent.clickDataRow(String participantId) =
+      ParticipantsTableClickDataRow;
+  const factory ParticipantsTableEvent.clickNewRow() =
+      ParticipantsTableClickNewRow;
+  const factory ParticipantsTableEvent.clickOutside() =
+      ParticipantsTableClickOutside;
+  const factory ParticipantsTableEvent.doubleClickDataRow(
+      String participantId) = ParticipantsTableDoubleClickDataRow;
+  const factory ParticipantsTableEvent.doubleClickNewRow() =
+      ParticipantsTableDoubleClickNewRow;
+  const factory ParticipantsTableEvent.rightClickDataRow({
+    required String participantId,
+    required Offset position,
+  }) = ParticipantsTableRightClickDataRow;
+  const factory ParticipantsTableEvent.rightClickNewRow() =
+      ParticipantsTableRightClickNewRow;
+  const factory ParticipantsTableEvent.pressEnter() =
+      ParticipantsTablePressEnter;
+  const factory ParticipantsTableEvent.pressEscape() =
+      ParticipantsTablePressEscape;
+  const factory ParticipantsTableEvent.pressArrowUp() =
+      ParticipantsTablePressArrowUp;
+  const factory ParticipantsTableEvent.pressArrowDown() =
+      ParticipantsTablePressArrowDown;
+  const factory ParticipantsTableEvent.textChanged(String value) =
+      ParticipantsTableTextChanged;
+}
+
+final class ParticipantsTableClickDataRow extends ParticipantsTableEvent {
+  const ParticipantsTableClickDataRow(this.participantId);
+
+  final String participantId;
+}
+
+final class ParticipantsTableClickNewRow extends ParticipantsTableEvent {
+  const ParticipantsTableClickNewRow();
+}
+
+final class ParticipantsTableClickOutside extends ParticipantsTableEvent {
+  const ParticipantsTableClickOutside();
+}
+
+final class ParticipantsTableDoubleClickDataRow extends ParticipantsTableEvent {
+  const ParticipantsTableDoubleClickDataRow(this.participantId);
+
+  final String participantId;
+}
+
+final class ParticipantsTableDoubleClickNewRow extends ParticipantsTableEvent {
+  const ParticipantsTableDoubleClickNewRow();
+}
+
+final class ParticipantsTableRightClickDataRow extends ParticipantsTableEvent {
+  const ParticipantsTableRightClickDataRow({
+    required this.participantId,
+    required this.position,
+  });
+
+  final String participantId;
+  final Offset position;
+}
+
+final class ParticipantsTableRightClickNewRow extends ParticipantsTableEvent {
+  const ParticipantsTableRightClickNewRow();
+}
+
+final class ParticipantsTablePressEnter extends ParticipantsTableEvent {
+  const ParticipantsTablePressEnter();
+}
+
+final class ParticipantsTablePressEscape extends ParticipantsTableEvent {
+  const ParticipantsTablePressEscape();
+}
+
+final class ParticipantsTablePressArrowUp extends ParticipantsTableEvent {
+  const ParticipantsTablePressArrowUp();
+}
+
+final class ParticipantsTablePressArrowDown extends ParticipantsTableEvent {
+  const ParticipantsTablePressArrowDown();
+}
+
+final class ParticipantsTableTextChanged extends ParticipantsTableEvent {
+  const ParticipantsTableTextChanged(this.value);
+
+  final String value;
+}
+
+final class ParticipantsTableTransition {
+  const ParticipantsTableTransition({
+    required this.state,
+    this.submitRequest,
+  });
+
+  final ParticipantsTableState state;
+  final ParticipantsTableSubmitRequest? submitRequest;
+}
+
+enum ParticipantsTableSubmitMode {
+  create,
+  update,
+}
+
+sealed class ParticipantsTableSuccessTarget {
+  const ParticipantsTableSuccessTarget();
+
+  const factory ParticipantsTableSuccessTarget.noSelection() =
+      ParticipantsTableSuccessNoSelection;
+  const factory ParticipantsTableSuccessTarget.selectRow(String participantId) =
+      ParticipantsTableSuccessSelectRow;
+  const factory ParticipantsTableSuccessTarget.editRow(String participantId) =
+      ParticipantsTableSuccessEditRow;
+  const factory ParticipantsTableSuccessTarget.editNewRow() =
+      ParticipantsTableSuccessEditNewRow;
+  const factory ParticipantsTableSuccessTarget.selectCreatedRow() =
+      ParticipantsTableSuccessSelectCreatedRow;
+}
+
+final class ParticipantsTableSuccessNoSelection
+    extends ParticipantsTableSuccessTarget {
+  const ParticipantsTableSuccessNoSelection();
+}
+
+final class ParticipantsTableSuccessSelectRow
+    extends ParticipantsTableSuccessTarget {
+  const ParticipantsTableSuccessSelectRow(this.participantId);
+
+  final String participantId;
+}
+
+final class ParticipantsTableSuccessEditRow
+    extends ParticipantsTableSuccessTarget {
+  const ParticipantsTableSuccessEditRow(this.participantId);
+
+  final String participantId;
+}
+
+final class ParticipantsTableSuccessEditNewRow
+    extends ParticipantsTableSuccessTarget {
+  const ParticipantsTableSuccessEditNewRow();
+}
+
+final class ParticipantsTableSuccessSelectCreatedRow
+    extends ParticipantsTableSuccessTarget {
+  const ParticipantsTableSuccessSelectCreatedRow();
+}
+
+final class ParticipantsTableSubmitRequest {
+  const ParticipantsTableSubmitRequest({
+    required this.mode,
+    required this.rawValue,
+    required this.successTarget,
+    this.participantId,
+  });
+
+  final ParticipantsTableSubmitMode mode;
+  final String rawValue;
+  final String? participantId;
+  final ParticipantsTableSuccessTarget successTarget;
+}
+
+final class ParticipantsTableReducer {
+  const ParticipantsTableReducer();
+
+  ParticipantsTableTransition reduce({
+    required ParticipantsTableState state,
+    required ParticipantsTableEvent event,
+    required List<ParticipantsTableRowData> rows,
+  }) {
+    return switch (event) {
+      ParticipantsTableClickDataRow(:final participantId) => _onClickDataRow(
+          state: state,
+          targetParticipantId: participantId,
+        ),
+      ParticipantsTableClickNewRow() => _onClickNewRow(state),
+      ParticipantsTableClickOutside() => _onClickOutside(state),
+      ParticipantsTableDoubleClickDataRow(:final participantId) =>
+        _onDoubleClickDataRow(
+          state: state,
+          targetParticipantId: participantId,
+          rows: rows,
+        ),
+      ParticipantsTableDoubleClickNewRow() => _onDoubleClickNewRow(state),
+      ParticipantsTableRightClickDataRow(
+        :final participantId,
+        :final position,
+      ) =>
+        _onRightClickDataRow(
+          state: state,
+          targetParticipantId: participantId,
+          position: position,
+        ),
+      ParticipantsTableRightClickNewRow() => _onRightClickNewRow(state),
+      ParticipantsTablePressEnter() => _onPressEnter(
+          state: state,
+          rows: rows,
+        ),
+      ParticipantsTablePressEscape() => _onPressEscape(state),
+      ParticipantsTablePressArrowUp() => _onPressArrow(
+          state: state,
+          rows: rows,
+          offset: -1,
+        ),
+      ParticipantsTablePressArrowDown() => _onPressArrow(
+          state: state,
+          rows: rows,
+          offset: 1,
+        ),
+      ParticipantsTableTextChanged(:final value) => _onTextChanged(
+          state: state,
+          value: value,
+        ),
+    };
+  }
+
+  ParticipantsTableState resolveSubmitSuccess({
+    required ParticipantsTableSuccessTarget target,
+    required List<ParticipantsTableRowData> rows,
+    String? createdParticipantId,
+  }) {
+    return switch (target) {
+      ParticipantsTableSuccessNoSelection() =>
+        const ParticipantsTableNoSelection(),
+      ParticipantsTableSuccessSelectRow(:final participantId) =>
+        ParticipantsTableSelectedDataRow(participantId: participantId),
+      ParticipantsTableSuccessEditRow(:final participantId) =>
+        _editStateForRow(rows, participantId) ??
+            const ParticipantsTableNoSelection(),
+      ParticipantsTableSuccessEditNewRow() =>
+        const ParticipantsTableEditNewRow(currentValue: ''),
+      ParticipantsTableSuccessSelectCreatedRow() => createdParticipantId == null
+          ? const ParticipantsTableNoSelection()
+          : ParticipantsTableSelectedDataRow(
+              participantId: createdParticipantId),
+    };
+  }
+
+  ParticipantsTableEditDataRow? _editStateForRow(
+    List<ParticipantsTableRowData> rows,
+    String participantId,
+  ) {
+    for (final row in rows) {
+      if (row.id == participantId) {
+        return ParticipantsTableEditDataRow(
+          participantId: participantId,
+          initialValue: row.name,
+          currentValue: row.name,
+        );
+      }
+    }
+    return null;
+  }
+
+  ParticipantsTableTransition _onClickDataRow({
+    required ParticipantsTableState state,
+    required String targetParticipantId,
+  }) {
+    return switch (state) {
+      ParticipantsTableNoSelection() => ParticipantsTableTransition(
+          state: ParticipantsTableSelectedDataRow(
+            participantId: targetParticipantId,
+          ),
+        ),
+      ParticipantsTableSelectedDataRow() => ParticipantsTableTransition(
+          state: ParticipantsTableSelectedDataRow(
+            participantId: targetParticipantId,
+          ),
+        ),
+      ParticipantsTableEditDataRow(
+        :final participantId,
+        :final currentValue,
+        :final isDirty,
+      ) =>
+        isDirty
+            ? ParticipantsTableTransition(
+                state: state,
+                submitRequest: ParticipantsTableSubmitRequest(
+                  mode: ParticipantsTableSubmitMode.update,
+                  participantId: participantId,
+                  rawValue: currentValue,
+                  successTarget: ParticipantsTableSuccessTarget.selectRow(
+                    targetParticipantId,
+                  ),
+                ),
+              )
+            : ParticipantsTableTransition(
+                state: ParticipantsTableSelectedDataRow(
+                  participantId: targetParticipantId,
+                ),
+              ),
+      ParticipantsTableEditNewRow(:final currentValue, :final isDirty) =>
+        isDirty
+            ? ParticipantsTableTransition(
+                state: state,
+                submitRequest: ParticipantsTableSubmitRequest(
+                  mode: ParticipantsTableSubmitMode.create,
+                  rawValue: currentValue,
+                  successTarget: ParticipantsTableSuccessTarget.selectRow(
+                    targetParticipantId,
+                  ),
+                ),
+              )
+            : ParticipantsTableTransition(
+                state: ParticipantsTableSelectedDataRow(
+                  participantId: targetParticipantId,
+                ),
+              ),
+    };
+  }
+
+  ParticipantsTableTransition _onClickNewRow(ParticipantsTableState state) {
+    return switch (state) {
+      ParticipantsTableNoSelection() ||
+      ParticipantsTableSelectedDataRow() =>
+        const ParticipantsTableTransition(
+          state: ParticipantsTableEditNewRow(currentValue: ''),
+        ),
+      ParticipantsTableEditDataRow(
+        :final participantId,
+        :final currentValue,
+        :final isDirty,
+      ) =>
+        isDirty
+            ? ParticipantsTableTransition(
+                state: state,
+                submitRequest: ParticipantsTableSubmitRequest(
+                  mode: ParticipantsTableSubmitMode.update,
+                  participantId: participantId,
+                  rawValue: currentValue,
+                  successTarget:
+                      const ParticipantsTableSuccessTarget.editNewRow(),
+                ),
+              )
+            : const ParticipantsTableTransition(
+                state: ParticipantsTableEditNewRow(currentValue: ''),
+              ),
+      ParticipantsTableEditNewRow() =>
+        ParticipantsTableTransition(state: state),
+    };
+  }
+
+  ParticipantsTableTransition _onClickOutside(ParticipantsTableState state) {
+    return switch (state) {
+      ParticipantsTableNoSelection() => const ParticipantsTableTransition(
+          state: ParticipantsTableNoSelection(),
+        ),
+      ParticipantsTableSelectedDataRow() => const ParticipantsTableTransition(
+          state: ParticipantsTableNoSelection(),
+        ),
+      ParticipantsTableEditDataRow(
+        :final participantId,
+        :final currentValue,
+        :final isDirty,
+      ) =>
+        isDirty
+            ? ParticipantsTableTransition(
+                state: state,
+                submitRequest: ParticipantsTableSubmitRequest(
+                  mode: ParticipantsTableSubmitMode.update,
+                  participantId: participantId,
+                  rawValue: currentValue,
+                  successTarget:
+                      const ParticipantsTableSuccessTarget.noSelection(),
+                ),
+              )
+            : const ParticipantsTableTransition(
+                state: ParticipantsTableNoSelection(),
+              ),
+      ParticipantsTableEditNewRow(:final currentValue, :final isDirty) =>
+        isDirty
+            ? ParticipantsTableTransition(
+                state: state,
+                submitRequest: ParticipantsTableSubmitRequest(
+                  mode: ParticipantsTableSubmitMode.create,
+                  rawValue: currentValue,
+                  successTarget:
+                      const ParticipantsTableSuccessTarget.noSelection(),
+                ),
+              )
+            : const ParticipantsTableTransition(
+                state: ParticipantsTableNoSelection(),
+              ),
+    };
+  }
+
+  ParticipantsTableTransition _onDoubleClickDataRow({
+    required ParticipantsTableState state,
+    required String targetParticipantId,
+    required List<ParticipantsTableRowData> rows,
+  }) {
+    final targetEditState = _editStateForRow(rows, targetParticipantId);
+    if (targetEditState == null) {
+      return ParticipantsTableTransition(state: state);
+    }
+
+    return switch (state) {
+      ParticipantsTableEditDataRow(
+        :final participantId,
+        :final currentValue,
+        :final isDirty,
+      ) =>
+        isDirty
+            ? ParticipantsTableTransition(
+                state: state,
+                submitRequest: ParticipantsTableSubmitRequest(
+                  mode: ParticipantsTableSubmitMode.update,
+                  participantId: participantId,
+                  rawValue: currentValue,
+                  successTarget: ParticipantsTableSuccessTarget.editRow(
+                    targetParticipantId,
+                  ),
+                ),
+              )
+            : ParticipantsTableTransition(state: targetEditState),
+      ParticipantsTableEditNewRow(:final currentValue, :final isDirty) =>
+        isDirty
+            ? ParticipantsTableTransition(
+                state: state,
+                submitRequest: ParticipantsTableSubmitRequest(
+                  mode: ParticipantsTableSubmitMode.create,
+                  rawValue: currentValue,
+                  successTarget: ParticipantsTableSuccessTarget.editRow(
+                    targetParticipantId,
+                  ),
+                ),
+              )
+            : ParticipantsTableTransition(state: targetEditState),
+      _ => ParticipantsTableTransition(state: targetEditState),
+    };
+  }
+
+  ParticipantsTableTransition _onDoubleClickNewRow(
+      ParticipantsTableState state) {
+    return switch (state) {
+      ParticipantsTableEditDataRow(
+        :final participantId,
+        :final currentValue,
+        :final isDirty,
+      ) =>
+        isDirty
+            ? ParticipantsTableTransition(
+                state: state,
+                submitRequest: ParticipantsTableSubmitRequest(
+                  mode: ParticipantsTableSubmitMode.update,
+                  participantId: participantId,
+                  rawValue: currentValue,
+                  successTarget:
+                      const ParticipantsTableSuccessTarget.editNewRow(),
+                ),
+              )
+            : const ParticipantsTableTransition(
+                state: ParticipantsTableEditNewRow(currentValue: ''),
+              ),
+      ParticipantsTableEditNewRow() =>
+        ParticipantsTableTransition(state: state),
+      _ => const ParticipantsTableTransition(
+          state: ParticipantsTableEditNewRow(currentValue: ''),
+        ),
+    };
+  }
+
+  ParticipantsTableTransition _onRightClickDataRow({
+    required ParticipantsTableState state,
+    required String targetParticipantId,
+    required Offset position,
+  }) {
+    return switch (state) {
+      ParticipantsTableNoSelection() ||
+      ParticipantsTableSelectedDataRow() =>
+        ParticipantsTableTransition(
+          state: ParticipantsTableSelectedDataRow(
+            participantId: targetParticipantId,
+            contextMenuPosition: position,
+          ),
+        ),
+      ParticipantsTableEditDataRow(
+        :final participantId,
+        :final currentValue,
+        :final isDirty,
+      ) =>
+        isDirty
+            ? ParticipantsTableTransition(
+                state: state,
+                submitRequest: ParticipantsTableSubmitRequest(
+                  mode: ParticipantsTableSubmitMode.update,
+                  participantId: participantId,
+                  rawValue: currentValue,
+                  successTarget: ParticipantsTableSuccessTarget.selectRow(
+                    targetParticipantId,
+                  ),
+                ),
+              )
+            : ParticipantsTableTransition(
+                state: ParticipantsTableSelectedDataRow(
+                  participantId: targetParticipantId,
+                ),
+              ),
+      ParticipantsTableEditNewRow(:final currentValue, :final isDirty) =>
+        isDirty
+            ? ParticipantsTableTransition(
+                state: state,
+                submitRequest: ParticipantsTableSubmitRequest(
+                  mode: ParticipantsTableSubmitMode.create,
+                  rawValue: currentValue,
+                  successTarget: ParticipantsTableSuccessTarget.selectRow(
+                    targetParticipantId,
+                  ),
+                ),
+              )
+            : ParticipantsTableTransition(
+                state: ParticipantsTableSelectedDataRow(
+                  participantId: targetParticipantId,
+                ),
+              ),
+    };
+  }
+
+  ParticipantsTableTransition _onRightClickNewRow(
+      ParticipantsTableState state) {
+    if (state is ParticipantsTableSelectedDataRow) {
+      return ParticipantsTableTransition(
+        state: state.isContextMenuOpen
+            ? ParticipantsTableSelectedDataRow(
+                participantId: state.participantId)
+            : state,
+      );
+    }
+    if (state is ParticipantsTableNoSelection) {
+      return const ParticipantsTableTransition(
+        state: ParticipantsTableNoSelection(),
+      );
+    }
+    if (state is ParticipantsTableEditDataRow) {
+      if (state.isDirty) {
+        return ParticipantsTableTransition(
+          state: state,
+          submitRequest: ParticipantsTableSubmitRequest(
+            mode: ParticipantsTableSubmitMode.update,
+            participantId: state.participantId,
+            rawValue: state.currentValue,
+            successTarget: ParticipantsTableSuccessTarget.selectRow(
+              state.participantId,
+            ),
+          ),
+        );
+      }
+      return ParticipantsTableTransition(
+        state: ParticipantsTableSelectedDataRow(
+          participantId: state.participantId,
+        ),
+      );
+    }
+    return ParticipantsTableTransition(state: state);
+  }
+
+  ParticipantsTableTransition _onPressEnter({
+    required ParticipantsTableState state,
+    required List<ParticipantsTableRowData> rows,
+  }) {
+    return switch (state) {
+      ParticipantsTableNoSelection() => const ParticipantsTableTransition(
+          state: ParticipantsTableNoSelection(),
+        ),
+      ParticipantsTableSelectedDataRow(
+        :final participantId,
+        :final isContextMenuOpen,
+      ) =>
+        ParticipantsTableTransition(
+          state: isContextMenuOpen
+              ? ParticipantsTableSelectedDataRow(participantId: participantId)
+              : _editStateForRow(rows, participantId) ??
+                  ParticipantsTableSelectedDataRow(
+                      participantId: participantId),
+        ),
+      ParticipantsTableEditDataRow(
+        :final participantId,
+        :final currentValue,
+        :final isDirty,
+      ) =>
+        isDirty
+            ? ParticipantsTableTransition(
+                state: state,
+                submitRequest: ParticipantsTableSubmitRequest(
+                  mode: ParticipantsTableSubmitMode.update,
+                  participantId: participantId,
+                  rawValue: currentValue,
+                  successTarget: ParticipantsTableSuccessTarget.selectRow(
+                    participantId,
+                  ),
+                ),
+              )
+            : ParticipantsTableTransition(
+                state: ParticipantsTableSelectedDataRow(
+                    participantId: participantId),
+              ),
+      ParticipantsTableEditNewRow(:final currentValue, :final isDirty) =>
+        isDirty
+            ? ParticipantsTableTransition(
+                state: state,
+                submitRequest: ParticipantsTableSubmitRequest(
+                  mode: ParticipantsTableSubmitMode.create,
+                  rawValue: currentValue,
+                  successTarget:
+                      const ParticipantsTableSuccessTarget.selectCreatedRow(),
+                ),
+              )
+            : const ParticipantsTableTransition(
+                state: ParticipantsTableNoSelection(),
+              ),
+    };
+  }
+
+  ParticipantsTableTransition _onPressEscape(ParticipantsTableState state) {
+    return switch (state) {
+      ParticipantsTableNoSelection() => const ParticipantsTableTransition(
+          state: ParticipantsTableNoSelection(),
+        ),
+      ParticipantsTableSelectedDataRow(
+        :final participantId,
+        :final isContextMenuOpen,
+      ) =>
+        ParticipantsTableTransition(
+          state: isContextMenuOpen
+              ? ParticipantsTableSelectedDataRow(participantId: participantId)
+              : const ParticipantsTableNoSelection(),
+        ),
+      ParticipantsTableEditDataRow(:final participantId) =>
+        ParticipantsTableTransition(
+          state: ParticipantsTableSelectedDataRow(participantId: participantId),
+        ),
+      ParticipantsTableEditNewRow() => const ParticipantsTableTransition(
+          state: ParticipantsTableNoSelection(),
+        ),
+    };
+  }
+
+  ParticipantsTableTransition _onPressArrow({
+    required ParticipantsTableState state,
+    required List<ParticipantsTableRowData> rows,
+    required int offset,
+  }) {
+    return switch (state) {
+      ParticipantsTableNoSelection() => _selectEdgeRow(rows, offset),
+      ParticipantsTableSelectedDataRow(
+        :final participantId,
+        :final isContextMenuOpen,
+      ) =>
+        isContextMenuOpen
+            ? ParticipantsTableTransition(state: state)
+            : _moveSelectedRow(
+                rows: rows,
+                participantId: participantId,
+                offset: offset,
+              ),
+      ParticipantsTableEditDataRow(
+        :final participantId,
+        :final currentValue,
+        :final isDirty,
+      ) =>
+        _moveEditRow(
+          rows: rows,
+          participantId: participantId,
+          currentValue: currentValue,
+          isDirty: isDirty,
+          offset: offset,
+        ),
+      ParticipantsTableEditNewRow(:final currentValue, :final isDirty) =>
+        _moveFromNewRow(
+          rows: rows,
+          currentValue: currentValue,
+          isDirty: isDirty,
+          offset: offset,
+        ),
+    };
+  }
+
+  ParticipantsTableTransition _onTextChanged({
+    required ParticipantsTableState state,
+    required String value,
+  }) {
+    return switch (state) {
+      ParticipantsTableEditDataRow(:final participantId, :final initialValue) =>
+        ParticipantsTableTransition(
+          state: ParticipantsTableEditDataRow(
+            participantId: participantId,
+            initialValue: initialValue,
+            currentValue: value,
+          ),
+        ),
+      ParticipantsTableEditNewRow() => ParticipantsTableTransition(
+          state: ParticipantsTableEditNewRow(currentValue: value),
+        ),
+      _ => ParticipantsTableTransition(state: state),
+    };
+  }
+
+  ParticipantsTableTransition _selectEdgeRow(
+    List<ParticipantsTableRowData> rows,
+    int offset,
+  ) {
+    if (rows.isEmpty) {
+      return const ParticipantsTableTransition(
+        state: ParticipantsTableNoSelection(),
+      );
+    }
+
+    return ParticipantsTableTransition(
+      state: ParticipantsTableSelectedDataRow(
+        participantId: offset > 0 ? rows.first.id : rows.last.id,
+      ),
+    );
+  }
+
+  ParticipantsTableTransition _moveSelectedRow({
+    required List<ParticipantsTableRowData> rows,
+    required String participantId,
+    required int offset,
+  }) {
+    final currentIndex = rows.indexWhere((row) => row.id == participantId);
+    if (currentIndex == -1) {
+      return const ParticipantsTableTransition(
+        state: ParticipantsTableNoSelection(),
+      );
+    }
+
+    final targetIndex = currentIndex + offset;
+    if (targetIndex < 0 || targetIndex >= rows.length) {
+      return ParticipantsTableTransition(
+        state: ParticipantsTableSelectedDataRow(participantId: participantId),
+      );
+    }
+
+    return ParticipantsTableTransition(
+      state: ParticipantsTableSelectedDataRow(
+        participantId: rows[targetIndex].id,
+      ),
+    );
+  }
+
+  ParticipantsTableTransition _moveEditRow({
+    required List<ParticipantsTableRowData> rows,
+    required String participantId,
+    required String currentValue,
+    required bool isDirty,
+    required int offset,
+  }) {
+    final currentIndex = rows.indexWhere((row) => row.id == participantId);
+    if (currentIndex == -1) {
+      return const ParticipantsTableTransition(
+        state: ParticipantsTableNoSelection(),
+      );
+    }
+
+    final targetIndex = currentIndex + offset;
+    if (targetIndex < 0 || targetIndex >= rows.length) {
+      return ParticipantsTableTransition(
+        state: _editStateForRow(rows, participantId) ??
+            const ParticipantsTableNoSelection(),
+      );
+    }
+
+    final targetParticipantId = rows[targetIndex].id;
+    if (!isDirty) {
+      return ParticipantsTableTransition(
+        state: _editStateForRow(rows, targetParticipantId) ??
+            const ParticipantsTableNoSelection(),
+      );
+    }
+
+    return ParticipantsTableTransition(
+      state: ParticipantsTableEditDataRow(
+        participantId: participantId,
+        initialValue: _editStateForRow(rows, participantId)!.initialValue,
+        currentValue: currentValue,
+      ),
+      submitRequest: ParticipantsTableSubmitRequest(
+        mode: ParticipantsTableSubmitMode.update,
+        participantId: participantId,
+        rawValue: currentValue,
+        successTarget: ParticipantsTableSuccessTarget.editRow(
+          targetParticipantId,
+        ),
+      ),
+    );
+  }
+
+  ParticipantsTableTransition _moveFromNewRow({
+    required List<ParticipantsTableRowData> rows,
+    required String currentValue,
+    required bool isDirty,
+    required int offset,
+  }) {
+    if (offset > 0 || rows.isEmpty) {
+      return ParticipantsTableTransition(
+        state: ParticipantsTableEditNewRow(currentValue: currentValue),
+      );
+    }
+
+    final targetParticipantId = rows.last.id;
+    if (!isDirty) {
+      return ParticipantsTableTransition(
+        state: _editStateForRow(rows, targetParticipantId) ??
+            const ParticipantsTableNoSelection(),
+      );
+    }
+
+    return ParticipantsTableTransition(
+      state: ParticipantsTableEditNewRow(currentValue: currentValue),
+      submitRequest: ParticipantsTableSubmitRequest(
+        mode: ParticipantsTableSubmitMode.create,
+        rawValue: currentValue,
+        successTarget: ParticipantsTableSuccessTarget.editRow(
+          targetParticipantId,
+        ),
+      ),
+    );
+  }
+}

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -28,11 +28,7 @@ void main() {
 
     await tester.pumpWidget(BochkiScheduleApp(services: context.services));
     await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key('directories_menu_button')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Участники').last);
-    await tester.pumpAndSettle();
+    await _openParticipantsDialog(tester);
 
     expect(
       find.byKey(const Key('participants_directory_dialog')),
@@ -45,18 +41,14 @@ void main() {
     expect(find.text('Ok'), findsOneWidget);
   });
 
-  testWidgets('participants dialog supports inline add edit and delete', (
+  testWidgets('participants dialog supports create edit and delete', (
     tester,
   ) async {
     final context = _buildTestContext();
 
     await tester.pumpWidget(BochkiScheduleApp(services: context.services));
     await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key('directories_menu_button')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('Участники').last);
-    await tester.pumpAndSettle();
+    await _openParticipantsDialog(tester);
 
     await tester.tap(find.byKey(const Key('participant_add_row')));
     await tester.pumpAndSettle();
@@ -71,7 +63,6 @@ void main() {
 
     expect(find.text('Иван Иванов'), findsOneWidget);
     expect(context.repository.participants.single.name, 'Иван Иванов');
-    expect(find.text('Участники (1)'), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('participant_add_row')));
     await tester.pumpAndSettle();
@@ -82,46 +73,30 @@ void main() {
     await tester.tap(find.text('Участники (1)'));
     await tester.pumpAndSettle();
 
-    expect(
-      context.repository.participants.map((participant) => participant.name),
-      ['Иван Иванов', 'Борис'],
-    );
-
     final firstRow = find.byKey(const Key('participant_row_1'));
-    await _mouseClick(tester, firstRow);
-    await tester.pump(const Duration(milliseconds: 50));
-    await _mouseClick(tester, firstRow);
-    await tester.pumpAndSettle();
+    await _doubleMouseClick(tester, firstRow);
     await tester.enterText(
       find.byKey(const Key('participant_name_field')),
       'Иван Петров',
     );
-
     await _mouseClick(tester, find.byKey(const Key('participant_row_2')));
     await tester.pumpAndSettle();
 
     expect(find.text('Иван Петров'), findsOneWidget);
-    expect(find.text('Иван Иванов'), findsNothing);
     expect(context.repository.participants.first.name, 'Иван Петров');
 
-    final borisRow = find.byKey(const Key('participant_row_2'));
-    await _mouseClick(
-      tester,
-      borisRow,
-      buttons: kSecondaryMouseButton,
-    );
+    final secondRow = find.byKey(const Key('participant_row_2'));
+    await _mouseClick(tester, secondRow, buttons: kSecondaryMouseButton);
     await tester.pumpAndSettle();
-
     await tester.tap(find.text('Delete'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Удалить').last);
     await tester.pumpAndSettle();
 
     expect(
-        context.repository.participants.map((participant) => participant.name),
-        [
-          'Иван Петров',
-        ]);
+      context.repository.participants.map((participant) => participant.name),
+      ['Иван Петров'],
+    );
     expect(find.text('Участники (1)'), findsOneWidget);
   });
 
@@ -139,15 +114,14 @@ void main() {
     await _openParticipantsDialog(tester);
 
     final row = find.byKey(const Key('participant_row_1'));
-    await tester.tap(row);
+    await _mouseClick(tester, row);
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('participant_name_field')), findsNothing);
   });
 
-  testWidgets('enter commits inline edit and keeps row selected', (
-    tester,
-  ) async {
+  testWidgets('enter commits edited row after inline edit starts',
+      (tester) async {
     final context = _buildTestContext(
       participants: [
         Participant(id: '1', name: 'Анна'),
@@ -159,10 +133,7 @@ void main() {
     await _openParticipantsDialog(tester);
 
     final row = find.byKey(const Key('participant_row_1'));
-    await _mouseClick(tester, row);
-    await tester.pump(const Duration(milliseconds: 50));
-    await _mouseClick(tester, row);
-    await tester.pumpAndSettle();
+    await _doubleMouseClick(tester, row);
 
     await tester.enterText(
       find.byKey(const Key('participant_name_field')),
@@ -174,7 +145,7 @@ void main() {
     expect(find.byKey(const Key('participant_name_field')), findsNothing);
     expect(find.text('Анна Петрова'), findsOneWidget);
     expect(context.repository.participants.single.name, 'Анна Петрова');
-    expect(find.text('▶'), findsOneWidget);
+    expect(find.descendant(of: row, matching: find.text('▶')), findsOneWidget);
   });
 
   testWidgets('empty add row is cancelled on click outside', (tester) async {
@@ -197,9 +168,7 @@ void main() {
     expect(find.text('Введите имя участника.'), findsNothing);
   });
 
-  testWidgets('double click opens inline edit for row', (
-    tester,
-  ) async {
+  testWidgets('double click opens inline edit for row', (tester) async {
     final context = _buildTestContext(
       participants: [
         Participant(id: '1', name: 'Анна'),
@@ -210,17 +179,42 @@ void main() {
     await tester.pumpAndSettle();
     await _openParticipantsDialog(tester);
 
-    final row = find.byKey(const Key('participant_row_1'));
-    await _mouseClick(tester, row);
-    await tester.pump(const Duration(milliseconds: 50));
-    await _mouseClick(tester, row);
-    await tester.pumpAndSettle();
+    await _doubleMouseClick(
+      tester,
+      find.byKey(const Key('participant_row_1')),
+    );
 
     expect(find.byKey(const Key('participant_name_field')), findsOneWidget);
   });
 
-  testWidgets('row becomes selected on mouse down while another row is editing',
-      (
+  testWidgets('escape rolls back dirty existing row', (tester) async {
+    final context = _buildTestContext(
+      participants: [
+        Participant(id: '1', name: 'Анна'),
+      ],
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await _openParticipantsDialog(tester);
+
+    await _doubleMouseClick(
+      tester,
+      find.byKey(const Key('participant_row_1')),
+    );
+    await tester.enterText(
+      find.byKey(const Key('participant_name_field')),
+      'Анна Петрова',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('participant_name_field')), findsNothing);
+    expect(find.text('Анна'), findsOneWidget);
+    expect(context.repository.participants.single.name, 'Анна');
+  });
+
+  testWidgets('arrow navigation selects edge rows from no selection', (
     tester,
   ) async {
     final context = _buildTestContext(
@@ -234,32 +228,24 @@ void main() {
     await tester.pumpAndSettle();
     await _openParticipantsDialog(tester);
 
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+
     final firstRow = find.byKey(const Key('participant_row_1'));
-    await _mouseClick(tester, firstRow);
-    await tester.pump(const Duration(milliseconds: 50));
-    await _mouseClick(tester, firstRow);
+    expect(find.descendant(of: firstRow, matching: find.text('▶')),
+        findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
 
     final secondRow = find.byKey(const Key('participant_row_2'));
-    final gesture = await tester.createGesture(
-      kind: PointerDeviceKind.mouse,
-      buttons: kPrimaryMouseButton,
-    );
-    final center = tester.getCenter(secondRow);
-    await gesture.addPointer(location: center);
-    await gesture.moveTo(center);
-    await tester.pump();
-    await gesture.down(center);
-    await tester.pump();
-
-    expect(find.text('▶'), findsOneWidget);
-
-    await gesture.up();
-    await gesture.removePointer();
-    await tester.pumpAndSettle();
+    expect(find.descendant(of: secondRow, matching: find.text('▶')),
+        findsOneWidget);
   });
 
-  testWidgets('context menu closes without waiting for animation', (
+  testWidgets('context menu closes on escape without animation wait', (
     tester,
   ) async {
     final context = _buildTestContext(
@@ -273,20 +259,16 @@ void main() {
     await _openParticipantsDialog(tester);
 
     final row = find.byKey(const Key('participant_row_1'));
-    await _mouseClick(
-      tester,
-      row,
-      buttons: kSecondaryMouseButton,
-    );
-    await tester.pump();
+    await _mouseClick(tester, row, buttons: kSecondaryMouseButton);
+    await tester.pumpAndSettle();
 
     expect(find.text('Delete'), findsOneWidget);
 
-    await tester.tap(find.text('Delete'));
-    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
 
     expect(find.text('Delete'), findsNothing);
-    expect(find.text('Удалить участника?'), findsOneWidget);
+    expect(find.descendant(of: row, matching: find.text('▶')), findsOneWidget);
   });
 }
 
@@ -306,6 +288,16 @@ Future<void> _mouseClick(
   await gesture.down(center);
   await gesture.up();
   await gesture.removePointer();
+}
+
+Future<void> _doubleMouseClick(
+  WidgetTester tester,
+  Finder finder,
+) async {
+  await _mouseClick(tester, finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await _mouseClick(tester, finder);
+  await tester.pumpAndSettle();
 }
 
 Future<void> _openParticipantsDialog(WidgetTester tester) async {

--- a/packages/bochki_schedule_app/test/features/participants/participants_table_state_test.dart
+++ b/packages/bochki_schedule_app/test/features/participants/participants_table_state_test.dart
@@ -1,0 +1,181 @@
+import 'package:bochki_schedule_app/src/features/participants/participants_table_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const reducer = ParticipantsTableReducer();
+  const rows = [
+    ParticipantsTableRowData(id: '1', name: 'Анна'),
+    ParticipantsTableRowData(id: '2', name: 'Борис'),
+  ];
+
+  test('no selection click on data row selects row', () {
+    final transition = reducer.reduce(
+      state: const ParticipantsTableNoSelection(),
+      event: const ParticipantsTableEvent.clickDataRow('2'),
+      rows: rows,
+    );
+
+    expect(
+      transition.state,
+      isA<ParticipantsTableSelectedDataRow>()
+          .having((state) => state.participantId, 'participantId', '2'),
+    );
+    expect(transition.submitRequest, isNull);
+  });
+
+  test('no selection click on new row opens edit new row', () {
+    final transition = reducer.reduce(
+      state: const ParticipantsTableNoSelection(),
+      event: const ParticipantsTableEvent.clickNewRow(),
+      rows: rows,
+    );
+
+    expect(transition.state, isA<ParticipantsTableEditNewRow>());
+    expect(transition.submitRequest, isNull);
+  });
+
+  test('right click on data row opens context menu', () {
+    final transition = reducer.reduce(
+      state: const ParticipantsTableNoSelection(),
+      event: const ParticipantsTableEvent.rightClickDataRow(
+        participantId: '1',
+        position: Offset(24, 40),
+      ),
+      rows: rows,
+    );
+
+    expect(
+      transition.state,
+      isA<ParticipantsTableSelectedDataRow>()
+          .having((state) => state.participantId, 'participantId', '1')
+          .having(
+            (state) => state.contextMenuPosition,
+            'contextMenuPosition',
+            const Offset(24, 40),
+          ),
+    );
+  });
+
+  test('escape closes open context menu and keeps selection', () {
+    final transition = reducer.reduce(
+      state: const ParticipantsTableSelectedDataRow(
+        participantId: '1',
+        contextMenuPosition: Offset(24, 40),
+      ),
+      event: const ParticipantsTableEvent.pressEscape(),
+      rows: rows,
+    );
+
+    expect(
+      transition.state,
+      isA<ParticipantsTableSelectedDataRow>()
+          .having((state) => state.participantId, 'participantId', '1')
+          .having(
+              (state) => state.isContextMenuOpen, 'isContextMenuOpen', false),
+    );
+  });
+
+  test('enter on selected row opens edit for that row', () {
+    final transition = reducer.reduce(
+      state: const ParticipantsTableSelectedDataRow(participantId: '1'),
+      event: const ParticipantsTableEvent.pressEnter(),
+      rows: rows,
+    );
+
+    expect(
+      transition.state,
+      isA<ParticipantsTableEditDataRow>()
+          .having((state) => state.participantId, 'participantId', '1')
+          .having((state) => state.currentValue, 'currentValue', 'Анна'),
+    );
+    expect(transition.submitRequest, isNull);
+  });
+
+  test('dirty edit data row click another row requires submit', () {
+    final transition = reducer.reduce(
+      state: const ParticipantsTableEditDataRow(
+        participantId: '1',
+        initialValue: 'Анна',
+        currentValue: 'Анна Петрова',
+      ),
+      event: const ParticipantsTableEvent.clickDataRow('2'),
+      rows: rows,
+    );
+
+    expect(transition.state, isA<ParticipantsTableEditDataRow>());
+    expect(
+      transition.submitRequest,
+      isA<ParticipantsTableSubmitRequest>()
+          .having((request) => request.mode, 'mode',
+              ParticipantsTableSubmitMode.update)
+          .having((request) => request.participantId, 'participantId', '1')
+          .having((request) => request.rawValue, 'rawValue', 'Анна Петрова')
+          .having(
+            (request) => request.successTarget,
+            'successTarget',
+            isA<ParticipantsTableSuccessSelectRow>().having(
+              (target) => target.participantId,
+              'participantId',
+              '2',
+            ),
+          ),
+    );
+  });
+
+  test('clean edit data row arrow down moves edit to next row', () {
+    final transition = reducer.reduce(
+      state: const ParticipantsTableEditDataRow(
+        participantId: '1',
+        initialValue: 'Анна',
+        currentValue: 'Анна',
+      ),
+      event: const ParticipantsTableEvent.pressArrowDown(),
+      rows: rows,
+    );
+
+    expect(
+      transition.state,
+      isA<ParticipantsTableEditDataRow>()
+          .having((state) => state.participantId, 'participantId', '2')
+          .having((state) => state.currentValue, 'currentValue', 'Борис'),
+    );
+    expect(transition.submitRequest, isNull);
+  });
+
+  test('dirty edit new row enter submits and selects created row', () {
+    final transition = reducer.reduce(
+      state: const ParticipantsTableEditNewRow(currentValue: 'Глеб'),
+      event: const ParticipantsTableEvent.pressEnter(),
+      rows: rows,
+    );
+
+    expect(transition.state, isA<ParticipantsTableEditNewRow>());
+    expect(
+      transition.submitRequest,
+      isA<ParticipantsTableSubmitRequest>()
+          .having((request) => request.mode, 'mode',
+              ParticipantsTableSubmitMode.create)
+          .having((request) => request.rawValue, 'rawValue', 'Глеб')
+          .having(
+            (request) => request.successTarget,
+            'successTarget',
+            isA<ParticipantsTableSuccessSelectCreatedRow>(),
+          ),
+    );
+  });
+
+  test('clean edit new row arrow up moves edit to last data row', () {
+    final transition = reducer.reduce(
+      state: const ParticipantsTableEditNewRow(currentValue: ''),
+      event: const ParticipantsTableEvent.pressArrowUp(),
+      rows: rows,
+    );
+
+    expect(
+      transition.state,
+      isA<ParticipantsTableEditDataRow>()
+          .having((state) => state.participantId, 'participantId', '2')
+          .having((state) => state.currentValue, 'currentValue', 'Борис'),
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- replace ad-hoc participants table flags with an explicit reducer-driven state model
- align click, double-click, keyboard and context-menu transitions with issue #24
- add reducer tests plus updated widget coverage for the participants dialog

## Testing
- dart run melos run analyze
- dart run melos run format-check
- dart run melos run test
- flutter test test/bochki_schedule_app_test.dart test/features/participants/participants_table_state_test.dart test/features/participants/participants_view_model_test.dart -r expanded

## Notes
- local Linux desktop integration test could not be completed in this environment because Flutter could not find ninja while building the Linux runner

Closes #24
