### PR TITLE
fix(app): default procedure kind capacity to 1

### DIFF
--- a/packages/bochki_schedule_app/lib/src/features/procedure_kinds/procedure_kind_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_kinds/procedure_kind_dialog.dart
@@ -46,7 +46,7 @@ class _ProcedureKindDialogState extends State<ProcedureKindDialog> {
     _nameController = TextEditingController(text: initialProcedureKind?.name);
     _capacityController = TextEditingController(
       text: initialProcedureKind == null
-          ? ''
+          ? '1'
           : '${initialProcedureKind.capacity}',
     );
     _participantBusyTimeController = TextEditingController(

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -363,6 +363,27 @@ void main() {
     expect(capacityFieldWidth, equals(participantTimeFieldWidth));
   });
 
+  testWidgets('procedure kind create form defaults capacity to 1', (
+    tester,
+  ) async {
+    final context = _buildTestContext();
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await _openProcedureKindsDialog(tester);
+
+    await tester.tap(find.byKey(const Key('procedure_kind_add_button')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('procedure_kind_capacity_field')),
+        matching: find.text('1'),
+      ),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('single click selects row without opening inline edit', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary
- default the procedure kind create form capacity field to 1
- add a widget test that verifies the default value in the create dialog
- closes #42

## Testing
- cd packages/bochki_schedule_app && flutter test
