### PR TITLE
feat(app): async project document persistence

### DIFF
--- a/packages/bochki_schedule_app/integration_test/app_shell_test.dart
+++ b/packages/bochki_schedule_app/integration_test/app_shell_test.dart
@@ -19,6 +19,8 @@ void main() {
       createParticipantUseCase: CreateParticipantUseCase(repository),
       updateParticipantUseCase: UpdateParticipantUseCase(repository),
       deleteParticipantUseCase: DeleteParticipantUseCase(repository),
+      flushPending: _noopAsync,
+      shutdown: _noopAsync,
     );
 
     await tester.pumpWidget(BochkiScheduleApp(services: services));
@@ -48,6 +50,8 @@ void main() {
     expect(find.text('Добавить новую запись'), findsOneWidget);
   });
 }
+
+Future<void> _noopAsync() async {}
 
 final class _NoopLogger implements AppLogger {
   const _NoopLogger();

--- a/packages/bochki_schedule_app/lib/src/app.dart
+++ b/packages/bochki_schedule_app/lib/src/app.dart
@@ -1,15 +1,54 @@
+import 'dart:async';
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 
 import 'app_services.dart';
 import 'presentation/shell/bochki_shell.dart';
 
-class BochkiScheduleApp extends StatelessWidget {
+class BochkiScheduleApp extends StatefulWidget {
   const BochkiScheduleApp({
     required this.services,
     super.key,
   });
 
   final AppServices services;
+
+  @override
+  State<BochkiScheduleApp> createState() => _BochkiScheduleAppState();
+}
+
+class _BochkiScheduleAppState extends State<BochkiScheduleApp> {
+  late final AppLifecycleListener _lifecycleListener;
+
+  @override
+  void initState() {
+    super.initState();
+    _lifecycleListener = AppLifecycleListener(
+      onExitRequested: _handleExitRequested,
+    );
+  }
+
+  @override
+  void dispose() {
+    _lifecycleListener.dispose();
+    unawaited(widget.services.shutdown());
+    super.dispose();
+  }
+
+  Future<AppExitResponse> _handleExitRequested() async {
+    try {
+      await widget.services.shutdown();
+      return AppExitResponse.exit;
+    } catch (error, stackTrace) {
+      await widget.services.logger.error(
+        'Application shutdown failed',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return AppExitResponse.cancel;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +63,7 @@ class BochkiScheduleApp extends StatelessWidget {
         ),
         scaffoldBackgroundColor: const Color(0xFFF6F7F9),
       ),
-      home: BochkiShell(services: services),
+      home: BochkiShell(services: widget.services),
     );
   }
 }

--- a/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
+++ b/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
@@ -4,8 +4,9 @@ import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
 import 'package:path/path.dart' as p;
 
 import 'app_services.dart';
-import 'data/participants/participants_storage.dart';
 import 'data/participants/project_document_participants_repository.dart';
+import 'data/project_document/project_document_id_allocator.dart';
+import 'data/project_document/project_document_sync_coordinator.dart';
 import 'domain/participants/create_participant_use_case.dart';
 import 'domain/participants/delete_participant_use_case.dart';
 import 'domain/participants/list_participants_use_case.dart';
@@ -26,12 +27,23 @@ final class AppBootstrap {
       projectFile: File(p.join(appDataDirectory.path, 'project.json')),
       safeFileWriter: const AtomicFileWriter(),
     );
-    final participantsStorage = ProjectDocumentParticipantsStorage(
-      projectDocumentRepository,
+    final initialDocument = await projectDocumentRepository.load();
+    final syncCoordinator = ProjectDocumentSyncCoordinator(
+      repository: projectDocumentRepository,
+      initialDocument: initialDocument,
+      logger: logger,
+    );
+    final idAllocator = ProjectDocumentIdAllocator(
+      nextId: initialDocument.nextId,
+      onChanged: syncCoordinator.markChanged,
     );
     final participantsRepository = ProjectDocumentParticipantsRepository(
-      storage: participantsStorage,
+      initialDocument: initialDocument,
+      idAllocator: idAllocator,
+      onChanged: syncCoordinator.markChanged,
     );
+    syncCoordinator.registerPart(idAllocator);
+    syncCoordinator.registerPart(participantsRepository);
     final listParticipantsUseCase = ListParticipantsUseCase(
       participantsRepository,
     );
@@ -56,6 +68,8 @@ final class AppBootstrap {
       createParticipantUseCase: createParticipantUseCase,
       updateParticipantUseCase: updateParticipantUseCase,
       deleteParticipantUseCase: deleteParticipantUseCase,
+      flushPending: syncCoordinator.flushPending,
+      shutdown: syncCoordinator.shutdown,
     );
   }
 }

--- a/packages/bochki_schedule_app/lib/src/app_services.dart
+++ b/packages/bochki_schedule_app/lib/src/app_services.dart
@@ -15,6 +15,8 @@ final class AppServices {
     required this.createParticipantUseCase,
     required this.updateParticipantUseCase,
     required this.deleteParticipantUseCase,
+    required this.flushPending,
+    required this.shutdown,
   });
 
   final Directory appDataDirectory;
