### PR TITLE
fix: use ProgramSettings in procedure session schedule logic

### DIFF
--- a/packages/bochki_schedule_app/integration_test/app_shell_test.dart
+++ b/packages/bochki_schedule_app/integration_test/app_shell_test.dart
@@ -70,6 +70,7 @@ void main() {
         humansRepository: humansRepository,
         procedureKindsRepository: procedureKindsRepository,
         assistantsRepository: assistantsRepository,
+        programSettingsRepository: programSettingsRepository,
       ),
       updateProcedureSessionUseCase: UpdateProcedureSessionUseCase(
         procedureSessionsRepository,
@@ -77,6 +78,7 @@ void main() {
         humansRepository: humansRepository,
         procedureKindsRepository: procedureKindsRepository,
         assistantsRepository: assistantsRepository,
+        programSettingsRepository: programSettingsRepository,
       ),
       deleteProcedureSessionUseCase:
           DeleteProcedureSessionUseCase(procedureSessionsRepository),

--- a/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
+++ b/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
@@ -169,6 +169,7 @@ final class AppBootstrap {
       humansRepository: humansRepository,
       procedureKindsRepository: procedureKindsRepository,
       assistantsRepository: assistantsRepository,
+      programSettingsRepository: programSettingsRepository,
     );
     final updateProcedureSessionUseCase = UpdateProcedureSessionUseCase(
       procedureSessionsRepository,
@@ -176,6 +177,7 @@ final class AppBootstrap {
       humansRepository: humansRepository,
       procedureKindsRepository: procedureKindsRepository,
       assistantsRepository: assistantsRepository,
+      programSettingsRepository: programSettingsRepository,
     );
     final deleteProcedureSessionUseCase = DeleteProcedureSessionUseCase(
       procedureSessionsRepository,

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/create_procedure_session_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/create_procedure_session_use_case.dart
@@ -1,6 +1,7 @@
 import '../assistants/assistants_repository.dart';
 import '../humans/humans_repository.dart';
 import '../procedure_kinds/procedure_kinds_repository.dart';
+import '../program_settings/program_settings_repository.dart';
 import '../workdays/workdays_repository.dart';
 
 import 'procedure_session_raw.dart';
@@ -14,16 +15,19 @@ final class CreateProcedureSessionUseCase {
     required HumansRepository humansRepository,
     required ProcedureKindsRepository procedureKindsRepository,
     required AssistantsRepository assistantsRepository,
+    required ProgramSettingsRepository programSettingsRepository,
   })  : _workdaysRepository = workdaysRepository,
         _humansRepository = humansRepository,
         _procedureKindsRepository = procedureKindsRepository,
-        _assistantsRepository = assistantsRepository;
+        _assistantsRepository = assistantsRepository,
+        _programSettingsRepository = programSettingsRepository;
 
   final ProcedureSessionsRepository _repository;
   final WorkdaysRepository _workdaysRepository;
   final HumansRepository _humansRepository;
   final ProcedureKindsRepository _procedureKindsRepository;
   final AssistantsRepository _assistantsRepository;
+  final ProgramSettingsRepository _programSettingsRepository;
 
   Future<ProcedureSessionRaw> execute(
       ProcedureSessionRaw procedureSession) async {
@@ -33,6 +37,7 @@ final class CreateProcedureSessionUseCase {
       existingHumans: await _humansRepository.list(),
       existingProcedureKinds: await _procedureKindsRepository.list(),
       existingAssistants: await _assistantsRepository.list(),
+      programSettings: await _programSettingsRepository.get(),
     );
     return _repository.create(validatedProcedureSession);
   }

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_validator.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_validator.dart
@@ -2,9 +2,11 @@ import '../assistants/assistant.dart';
 import '../humans/human.dart';
 import '../procedure_kinds/procedure_kind.dart';
 import '../workdays/workday.dart';
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 
 import 'procedure_session_raw.dart';
 import 'procedure_sessions_validation_exception.dart';
+import 'procedure_session_time.dart';
 
 abstract final class ProcedureSessionValidator {
   static ProcedureSessionRaw validateForSave(
@@ -13,6 +15,7 @@ abstract final class ProcedureSessionValidator {
     required Iterable<Human> existingHumans,
     required Iterable<ProcedureKind> existingProcedureKinds,
     required Iterable<Assistant> existingAssistants,
+    required ProgramSettings programSettings,
   }) {
     final workday = _findWorkday(existingWorkdays, procedureSession.dayId);
     if (workday == null) {
@@ -35,6 +38,11 @@ abstract final class ProcedureSessionValidator {
       throw const ProcedureSessionsValidationException('Выберите процедуру.');
     }
 
+    _validateStartTime(
+      procedureSession.startTime,
+      programSettings: programSettings,
+    );
+
     if (procedureKind.isCurated) {
       if (procedureSession.assistantId == null) {
         throw const ProcedureSessionsValidationException(
@@ -55,6 +63,22 @@ abstract final class ProcedureSessionValidator {
     }
 
     return procedureSession.copyWith(clearAssistantId: true);
+  }
+
+  static void _validateStartTime(
+    String startTime, {
+    required ProgramSettings programSettings,
+  }) {
+    final startMinutes = ProcedureSessionTime.toMinutes(startTime);
+    final minimumStartMinutes = programSettings.minimumHour * 60;
+    final maximumStartMinutes = programSettings.maximumHour * 60 + 55;
+    if (startMinutes < minimumStartMinutes ||
+        startMinutes > maximumStartMinutes) {
+      throw ProcedureSessionsValidationException(
+        'Время начала должно быть в диапазоне '
+        '${_formatTime(minimumStartMinutes)}-${_formatTime(maximumStartMinutes)}.',
+      );
+    }
   }
 
   static void validateId(String procedureSessionId) {
@@ -102,5 +126,11 @@ abstract final class ProcedureSessionValidator {
       }
     }
     return null;
+  }
+
+  static String _formatTime(int totalMinutes) {
+    final hour = (totalMinutes ~/ 60).toString().padLeft(2, '0');
+    final minute = (totalMinutes % 60).toString().padLeft(2, '0');
+    return '$hour:$minute';
   }
 }

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/update_procedure_session_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/update_procedure_session_use_case.dart
@@ -1,6 +1,7 @@
 import '../assistants/assistants_repository.dart';
 import '../humans/humans_repository.dart';
 import '../procedure_kinds/procedure_kinds_repository.dart';
+import '../program_settings/program_settings_repository.dart';
 import '../workdays/workdays_repository.dart';
 
 import 'procedure_session_raw.dart';
@@ -14,16 +15,19 @@ final class UpdateProcedureSessionUseCase {
     required HumansRepository humansRepository,
     required ProcedureKindsRepository procedureKindsRepository,
     required AssistantsRepository assistantsRepository,
+    required ProgramSettingsRepository programSettingsRepository,
   })  : _workdaysRepository = workdaysRepository,
         _humansRepository = humansRepository,
         _procedureKindsRepository = procedureKindsRepository,
-        _assistantsRepository = assistantsRepository;
+        _assistantsRepository = assistantsRepository,
+        _programSettingsRepository = programSettingsRepository;
 
   final ProcedureSessionsRepository _repository;
   final WorkdaysRepository _workdaysRepository;
   final HumansRepository _humansRepository;
   final ProcedureKindsRepository _procedureKindsRepository;
   final AssistantsRepository _assistantsRepository;
+  final ProgramSettingsRepository _programSettingsRepository;
 
   Future<ProcedureSessionRaw> execute(
       ProcedureSessionRaw procedureSession) async {
@@ -33,6 +37,7 @@ final class UpdateProcedureSessionUseCase {
       existingHumans: await _humansRepository.list(),
       existingProcedureKinds: await _procedureKindsRepository.list(),
       existingAssistants: await _assistantsRepository.list(),
+      programSettings: await _programSettingsRepository.get(),
     );
     return _repository.update(validatedProcedureSession);
   }

--- a/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_session_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_session_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 
 import '../../domain/assistants/assistant.dart';
 import '../../domain/humans/human.dart';
@@ -14,6 +15,7 @@ class ProcedureSessionDialog extends StatefulWidget {
     required this.participants,
     required this.procedureKinds,
     required this.assistants,
+    required this.programSettings,
     this.isSaving = false,
     super.key,
   });
@@ -23,6 +25,7 @@ class ProcedureSessionDialog extends StatefulWidget {
   final List<Human> participants;
   final List<ProcedureKind> procedureKinds;
   final List<Assistant> assistants;
+  final ProgramSettings programSettings;
   final bool isSaving;
 
   bool get isEditing => initialValue.id != 'draft';
@@ -40,9 +43,6 @@ class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
   late String _minute;
   String? _formErrorText;
 
-  static final List<String> _hours = [
-    for (int hour = 8; hour <= 20; hour++) hour.toString().padLeft(2, '0'),
-  ];
   static final List<String> _minutes = [
     for (int minute = 0; minute <= 55; minute += 5) '$minute'.padLeft(2, '0'),
   ];
@@ -72,6 +72,28 @@ class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
 
   bool get requiresAssistant => _selectedProcedureKind?.isCurated ?? false;
 
+  List<String> get _hours {
+    final hours = [
+      for (int hour = widget.programSettings.minimumHour;
+          hour <= widget.programSettings.maximumHour;
+          hour++)
+        hour.toString().padLeft(2, '0'),
+    ];
+    if (!hours.contains(_hour)) {
+      hours.add(_hour);
+      hours.sort();
+    }
+    return hours;
+  }
+
+  List<String> get _availableMinutes {
+    if (_minutes.contains(_minute)) {
+      return _minutes;
+    }
+    final minutes = [..._minutes, _minute]..sort();
+    return minutes;
+  }
+
   String get _finishTime {
     final procedureKind = _selectedProcedureKind;
     if (procedureKind == null) {
@@ -81,6 +103,16 @@ class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
       ProcedureSessionTime.toMinutes('$_hour:$_minute') +
           procedureKind.participantBusyTime,
     );
+  }
+
+  String get _scheduleHint {
+    final minimumHour =
+        widget.programSettings.minimumHour.toString().padLeft(2, '0');
+    final maximumHour =
+        widget.programSettings.maximumHour.toString().padLeft(2, '0');
+    return 'Допустимое время начала: $minimumHour:00-$maximumHour:55. '
+        'Обед: с ${_formatSettingsTime(widget.programSettings.lunchStart)} '
+        'до ${_formatSettingsTime(widget.programSettings.lunchEnd)}.';
   }
 
   List<DropdownMenuItem<String>> _buildWorkdayItems() {
@@ -308,6 +340,12 @@ class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
                 ),
               ),
               const SizedBox(height: 12),
+              Text(
+                _scheduleHint,
+                key: const Key('procedure_session_schedule_hint'),
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              const SizedBox(height: 12),
               Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -349,7 +387,7 @@ class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
                               value: _minute,
                               isExpanded: true,
                               items: [
-                                for (final minute in _minutes)
+                                for (final minute in _availableMinutes)
                                   DropdownMenuItem<String>(
                                     value: minute,
                                     child: Text(minute),
@@ -456,6 +494,12 @@ class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
         ),
       ],
     );
+  }
+
+  String _formatSettingsTime(ProgramSettingsTime value) {
+    final hour = value.hour.toString().padLeft(2, '0');
+    final minute = value.minute.toString().padLeft(2, '0');
+    return '$hour:$minute';
   }
 }
 

--- a/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_sessions_view_model.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_sessions_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 
 import '../../domain/assistants/assistant.dart';
 import '../../domain/assistants/list_assistants_use_case.dart';
@@ -6,6 +7,7 @@ import '../../domain/humans/human.dart';
 import '../../domain/humans/list_humans_use_case.dart';
 import '../../domain/procedure_kinds/list_procedure_kinds_use_case.dart';
 import '../../domain/procedure_kinds/procedure_kind.dart';
+import '../../domain/program_settings/get_program_settings_use_case.dart';
 import '../../domain/procedure_sessions/create_procedure_session_use_case.dart';
 import '../../domain/procedure_sessions/delete_procedure_session_use_case.dart';
 import '../../domain/procedure_sessions/list_rich_procedure_sessions_use_case.dart';
@@ -37,6 +39,7 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
     required ListHumansUseCase listHumansUseCase,
     required ListProcedureKindsUseCase listProcedureKindsUseCase,
     required ListAssistantsUseCase listAssistantsUseCase,
+    required GetProgramSettingsUseCase getProgramSettingsUseCase,
   })  : _listRichProcedureSessionsUseCase = listRichProcedureSessionsUseCase,
         _createProcedureSessionUseCase = createProcedureSessionUseCase,
         _updateProcedureSessionUseCase = updateProcedureSessionUseCase,
