### PR TITLE
fix: make participant selection instant

### DIFF
--- a/packages/bochki_schedule_app/lib/src/features/participants/participants_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/participants/participants_dialog.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -480,65 +481,71 @@ class _ParticipantsDialogState extends State<ParticipantsDialog> {
             ? const Color(0xFFF0F7FF)
             : Colors.white;
 
-    return GestureDetector(
+    return Listener(
       key: Key('participant_row_${participant.id}'),
-      behavior: HitTestBehavior.opaque,
-      onTapDown: viewModel.isSaving
+      onPointerDown: viewModel.isSaving
           ? null
-          : (_) => _handleParticipantTapDown(participant),
-      onTap: viewModel.isSaving
-          ? null
-          : () => _dispatch(
-                ParticipantsTableEvent.clickDataRow(participant.id),
-              ),
-      onDoubleTap: viewModel.isSaving
-          ? null
-          : () => _dispatch(
-                ParticipantsTableEvent.doubleClickDataRow(participant.id),
-                clearFormError: true,
-              ),
-      onSecondaryTapDown: viewModel.isSaving
-          ? null
-          : (details) => _dispatch(
-                ParticipantsTableEvent.rightClickDataRow(
-                  participantId: participant.id,
-                  position: _toTableLocalPosition(details.globalPosition),
+          : (event) {
+              if (event.buttons == kPrimaryMouseButton) {
+                _handleParticipantTapDown(participant);
+              }
+            },
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: viewModel.isSaving || !_tableState.isEditing
+            ? null
+            : () => _dispatch(
+                  ParticipantsTableEvent.clickDataRow(participant.id),
                 ),
-              ),
-      child: Container(
-        decoration: const BoxDecoration(
-          border: Border(
-            bottom: BorderSide(color: _rowBorderColor),
-          ),
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            _buildIndicatorCell(
-              child: _buildIndicator(
-                isEditing: isEditing,
-                isAddRow: false,
-                isSelected: isSelected,
-              ),
-            ),
-            Expanded(
-              child: ColoredBox(
-                color: backgroundColor,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 12,
-                    vertical: 8,
+        onDoubleTap: viewModel.isSaving
+            ? null
+            : () => _dispatch(
+                  ParticipantsTableEvent.doubleClickDataRow(participant.id),
+                  clearFormError: true,
+                ),
+        onSecondaryTapDown: viewModel.isSaving
+            ? null
+            : (details) => _dispatch(
+                  ParticipantsTableEvent.rightClickDataRow(
+                    participantId: participant.id,
+                    position: _toTableLocalPosition(details.globalPosition),
                   ),
-                  child: isEditing
-                      ? _buildNameEditor(viewModel)
-                      : Text(
-                          participant.name,
-                          style: Theme.of(context).textTheme.bodyLarge,
-                        ),
+                ),
+        child: Container(
+          decoration: const BoxDecoration(
+            border: Border(
+              bottom: BorderSide(color: _rowBorderColor),
+            ),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              _buildIndicatorCell(
+                child: _buildIndicator(
+                  isEditing: isEditing,
+                  isAddRow: false,
+                  isSelected: isSelected,
                 ),
               ),
-            ),
-          ],
+              Expanded(
+                child: ColoredBox(
+                  color: backgroundColor,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    child: isEditing
+                        ? _buildNameEditor(viewModel)
+                        : Text(
+                            participant.name,
+                            style: Theme.of(context).textTheme.bodyLarge,
+                          ),
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -120,6 +120,40 @@ void main() {
     expect(find.byKey(const Key('participant_name_field')), findsNothing);
   });
 
+  testWidgets('row becomes selected on mouse down before tap completes', (
+    tester,
+  ) async {
+    final context = _buildTestContext(
+      participants: [
+        Participant(id: '1', name: 'Анна'),
+      ],
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await _openParticipantsDialog(tester);
+
+    final row = find.byKey(const Key('participant_row_1'));
+    final gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+      buttons: kPrimaryMouseButton,
+    );
+    final center = tester.getCenter(row);
+
+    await gesture.addPointer(location: center);
+    await gesture.moveTo(center);
+    await tester.pump();
+    await gesture.down(center);
+    await tester.pump();
+
+    expect(find.descendant(of: row, matching: find.text('▶')), findsOneWidget);
+    expect(find.byKey(const Key('participant_name_field')), findsNothing);
+
+    await gesture.up();
+    await gesture.removePointer();
+    await tester.pump(const Duration(milliseconds: 50));
+  });
+
   testWidgets('enter commits edited row after inline edit starts',
       (tester) async {
     final context = _buildTestContext(


### PR DESCRIPTION
## Summary
- move participant row selection to primary pointer down for immediate feedback
- keep double click edit behavior and existing edit-state transitions intact
- add a widget regression test that asserts selection happens before tap completion

Closes #26