### PR TITLE
fix: store project data beside launch binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ fvm flutter run -d windows
 make windows-release
 ```
 
+По умолчанию desktop-сборка хранит `project.json` и `logs/app.log` рядом с файлом запуска.
+Если нужен явный путь для CI или локального smoke-run, передайте `--app-data-dir=<path>`.
+
 ## Команды workspace
 
 ```bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -42,3 +42,8 @@ For local Linux desktop integration runs, install:
 - `ninja-build`
 - `pkg-config`
 - `libgtk-3-dev`
+
+## Desktop Launch Path
+
+When the desktop app is launched without arguments, it stores `project.json` in the same folder as the launched binary or macOS bundle location.
+For CI or local smoke runs, pass `--app-data-dir=<path>` so the app writes into an explicit temporary directory.

--- a/packages/bochki_schedule_app/lib/main.dart
+++ b/packages/bochki_schedule_app/lib/main.dart
@@ -6,16 +6,19 @@ import 'package:bochki_schedule_app/bochki_schedule_app.dart';
 import 'package:flutter/widgets.dart';
 import 'package:window_manager/window_manager.dart';
 
+import 'src/app_launch_arguments.dart';
 import 'src/presentation/startup_error_app.dart';
 
-Future<void> main() async {
+Future<void> main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
   await _configureWindow();
 
   AppServices? services;
 
   try {
-    services = await AppBootstrap.initialize();
+    services = await AppBootstrap.initialize(
+      appDataDirectory: resolveAppDataDirectoryOverride(args),
+    );
     FlutterError.onError = (details) {
       FlutterError.presentError(details);
       unawaited(

--- a/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
+++ b/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
@@ -18,18 +18,16 @@ import 'domain/trainers/list_trainers_use_case.dart';
 import 'domain/trainers/update_trainer_use_case.dart';
 
 final class AppBootstrap {
-  static const String appDirectoryName = 'bochki_schedule';
-
-  static Future<AppServices> initialize() async {
-    final appDataProvider = PlatformAppDataDirectoryProvider(
-      appDirectoryName: appDirectoryName,
-    );
-    final appDataDirectory = await appDataProvider.getAppDataDirectory();
+  static Future<AppServices> initialize({
+    Directory? appDataDirectory,
+  }) async {
+    final resolvedAppDataDirectory = appDataDirectory ??
+        await LaunchAppDataDirectoryProvider().getAppDataDirectory();
     final logger = FileAppLogger(
-      logFile: File(p.join(appDataDirectory.path, 'logs', 'app.log')),
+      logFile: File(p.join(resolvedAppDataDirectory.path, 'logs', 'app.log')),
     );
     final projectDocumentRepository = JsonProjectDocumentRepository(
-      projectFile: File(p.join(appDataDirectory.path, 'project.json')),
+      projectFile: File(p.join(resolvedAppDataDirectory.path, 'project.json')),
       safeFileWriter: const AtomicFileWriter(),
     );
     final initialDocument = await projectDocumentRepository.load();
@@ -81,11 +79,11 @@ final class AppBootstrap {
     );
 
     await logger.info(
-      'Bootstrap completed. appDataDirectory=${appDataDirectory.path}',
+      'Bootstrap completed. appDataDirectory=${resolvedAppDataDirectory.path}',
     );
 
     return AppServices(
-      appDataDirectory: appDataDirectory,
+      appDataDirectory: resolvedAppDataDirectory,
       logger: logger,
       listParticipantsUseCase: listParticipantsUseCase,
       createParticipantUseCase: createParticipantUseCase,

--- a/packages/bochki_schedule_app/lib/src/app_launch_arguments.dart
+++ b/packages/bochki_schedule_app/lib/src/app_launch_arguments.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+Directory? resolveAppDataDirectoryOverride(List<String> args) {
+  const prefix = '--app-data-dir=';
+  for (var index = 0; index < args.length; index += 1) {
+    final arg = args[index];
+    if (arg.startsWith(prefix)) {
+      final value = arg.substring(prefix.length);
+      if (value.isEmpty) {
+        throw ArgumentError.value(arg, 'args', 'Missing app data directory');
+      }
+      return Directory(value);
+    }
+
+    if (arg == '--app-data-dir') {
+      final nextIndex = index + 1;
+      if (nextIndex >= args.length) {
+        throw ArgumentError.value(arg, 'args', 'Missing app data directory');
+      }
+
+      final value = args[nextIndex];
+      if (value.startsWith('--')) {
+        throw ArgumentError.value(arg, 'args', 'Missing app data directory');
+      }
+
+      return Directory(value);
+    }
+  }
+
+  return null;
+}

--- a/packages/bochki_schedule_app/pubspec.lock
+++ b/packages/bochki_schedule_app/pubspec.lock
@@ -15,14 +15,14 @@ packages:
       path: "../bochki_schedule_domain"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.2"
   bochki_schedule_infra:
     dependency: "direct main"
     description:
       path: "../bochki_schedule_infra"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.2"
   boolean_selector:
     dependency: transitive
     description:

--- a/packages/bochki_schedule_app/test/app_bootstrap_test.dart
+++ b/packages/bochki_schedule_app/test/app_bootstrap_test.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+import 'package:bochki_schedule_app/bochki_schedule_app.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  test('bootstrap uses the provided app data directory override', () async {
+    final tempRoot = await Directory.systemTemp.createTemp(
+      'bochki_bootstrap_test',
+    );
+    final services = await AppBootstrap.initialize(
+      appDataDirectory: tempRoot,
+    );
+    addTearDown(() async {
+      await services.shutdown();
+      await tempRoot.delete(recursive: true);
+    });
+
+    await services.logger.info('bootstrap smoke');
+    await services.createParticipantUseCase.execute('Иван');
+    await services.flushPending();
+
+    final logFile = File(p.join(tempRoot.path, 'logs', 'app.log'));
+    final projectFile = File(p.join(tempRoot.path, 'project.json'));
+
+    expect(await logFile.exists(), isTrue);
+    expect(await projectFile.exists(), isTrue);
+    expect(services.appDataDirectory.path, tempRoot.path);
+  });
+}

--- a/packages/bochki_schedule_app/test/app_launch_arguments_test.dart
+++ b/packages/bochki_schedule_app/test/app_launch_arguments_test.dart
@@ -1,0 +1,30 @@
+import 'package:bochki_schedule_app/src/app_launch_arguments.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('parses app data override from equals form', () {
+    final directory = resolveAppDataDirectoryOverride([
+      '--app-data-dir=/tmp/bochki_schedule_test',
+    ]);
+
+    expect(directory?.path, '/tmp/bochki_schedule_test');
+  });
+
+  test('parses app data override from split form', () {
+    final directory = resolveAppDataDirectoryOverride([
+      '--app-data-dir',
+      '/tmp/bochki_schedule_test',
+    ]);
+
+    expect(directory?.path, '/tmp/bochki_schedule_test');
+  });
+
+  test('ignores unrelated arguments', () {
+    final directory = resolveAppDataDirectoryOverride([
+      '--foo=bar',
+      '--dart-define=BAZ=1',
+    ]);
+
+    expect(directory, isNull);
+  });
+}

--- a/packages/bochki_schedule_infra/lib/src/app_paths.dart
+++ b/packages/bochki_schedule_infra/lib/src/app_paths.dart
@@ -6,59 +6,43 @@ abstract interface class AppDataDirectoryProvider {
   Future<Directory> getAppDataDirectory();
 }
 
-final class PlatformAppDataDirectoryProvider
-    implements AppDataDirectoryProvider {
-  PlatformAppDataDirectoryProvider({
-    required this.appDirectoryName,
-    Map<String, String>? environment,
+String resolveLaunchAppDataDirectoryPath({
+  required String resolvedExecutable,
+  required String operatingSystem,
+}) {
+  final pathContext = p.Context(
+      style: operatingSystem == 'windows' ? p.Style.windows : p.Style.posix);
+  final executableDirectory = pathContext.dirname(resolvedExecutable);
+
+  if (operatingSystem == 'macos') {
+    final contentsDirectory = pathContext.dirname(executableDirectory);
+    final bundleDirectory = pathContext.dirname(contentsDirectory);
+    if (pathContext.basename(bundleDirectory).endsWith('.app')) {
+      return pathContext.dirname(bundleDirectory);
+    }
+  }
+
+  return executableDirectory;
+}
+
+final class LaunchAppDataDirectoryProvider implements AppDataDirectoryProvider {
+  LaunchAppDataDirectoryProvider({
+    String? resolvedExecutable,
     String? operatingSystem,
-  })  : _environment = environment ?? Platform.environment,
+  })  : _resolvedExecutable = resolvedExecutable ?? Platform.resolvedExecutable,
         _operatingSystem = operatingSystem ?? Platform.operatingSystem;
 
-  final String appDirectoryName;
-  final Map<String, String> _environment;
+  final String _resolvedExecutable;
   final String _operatingSystem;
 
   @override
   Future<Directory> getAppDataDirectory() async {
-    final baseDirectoryPath = _resolveBaseDirectoryPath();
-    final directory = Directory(p.join(baseDirectoryPath, appDirectoryName));
+    final baseDirectoryPath = resolveLaunchAppDataDirectoryPath(
+      resolvedExecutable: _resolvedExecutable,
+      operatingSystem: _operatingSystem,
+    );
+    final directory = Directory(baseDirectoryPath);
     await directory.create(recursive: true);
     return directory;
-  }
-
-  String _resolveBaseDirectoryPath() {
-    switch (_operatingSystem) {
-      case 'windows':
-        final appData = _environment['APPDATA'];
-        if (appData != null && appData.isNotEmpty) {
-          return appData;
-        }
-
-        return p.join(
-            _requiredEnvironmentValue('USERPROFILE'), 'AppData', 'Roaming');
-      case 'macos':
-        return p.join(
-          _requiredEnvironmentValue('HOME'),
-          'Library',
-          'Application Support',
-        );
-      default:
-        final xdgDataHome = _environment['XDG_DATA_HOME'];
-        if (xdgDataHome != null && xdgDataHome.isNotEmpty) {
-          return xdgDataHome;
-        }
-
-        return p.join(_requiredEnvironmentValue('HOME'), '.local', 'share');
-    }
-  }
-
-  String _requiredEnvironmentValue(String key) {
-    final value = _environment[key];
-    if (value == null || value.isEmpty) {
-      throw StateError('Missing required environment variable: $key');
-    }
-
-    return value;
   }
 }

--- a/packages/bochki_schedule_infra/pubspec.lock
+++ b/packages/bochki_schedule_infra/pubspec.lock
@@ -39,7 +39,7 @@ packages:
       path: "../bochki_schedule_domain"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.2"
   boolean_selector:
     dependency: transitive
     description:

--- a/packages/bochki_schedule_infra/test/bochki_schedule_infra_test.dart
+++ b/packages/bochki_schedule_infra/test/bochki_schedule_infra_test.dart
@@ -9,30 +9,50 @@ void main() {
     expect(bochkiScheduleInfraPackageName, 'bochki_schedule_infra');
   });
 
-  test('platform app data provider uses linux fallback path', () async {
-    final provider = PlatformAppDataDirectoryProvider(
-      appDirectoryName: 'bochki_schedule',
-      environment: const <String, String>{'HOME': '/tmp/test-home'},
+  test('launch data directory resolves linux executable parent', () {
+    final directoryPath = resolveLaunchAppDataDirectoryPath(
+      resolvedExecutable: '/tmp/test-home/bin/bochki_schedule_app',
       operatingSystem: 'linux',
     );
 
-    final directory = await provider.getAppDataDirectory();
-
-    expect(directory.path, '/tmp/test-home/.local/share/bochki_schedule');
+    expect(directoryPath, '/tmp/test-home/bin');
   });
 
-  test('platform app data provider uses APPDATA on windows', () async {
-    final provider = PlatformAppDataDirectoryProvider(
-      appDirectoryName: 'bochki_schedule',
-      environment: const <String, String>{
-        'APPDATA': r'C:\Users\Test\AppData\Roaming'
-      },
+  test('launch data directory resolves windows executable parent', () {
+    final directoryPath = resolveLaunchAppDataDirectoryPath(
+      resolvedExecutable: r'C:\Users\Test\Desktop\bochki_schedule_app.exe',
       operatingSystem: 'windows',
+    );
+
+    expect(directoryPath, r'C:\Users\Test\Desktop');
+  });
+
+  test('launch data directory resolves macos app bundle sibling', () {
+    final directoryPath = resolveLaunchAppDataDirectoryPath(
+      resolvedExecutable:
+          '/Applications/bochki_schedule_app.app/Contents/MacOS/bochki_schedule_app',
+      operatingSystem: 'macos',
+    );
+
+    expect(directoryPath, '/Applications');
+  });
+
+  test('launch app data provider creates directory under launch root',
+      () async {
+    final tempDirectory =
+        await Directory.systemTemp.createTemp('bochki_launch_root_test');
+    addTearDown(() => tempDirectory.delete(recursive: true));
+
+    final provider = LaunchAppDataDirectoryProvider(
+      resolvedExecutable:
+          '${tempDirectory.path}/bochki_schedule_app.app/Contents/MacOS/bochki_schedule_app',
+      operatingSystem: 'macos',
     );
 
     final directory = await provider.getAppDataDirectory();
 
-    expect(directory.path, r'C:\Users\Test\AppData\Roaming/bochki_schedule');
+    expect(directory.path, tempDirectory.path);
+    expect(await directory.exists(), isTrue);
   });
 
   test('file logger appends log lines to file', () async {


### PR DESCRIPTION
Closes #33

Summary:
- switch default storage root to the launch directory instead of user service folders
- add an app-data-dir override for CI and smoke runs
- cover launch-path resolution and bootstrap persistence with tests