@@ -44,7 +47,8 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
         _listWorkdaysUseCase = listWorkdaysUseCase,
         _listHumansUseCase = listHumansUseCase,
         _listProcedureKindsUseCase = listProcedureKindsUseCase,
-        _listAssistantsUseCase = listAssistantsUseCase;
+        _listAssistantsUseCase = listAssistantsUseCase,
+        _getProgramSettingsUseCase = getProgramSettingsUseCase;
 
   final ListRichProcedureSessionsUseCase _listRichProcedureSessionsUseCase;
   final CreateProcedureSessionUseCase _createProcedureSessionUseCase;
@@ -54,12 +58,14 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
   final ListHumansUseCase _listHumansUseCase;
   final ListProcedureKindsUseCase _listProcedureKindsUseCase;
   final ListAssistantsUseCase _listAssistantsUseCase;
+  final GetProgramSettingsUseCase _getProgramSettingsUseCase;
 
   List<ProcedureSessionRich> _allEntries = const [];
   List<Workday> _workdays = const [];
   List<Human> _participants = const [];
   List<ProcedureKind> _procedureKinds = const [];
   List<Assistant> _assistants = const [];
+  ProgramSettings _programSettings = ProgramSettings.defaults;
   bool _isLoading = false;
   bool _isSaving = false;
   String? _loadErrorMessage;