@@ -23,4 +25,6 @@ final class AppServices {
   final CreateParticipantUseCase createParticipantUseCase;
   final UpdateParticipantUseCase updateParticipantUseCase;
   final DeleteParticipantUseCase deleteParticipantUseCase;
+  final Future<void> Function() flushPending;
+  final Future<void> Function() shutdown;
 }

--- a/packages/bochki_schedule_app/lib/src/data/participants/project_document_participants_repository.dart
+++ b/packages/bochki_schedule_app/lib/src/data/participants/project_document_participants_repository.dart
@@ -2,22 +2,30 @@ import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 
 import '../../domain/participants/participant.dart';
 import '../../domain/participants/participants_repository.dart';
+import '../project_document/project_document_id_allocator.dart';
+import '../project_document/project_document_sync_part.dart';
 import 'participants_dto.dart';
-import 'participants_storage.dart';
 
 final class ProjectDocumentParticipantsRepository
-    implements ParticipantsRepository {
-  const ProjectDocumentParticipantsRepository({
-    required ParticipantsStorage storage,
-  }) : _storage = storage;
+    with DirtyTrackingProjectDocumentSyncPart
+    implements ParticipantsRepository, ProjectDocumentSyncPart {
+  ProjectDocumentParticipantsRepository({
+    required ProjectDocument initialDocument,
+    required ProjectDocumentIdAllocator idAllocator,
+    required void Function() onChanged,
+  })  : _idAllocator = idAllocator,
+        _onChanged = onChanged,
+        _participants = initialDocument.participants
+            .map(ParticipantDto.fromJson)
+            .toList(growable: true);
 
-  final ParticipantsStorage _storage;
+  final ProjectDocumentIdAllocator _idAllocator;
+  final void Function() _onChanged;
+  final List<ParticipantDto> _participants;
 
   @override
   Future<List<Participant>> list() async {
-    final document = await _storage.loadDocument();
-    return document.participants
-        .map(ParticipantDto.fromJson)
+    return _participants
         .where((participant) => !participant.deleted)
         .map((participant) => participant.toDomain())
         .toList(growable: false);
@@ -27,41 +35,32 @@ final class ProjectDocumentParticipantsRepository
   Future<Participant> create({
     required String name,
   }) async {
-    final document = await _storage.loadDocument();
-    final participants = _participantDtosFromDocument(document);
     final createdParticipant = Participant(
-      id: document.nextId.toString(),
+      id: _idAllocator.nextId().toString(),
       name: name,
     );
-    participants.add(
+    _participants.add(
       ParticipantDto.fromDomain(createdParticipant, deleted: false),
     );
-
-    await _storage.saveDocument(
-      document.copyWith(
-        nextId: document.nextId + 1,
-        participants: _sortedParticipantJson(participants),
-      ),
-    );
+    _markRepositoryChanged();
     return createdParticipant;
   }
 
   @override
   Future<Participant> update(Participant participant) async {
-    final document = await _storage.loadDocument();
-    final participants = _participantDtosFromDocument(document);
     final participantId = int.parse(participant.id);
-    final index = participants.indexWhere(
+    final index = _participants.indexWhere(
       (candidate) => candidate.id == participantId,
     );
     if (index != -1) {
-      participants[index] =
-          participants[index].copyWith(name: participant.name);
-      await _storage.saveDocument(
-        document.copyWith(
-          participants: _sortedParticipantJson(participants),
-        ),
-      );
+      final current = _participants[index];
+      if (current.name != participant.name || current.deleted) {
+        _participants[index] = current.copyWith(
+          name: participant.name,
+          deleted: false,
+        );
+        _markRepositoryChanged();
+      }
     }
 
     return participant;
@@ -69,39 +68,39 @@ final class ProjectDocumentParticipantsRepository
 
   @override
   Future<void> delete(String participantId) async {
-    final document = await _storage.loadDocument();
-    final participants = _participantDtosFromDocument(document);
     final parsedId = int.parse(participantId);
-    final index = participants.indexWhere(
+    final index = _participants.indexWhere(
       (candidate) => candidate.id == parsedId,
     );
-    if (index == -1) {
+    if (index == -1 || _participants[index].deleted) {
       return;
     }
 
-    participants[index] = participants[index].copyWith(deleted: true);
-    await _storage.saveDocument(
-      document.copyWith(
-        participants: _sortedParticipantJson(participants),
-      ),
-    );
+    _participants[index] = _participants[index].copyWith(deleted: true);
+    _markRepositoryChanged();
   }
 
-  List<ParticipantDto> _participantDtosFromDocument(ProjectDocument document) {
-    return document.participants
-        .map(ParticipantDto.fromJson)
-        .toList(growable: true);
+  @override
+  ProjectDocument applyToDocument(ProjectDocument document) {
+    return document.copyWith(
+      participants: _sortedParticipantJson(_participants),
+    );
   }
 
   List<Map<String, Object?>> _sortedParticipantJson(
     List<ParticipantDto> participants,
   ) {
-    participants.sort(
-      (left, right) => Participant.sortKeyForName(left.name)
-          .compareTo(Participant.sortKeyForName(right.name)),
-    );
-    return participants
+    final sortedParticipants = [...participants]..sort(
+        (left, right) => Participant.sortKeyForName(left.name)
+            .compareTo(Participant.sortKeyForName(right.name)),
+      );
+    return sortedParticipants
         .map((participant) => participant.toJson())
         .toList(growable: false);
+  }
+
+  void _markRepositoryChanged() {
+    markChanged();
+    _onChanged();
   }
 }

--- a/packages/bochki_schedule_app/lib/src/data/project_document/project_document_id_allocator.dart
+++ b/packages/bochki_schedule_app/lib/src/data/project_document/project_document_id_allocator.dart
@@ -1,0 +1,28 @@
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+
+import 'project_document_sync_part.dart';
+
+final class ProjectDocumentIdAllocator
+    with DirtyTrackingProjectDocumentSyncPart
+    implements ProjectDocumentSyncPart {
+  ProjectDocumentIdAllocator({
+    required int nextId,
+    required void Function() onChanged,
+  })  : _generator = SequentialIdGenerator(startAt: nextId),
+        _onChanged = onChanged;
+
+  final SequentialIdGenerator _generator;
+  final void Function() _onChanged;
+
+  int nextId() {
+    final nextId = _generator.nextId();
+    markChanged();
+    _onChanged();
+    return nextId;
+  }
+
+  @override
+  ProjectDocument applyToDocument(ProjectDocument document) {
+    return document.copyWith(nextId: _generator.currentValue + 1);
+  }
+}

--- a/packages/bochki_schedule_app/lib/src/data/project_document/project_document_sync_coordinator.dart
+++ b/packages/bochki_schedule_app/lib/src/data/project_document/project_document_sync_coordinator.dart
@@ -1,0 +1,137 @@
+import 'dart:async';
+
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
+
+import 'project_document_sync_part.dart';
+
+final class ProjectDocumentSyncCoordinator {
+  ProjectDocumentSyncCoordinator({
+    required ProjectDocumentRepository repository,
+    required ProjectDocument initialDocument,
+    required AppLogger logger,
+    this.debounceDuration = const Duration(milliseconds: 400),
+  })  : _repository = repository,
+        _lastPersistedDocument = initialDocument,
+        _logger = logger;
+
+  final ProjectDocumentRepository _repository;
+  final AppLogger _logger;
+  final Duration debounceDuration;
+  final List<ProjectDocumentSyncPart> _parts = <ProjectDocumentSyncPart>[];
+
+  ProjectDocument _lastPersistedDocument;
+  Timer? _debounceTimer;
+  Future<void>? _activeFlush;
+  bool _flushQueued = false;
+  bool _isShutdown = false;
+
+  void registerPart(ProjectDocumentSyncPart part) {
+    _parts.add(part);
+  }
+
+  void markChanged() {
+    if (_isShutdown) {
+      return;
+    }
+
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(debounceDuration, _flushDebounced);
+  }
+
+  Future<void> flushPending() {
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    return _queueFlush();
+  }
+
+  Future<void> shutdown() async {
+    if (_isShutdown) {
+      return _activeFlush ?? Future<void>.value();
+    }
+
+    _isShutdown = true;
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    await _queueFlush();
+  }
+
+  void _flushDebounced() {
+    unawaited(_flushDebouncedSafely());
+  }
+
+  Future<void> _flushDebouncedSafely() async {
+    try {
+      await _queueFlush();
+    } catch (error, stackTrace) {
+      await _logger.error(
+        'Project document flush failed',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> _queueFlush() {
+    if (!_parts.any((part) => part.isDirty)) {
+      return _activeFlush ?? Future<void>.value();
+    }
+
+    _flushQueued = true;
+    final activeFlush = _activeFlush;
+    if (activeFlush != null) {
+      return activeFlush;
+    }
+
+    final flushFuture = _runFlushQueue();
+    _activeFlush = flushFuture;
+    return flushFuture;
+  }
+
+  Future<void> _runFlushQueue() async {
+    try {
+      while (_flushQueued) {
+        _flushQueued = false;
+        await _flushOnce();
+      }
+    } finally {
+      _activeFlush = null;
+    }
+  }
+
+  Future<void> _flushOnce() async {
+    final snapshots = <_PartSnapshot>[
+      for (final part in _parts)
+        if (part.isDirty) _PartSnapshot(part: part, revision: part.revision),
+    ];
+    if (snapshots.isEmpty) {
+      return;
+    }
+
+    var document = _lastPersistedDocument;
+    for (final snapshot in snapshots) {
+      document = snapshot.part.applyToDocument(document);
+    }
+
+    await _repository.save(document);
+    _lastPersistedDocument = document;
+
+    for (final snapshot in snapshots) {
+      snapshot.part.markPersisted(snapshot.revision);
+    }
+
+    if (_parts.any((part) => part.isDirty)) {
+      _flushQueued = true;
+    }
+  }
+}
+
+final class _PartSnapshot {
+  const _PartSnapshot({
+    required this.part,
+    required this.revision,
+  });
+
+  final ProjectDocumentSyncPart part;
+  final int revision;
+}

--- a/packages/bochki_schedule_app/lib/src/data/project_document/project_document_sync_part.dart
+++ b/packages/bochki_schedule_app/lib/src/data/project_document/project_document_sync_part.dart
@@ -1,0 +1,33 @@
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+
+abstract interface class ProjectDocumentSyncPart {
+  bool get isDirty;
+
+  int get revision;
+
+  ProjectDocument applyToDocument(ProjectDocument document);
+
+  void markPersisted(int revision);
+}
+
+mixin DirtyTrackingProjectDocumentSyncPart implements ProjectDocumentSyncPart {
+  int _revision = 0;
+  int _persistedRevision = 0;
+
+  @override
+  bool get isDirty => _revision != _persistedRevision;
+
+  @override
+  int get revision => _revision;
+
+  void markChanged() {
+    _revision += 1;
+  }
+
+  @override
+  void markPersisted(int revision) {
+    if (_revision == revision) {
+      _persistedRevision = revision;
+    }
+  }
+}

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -356,10 +356,14 @@ _TestContext _buildTestContext({
       createParticipantUseCase: CreateParticipantUseCase(repository),
       updateParticipantUseCase: UpdateParticipantUseCase(repository),
       deleteParticipantUseCase: DeleteParticipantUseCase(repository),
+      flushPending: _noopAsync,
+      shutdown: _noopAsync,
     ),
     repository: repository,
   );
 }
+
+Future<void> _noopAsync() async {}
 
 final class _TestContext {
   const _TestContext({

--- a/packages/bochki_schedule_app/test/data/project_document_participants_repository_test.dart
+++ b/packages/bochki_schedule_app/test/data/project_document_participants_repository_test.dart
@@ -1,0 +1,86 @@
+import 'package:bochki_schedule_app/src/data/participants/project_document_participants_repository.dart';
+import 'package:bochki_schedule_app/src/data/project_document/project_document_id_allocator.dart';
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('loads active participants from memory and preserves deleted rows',
+      () async {
+    var changeNotifications = 0;
+    final repository = ProjectDocumentParticipantsRepository(
+      initialDocument: const ProjectDocument(
+        nextId: 5,
+        participants: <Map<String, Object?>>[
+          <String, Object?>{'id': 1, 'name': 'Анна', 'deleted': false},
+          <String, Object?>{'id': 2, 'name': 'Борис', 'deleted': true},
+        ],
+      ),
+      idAllocator: ProjectDocumentIdAllocator(
+        nextId: 5,
+        onChanged: () {
+          changeNotifications += 1;
+        },
+      ),
+      onChanged: () {
+        changeNotifications += 1;
+      },
+    );
+
+    final participants = await repository.list();
+    final exportedDocument =
+        repository.applyToDocument(ProjectDocument.initial());
+
+    expect(participants.map((participant) => participant.name), ['Анна']);
+    expect(exportedDocument.participants, [
+      <String, Object?>{'id': 1, 'name': 'Анна', 'deleted': false},
+      <String, Object?>{'id': 2, 'name': 'Борис', 'deleted': true},
+    ]);
+    expect(repository.isDirty, isFalse);
+    expect(changeNotifications, 0);
+  });
+
+  test('create update and delete stay in memory and mark repository dirty',
+      () async {
+    var changeNotifications = 0;
+    final idAllocator = ProjectDocumentIdAllocator(
+      nextId: 3,
+      onChanged: () {
+        changeNotifications += 1;
+      },
+    );
+    final repository = ProjectDocumentParticipantsRepository(
+      initialDocument: const ProjectDocument(
+        nextId: 3,
+        participants: <Map<String, Object?>>[
+          <String, Object?>{'id': 1, 'name': 'Борис', 'deleted': false},
+          <String, Object?>{'id': 2, 'name': 'Анна', 'deleted': false},
+        ],
+      ),
+      idAllocator: idAllocator,
+      onChanged: () {
+        changeNotifications += 1;
+      },
+    );
+
+    final created = await repository.create(name: 'Василий');
+    await repository.update(created.copyWith(name: 'Василиса'));
+    await repository.delete('1');
+
+    final participants = await repository.list();
+    final exportedDocument =
+        repository.applyToDocument(const ProjectDocument(nextId: 4));
+
+    expect(created.id, '3');
+    expect(
+      participants.map((participant) => participant.name),
+      ['Анна', 'Василиса'],
+    );
+    expect(exportedDocument.participants, [
+      <String, Object?>{'id': 2, 'name': 'Анна', 'deleted': false},
+      <String, Object?>{'id': 1, 'name': 'Борис', 'deleted': true},
+      <String, Object?>{'id': 3, 'name': 'Василиса', 'deleted': false},
+    ]);
+    expect(repository.isDirty, isTrue);
+    expect(changeNotifications, 4);
+  });
+}

--- a/packages/bochki_schedule_app/test/data/project_document_sync_coordinator_test.dart
+++ b/packages/bochki_schedule_app/test/data/project_document_sync_coordinator_test.dart
@@ -1,0 +1,175 @@
+import 'dart:async';
+
+import 'package:bochki_schedule_app/src/data/project_document/project_document_sync_coordinator.dart';
+import 'package:bochki_schedule_app/src/data/project_document/project_document_sync_part.dart';
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('debounces multiple changes into a single save', () async {
+    final repository = _RecordingProjectDocumentRepository();
+    final coordinator = ProjectDocumentSyncCoordinator(
+      repository: repository,
+      initialDocument: ProjectDocument.initial(),
+      logger: const _NoopLogger(),
+      debounceDuration: const Duration(milliseconds: 40),
+    );
+    final part = _MutableSyncPart(
+      apply: (document, revision) => document.copyWith(
+        participants: [
+          <String, Object?>{'id': revision, 'name': 'P$revision'},
+        ],
+      ),
+    );
+    coordinator.registerPart(part);
+
+    part.bumpRevision();
+    coordinator.markChanged();
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    part.bumpRevision();
+    coordinator.markChanged();
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    part.bumpRevision();
+    coordinator.markChanged();
+
+    expect(repository.savedDocuments, isEmpty);
+
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+
+    expect(repository.savedDocuments, hasLength(1));
+    expect(repository.savedDocuments.single.participants.single['id'], 3);
+    expect(part.isDirty, isFalse);
+  });
+
+  test('flushPending writes immediately and preserves untouched sections',
+      () async {
+    final repository = _RecordingProjectDocumentRepository();
+    final coordinator = ProjectDocumentSyncCoordinator(
+      repository: repository,
+      initialDocument: const ProjectDocument(
+        nextId: 4,
+        trainers: <Map<String, Object?>>[
+          <String, Object?>{'id': 7, 'name': 'Trainer One'},
+        ],
+      ),
+      logger: const _NoopLogger(),
+      debounceDuration: const Duration(milliseconds: 400),
+    );
+    final part = _MutableSyncPart(
+      apply: (document, revision) => document.copyWith(
+        participants: [
+          <String, Object?>{'id': revision, 'name': 'Participant'},
+        ],
+      ),
+    );
+    coordinator.registerPart(part);
+
+    part.bumpRevision();
+    await coordinator.flushPending();
+
+    expect(repository.savedDocuments, hasLength(1));
+    expect(repository.savedDocuments.single.trainers.single['name'],
+        'Trainer One');
+    expect(
+      repository.savedDocuments.single.participants.single['name'],
+      'Participant',
+    );
+    expect(part.isDirty, isFalse);
+  });
+
+  test('keeps section dirty when it changes during active save', () async {
+    final saveStarted = Completer<void>();
+    final releaseSave = Completer<void>();
+    final repository = _RecordingProjectDocumentRepository(
+      onSave: (document) async {
+        if (!saveStarted.isCompleted) {
+          saveStarted.complete();
+          await releaseSave.future;
+        }
+      },
+    );
+    final coordinator = ProjectDocumentSyncCoordinator(
+      repository: repository,
+      initialDocument: ProjectDocument.initial(),
+      logger: const _NoopLogger(),
+      debounceDuration: Duration.zero,
+    );
+    final part = _MutableSyncPart(
+      apply: (document, revision) => document.copyWith(
+        nextId: revision + 1,
+      ),
+    );
+    coordinator.registerPart(part);
+
+    part.bumpRevision();
+    final firstFlush = coordinator.flushPending();
+    await saveStarted.future;
+
+    part.bumpRevision();
+    final secondFlush = coordinator.flushPending();
+    releaseSave.complete();
+
+    await firstFlush;
+    await secondFlush;
+
+    expect(repository.savedDocuments, hasLength(2));
+    expect(repository.savedDocuments.last.nextId, 3);
+    expect(part.isDirty, isFalse);
+  });
+}
+
+final class _MutableSyncPart
+    with DirtyTrackingProjectDocumentSyncPart
+    implements ProjectDocumentSyncPart {
+  _MutableSyncPart({
+    required ProjectDocument Function(ProjectDocument document, int revision)
+        apply,
+  }) : _apply = apply;
+
+  final ProjectDocument Function(ProjectDocument document, int revision) _apply;
+
+  @override
+  ProjectDocument applyToDocument(ProjectDocument document) {
+    return _apply(document, revision);
+  }
+
+  void bumpRevision() {
+    super.markChanged();
+  }
+}
+
+final class _RecordingProjectDocumentRepository
+    implements ProjectDocumentRepository {
+  _RecordingProjectDocumentRepository({
+    Future<void> Function(ProjectDocument document)? onSave,
+  }) : _onSave = onSave;
+
+  final Future<void> Function(ProjectDocument document)? _onSave;
+  final List<ProjectDocument> savedDocuments = <ProjectDocument>[];
+
+  @override
+  Future<ProjectDocument> load() async {
+    return ProjectDocument.initial();
+  }
+
+  @override
+  Future<void> save(ProjectDocument document) async {
+    savedDocuments.add(document);
+    await _onSave?.call(document);
+  }
+}
+
+final class _NoopLogger implements AppLogger {
+  const _NoopLogger();
+
+  @override
+  Future<void> error(
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+  }) async {}
+
+  @override
+  Future<void> info(String message) async {}
+}


### PR DESCRIPTION
## Summary
- move participants persistence to in-memory dirty-tracked repository
- add debounced project document sync coordinator with shutdown flush
- cover async persistence flow with unit and widget/integration test updates

Closes #29