@@ -77,6 +83,7 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
   List<Human> get participants => _participants;
   List<ProcedureKind> get procedureKinds => _procedureKinds;
   List<Assistant> get assistants => _assistants;
+  ProgramSettings get programSettings => _programSettings;
   bool get isLoading => _isLoading;
   bool get isSaving => _isSaving;
   String? get loadErrorMessage => _loadErrorMessage;
@@ -94,6 +101,7 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
+      _programSettings = await _getProgramSettingsUseCase.execute();
       _workdays = await _listWorkdaysUseCase.execute();
       _participants = (await _listHumansUseCase.execute())
           .where((human) => human.isParticipant)
@@ -193,7 +201,8 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
       participantId: _participants.isEmpty
           ? 'missing-participant'
           : _participants.first.id,
-      startTime: '08:00',
+      startTime:
+          '${_programSettings.minimumHour.toString().padLeft(2, '0')}:00',
       procedureKindId: firstProcedureKind == null
           ? 'missing-procedure'
           : firstProcedureKind.id,
@@ -206,6 +215,7 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
   }
 
   Future<void> _reloadEntries() async {
+    _programSettings = await _getProgramSettingsUseCase.execute();
     _allEntries = await _listRichProcedureSessionsUseCase.execute();
     _workdays = await _listWorkdaysUseCase.execute();
     _participants = (await _listHumansUseCase.execute())
@@ -250,16 +260,18 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
         return false;
       }
       final startMinutes = ProcedureSessionTime.toMinutes(entry.startTime);
+      final lunchStartMinutes = _programSettings.lunchStart.hour * 60 +
+          _programSettings.lunchStart.minute;
       switch (_partOfDayFilter) {
         case ProcedureSessionsPartOfDayFilter.fullDay:
           break;
         case ProcedureSessionsPartOfDayFilter.beforeLunch:
-          if (startMinutes >= 13 * 60) {
+          if (startMinutes >= lunchStartMinutes) {
             return false;
           }
           break;
         case ProcedureSessionsPartOfDayFilter.afterLunch:
-          if (startMinutes < 13 * 60) {
+          if (startMinutes < lunchStartMinutes) {
             return false;
           }
           break;

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -65,6 +65,7 @@ class _BochkiShellState extends State<BochkiShell> {
       listHumansUseCase: widget.services.listHumansUseCase,
       listProcedureKindsUseCase: widget.services.listProcedureKindsUseCase,
       listAssistantsUseCase: widget.services.listAssistantsUseCase,
+      getProgramSettingsUseCase: widget.services.getProgramSettingsUseCase,
     );
     unawaited(_procedureSessionsViewModel.load());
   }
@@ -244,6 +245,7 @@ class _BochkiShellState extends State<BochkiShell> {
       );
     } finally {
       viewModel.dispose();
+      unawaited(_procedureSessionsViewModel.load());
       if (mounted) {
         setState(() {
           _programSettingsDialogOpen = false;
@@ -291,6 +293,7 @@ class _BochkiShellState extends State<BochkiShell> {
           participants: _procedureSessionsViewModel.participants,
           procedureKinds: _procedureSessionsViewModel.procedureKinds,
           assistants: _procedureSessionsViewModel.assistants,
+          programSettings: _procedureSessionsViewModel.programSettings,
           isSaving: _procedureSessionsViewModel.isSaving,
         );
       },

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -228,7 +228,7 @@ void main() {
           id: '1',
           dayId: '1',
           participantId: '1',
-          startTime: '09:00',
+          startTime: '12:55',
           procedureKindId: '1',
           assistantId: '2',
         ),
@@ -241,6 +241,12 @@ void main() {
           assistantId: '2',
         ),
       ],
+      programSettings: const ProgramSettings(
+        lunchStart: ProgramSettingsTime(hour: 13, minute: 0),
+        lunchEnd: ProgramSettingsTime(hour: 14, minute: 0),
+        minimumHour: 8,
+        maximumHour: 20,
+      ),
     );
 
     await tester.pumpWidget(BochkiScheduleApp(services: context.services));
@@ -248,6 +254,74 @@ void main() {
 
     expect(find.byKey(const Key('procedure_session_row_1')), findsOneWidget);
     expect(find.byKey(const Key('procedure_session_row_2')), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const Key('procedure_sessions_part_of_day_filter')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('До обеда').last);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('procedure_session_row_1')), findsOneWidget);
+    expect(find.byKey(const Key('procedure_session_row_2')), findsNothing);
+  });
+
+  testWidgets(
+      'procedure sessions uses custom lunch start for part of day filter',
+      (tester) async {
+    final context = _buildTestContext(
+      participants: [
+        Participant(id: '1', name: 'Иван'),
+      ],
+      assistants: [
+        Assistant(id: '2', name: 'Петр'),
+      ],
+      procedureKinds: [
+        ProcedureKind(
+          id: '1',
+          patternId: ProcedureKindPatterns.curated.patternId,
+          name: 'Бочка',
+          capacity: 6,
+          participantBusyTime: 30,
+          assistantBusyTime: 10,
+          resourceBusyTime: 5,
+        ),
+      ],
+      workdays: [
+        Workday(
+          id: '1',
+          name: 'День А',
+          calendarDate: DateTime(2026, 7, 11),
+        ),
+      ],
+      procedureSessions: [
+        ProcedureSessionRaw(
+          id: '1',
+          dayId: '1',
+          participantId: '1',
+          startTime: '13:55',
+          procedureKindId: '1',
+          assistantId: '2',
+        ),
+        ProcedureSessionRaw(
+          id: '2',
+          dayId: '1',
+          participantId: '1',
+          startTime: '14:00',
+          procedureKindId: '1',
+          assistantId: '2',
+        ),
+      ],
+      programSettings: const ProgramSettings(
+        lunchStart: ProgramSettingsTime(hour: 14, minute: 0),
+        lunchEnd: ProgramSettingsTime(hour: 15, minute: 0),
+        minimumHour: 8,
+        maximumHour: 20,
+      ),
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
 
     await tester.tap(
       find.byKey(const Key('procedure_sessions_part_of_day_filter')),
@@ -336,6 +410,83 @@ void main() {
       context.procedureSessionsRepository.sessions.single.startTime,
       '10:30',
     );
+  });
+
+  testWidgets(
+      'procedure sessions blocks saving existing record outside configured start range',
+      (tester) async {
+    final context = _buildTestContext(
+      participants: [
+        Participant(id: '1', name: 'Иван'),
+      ],
+      assistants: [
+        Assistant(id: '2', name: 'Петр'),
+      ],
+      procedureKinds: [
+        ProcedureKind(
+          id: '1',
+          patternId: ProcedureKindPatterns.curated.patternId,
+          name: 'Бочка',
+          capacity: 6,
+          participantBusyTime: 30,
+          assistantBusyTime: 10,
+          resourceBusyTime: 5,
+        ),
+      ],
+      workdays: [
+        Workday(
+          id: '1',
+          name: 'День А',
+          calendarDate: DateTime(2026, 7, 11),
+        ),
+      ],
+      procedureSessions: [
+        ProcedureSessionRaw(
+          id: '1',
+          dayId: '1',
+          participantId: '1',
+          startTime: '09:00',
+          procedureKindId: '1',
+          assistantId: '2',
+        ),
+      ],
+      programSettings: const ProgramSettings(
+        lunchStart: ProgramSettingsTime(hour: 14, minute: 0),
+        lunchEnd: ProgramSettingsTime(hour: 15, minute: 0),
+        minimumHour: 10,
+        maximumHour: 18,
+      ),
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+
+    await _doubleMouseClick(
+      tester,
+      find.byKey(const Key('procedure_session_row_1')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('procedure_session_schedule_hint')),
+      findsOneWidget,
+    );
+    expect(
+      find.text(
+        'Допустимое время начала: 10:00-18:55. Обед: с 14:00 до 15:00.',
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('procedure_session_save_button')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Время начала должно быть в диапазоне 10:00-18:55.'),
+      findsOneWidget,
+    );
+    expect(
+        context.procedureSessionsRepository.sessions.single.startTime, '09:00');
   });
 
   testWidgets('procedure kinds dialog shows updated table headers', (
@@ -1096,6 +1247,7 @@ _TestContext _buildTestContext({
         humansRepository: humansRepository,
         procedureKindsRepository: procedureKindsRepository,
         assistantsRepository: assistantsRepository,
+        programSettingsRepository: programSettingsRepository,
       ),
       updateProcedureSessionUseCase: UpdateProcedureSessionUseCase(
         procedureSessionsRepository,
@@ -1103,6 +1255,7 @@ _TestContext _buildTestContext({
         humansRepository: humansRepository,
         procedureKindsRepository: procedureKindsRepository,
         assistantsRepository: assistantsRepository,
+        programSettingsRepository: programSettingsRepository,
       ),
       deleteProcedureSessionUseCase:
           DeleteProcedureSessionUseCase(procedureSessionsRepository),

--- a/packages/bochki_schedule_app/test/domain/procedure_sessions/procedure_sessions_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/procedure_sessions/procedure_sessions_use_cases_test.dart
@@ -1,4 +1,5 @@
 import 'package:bochki_schedule_app/bochki_schedule_app.dart';
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -9,6 +10,7 @@ void main() {
       final humansRepository = _InMemoryHumansRepository();
       final procedureKindsRepository = _InMemoryProcedureKindsRepository();
       final assistantsRepository = _InMemoryAssistantsRepository();
+      final programSettingsRepository = _InMemoryProgramSettingsRepository();
 
       final created = await CreateProcedureSessionUseCase(
         repository,
@@ -16,6 +18,7 @@ void main() {
         humansRepository: humansRepository,
         procedureKindsRepository: procedureKindsRepository,
         assistantsRepository: assistantsRepository,
+        programSettingsRepository: programSettingsRepository,
       ).execute(
         ProcedureSessionRaw(
           id: 'draft',
@@ -36,6 +39,7 @@ void main() {
       final humansRepository = _InMemoryHumansRepository();
       final procedureKindsRepository = _InMemoryProcedureKindsRepository();
       final assistantsRepository = _InMemoryAssistantsRepository();
+      final programSettingsRepository = _InMemoryProgramSettingsRepository();
 
       expect(
         () => CreateProcedureSessionUseCase(
@@ -44,6 +48,7 @@ void main() {
           humansRepository: humansRepository,
           procedureKindsRepository: procedureKindsRepository,
           assistantsRepository: assistantsRepository,
+          programSettingsRepository: programSettingsRepository,
         ).execute(
           ProcedureSessionRaw(
             id: 'draft',
@@ -95,6 +100,59 @@ void main() {
       final sorted = await ListProcedureSessionsUseCase(repository).execute();
 
       expect(sorted.map((entry) => entry.id), ['1', '2', '3']);
+    });
+
+    test('create rejects start time before minimum hour', () async {
+      final repository = _InMemoryProcedureSessionsRepository();
+
+      expect(
+        () => CreateProcedureSessionUseCase(
+          repository,
+          workdaysRepository: _InMemoryWorkdaysRepository(),
+          humansRepository: _InMemoryHumansRepository(),
+          procedureKindsRepository: _InMemoryProcedureKindsRepository(),
+          assistantsRepository: _InMemoryAssistantsRepository(),
+          programSettingsRepository: _InMemoryProgramSettingsRepository(),
+        ).execute(
+          ProcedureSessionRaw(
+            id: 'draft',
+            dayId: '1',
+            participantId: '1',
+            startTime: '07:55',
+            procedureKindId: '2',
+          ),
+        ),
+        throwsA(
+          isA<ProcedureSessionsValidationException>().having(
+            (error) => error.message,
+            'message',
+            'Время начала должно быть в диапазоне 08:00-20:55.',
+          ),
+        ),
+      );
+    });
+
+    test('create allows start time at maximum hour minute 55', () async {
+      final repository = _InMemoryProcedureSessionsRepository();
+
+      final created = await CreateProcedureSessionUseCase(
+        repository,
+        workdaysRepository: _InMemoryWorkdaysRepository(),
+        humansRepository: _InMemoryHumansRepository(),
+        procedureKindsRepository: _InMemoryProcedureKindsRepository(),
+        assistantsRepository: _InMemoryAssistantsRepository(),
+        programSettingsRepository: _InMemoryProgramSettingsRepository(),
+      ).execute(
+        ProcedureSessionRaw(
+          id: 'draft',
+          dayId: '1',
+          participantId: '1',
+          startTime: '20:55',
+          procedureKindId: '2',
+        ),
+      );
+
+      expect(created.startTime, '20:55');
     });
 
     test('rich model computes finish time', () {
@@ -346,4 +404,13 @@ final class _InMemoryAssistantsRepository implements AssistantsRepository {
 
   @override
   Future<Assistant> update(Assistant entry) async => entry;
+}
+
+final class _InMemoryProgramSettingsRepository
+    implements ProgramSettingsRepository {
+  @override
+  Future<ProgramSettings> get() async => ProgramSettings.defaults;
+
+  @override
+  Future<ProgramSettings> update(ProgramSettings settings) async => settings;
 }

--- a/packages/bochki_schedule_app/test/features/procedure_sessions/procedure_session_dialog_test.dart
+++ b/packages/bochki_schedule_app/test/features/procedure_sessions/procedure_session_dialog_test.dart
@@ -1,0 +1,76 @@
+import 'package:bochki_schedule_app/bochki_schedule_app.dart';
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('dialog shows settings-driven hint and hour options', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ProcedureSessionDialog(
+            initialValue: ProcedureSessionRaw(
+              id: 'draft',
+              dayId: '1',
+              participantId: '1',
+              startTime: '10:00',
+              procedureKindId: '1',
+              assistantId: '2',
+            ),
+            workdays: [
+              Workday(
+                id: '1',
+                name: 'День 1',
+                calendarDate: DateTime(2026, 7, 11),
+              ),
+            ],
+            participants: [
+              Human(
+                id: '1',
+                name: 'Иван',
+                isParticipant: true,
+                isAssistant: false,
+              ),
+            ],
+            procedureKinds: [
+              ProcedureKind(
+                id: '1',
+                patternId: ProcedureKindPatterns.curated.patternId,
+                name: 'Бочка',
+                capacity: 6,
+                participantBusyTime: 30,
+                assistantBusyTime: 10,
+              ),
+            ],
+            assistants: [
+              Assistant(id: '2', name: 'Петр'),
+            ],
+            programSettings: const ProgramSettings(
+              lunchStart: ProgramSettingsTime(hour: 13, minute: 30),
+              lunchEnd: ProgramSettingsTime(hour: 14, minute: 30),
+              minimumHour: 10,
+              maximumHour: 12,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.text(
+        'Допустимое время начала: 10:00-12:55. Обед: с 13:30 до 14:30.',
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('procedure_session_hour_field')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('10').last, findsOneWidget);
+    expect(find.text('11').last, findsOneWidget);
+    expect(find.text('12').last, findsOneWidget);
+    expect(find.text('09'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- use persisted ProgramSettings for procedure session validation, filtering, and dialog defaults
- replace hardcoded procedure session time boundaries with settings-driven UI hints and hour options
- add domain, widget, and app tests for schedule range and lunch filter behavior

Closes #56