### PR TITLE
fix(app): make procedure session row selection instant

### DIFF
--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import '../../app_services.dart';
@@ -643,6 +644,13 @@ class _ProcedureSessionsTable extends StatelessWidget {
   final void Function(String entryId) onEdit;
   final void Function(String entryId) onDelete;
 
+  void _handleRowPointerDown(String entryId, PointerDownEvent event) {
+    if (event.buttons != kPrimaryMouseButton) {
+      return;
+    }
+    viewModel.selectEntry(entryId);
+  }
+
   @override
   Widget build(BuildContext context) {
     final entries = viewModel.entries;
@@ -683,53 +691,60 @@ class _ProcedureSessionsTable extends StatelessWidget {
             itemBuilder: (context, index) {
               final entry = entries[index];
               final isSelected = viewModel.selectedEntryId == entry.id;
-              return GestureDetector(
-                key: Key('procedure_session_row_${entry.id}'),
-                onTap: () => viewModel.selectEntry(entry.id),
-                onDoubleTap: () => onEdit(entry.id),
-                child: Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-                  decoration: BoxDecoration(
-                    color: isSelected
-                        ? const Color(0xFFE7F1FB)
-                        : const Color(0xFFFBFCFD),
-                    borderRadius: BorderRadius.circular(10),
-                    border: Border.all(
-                      color: isSelected
-                          ? const Color(0xFF7AA7D9)
-                          : const Color(0xFFDCE3EA),
+              return Listener(
+                onPointerDown: (event) =>
+                    _handleRowPointerDown(entry.id, event),
+                child: GestureDetector(
+                  key: Key('procedure_session_row_${entry.id}'),
+                  onTap: () => viewModel.selectEntry(entry.id),
+                  onDoubleTap: () => onEdit(entry.id),
+                  child: Container(
+                    key: Key('procedure_session_row_content_${entry.id}'),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 10,
                     ),
-                  ),
-                  child: Row(
-                    children: [
-                      _ValueCell(flex: 2, text: _dayText(entry)),
-                      _ValueCell(flex: 2, text: _participantText(entry)),
-                      _ValueCell(flex: 1, text: entry.startTime),
-                      _ValueCell(flex: 1, text: entry.finishTime ?? ''),
-                      _ValueCell(
-                        flex: 2,
-                        text: _procedureText(entry),
+                    decoration: BoxDecoration(
+                      color: isSelected
+                          ? const Color(0xFFE7F1FB)
+                          : const Color(0xFFFBFCFD),
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(
+                        color: isSelected
+                            ? const Color(0xFF7AA7D9)
+                            : const Color(0xFFDCE3EA),
                       ),
-                      _ValueCell(
-                        flex: 2,
-                        text: _assistantText(entry),
-                      ),
-                      Expanded(
-                        child: TextButton(
-                          key: Key('procedure_session_edit_${entry.id}'),
-                          onPressed: () => onEdit(entry.id),
-                          child: const Text('Изм.'),
+                    ),
+                    child: Row(
+                      children: [
+                        _ValueCell(flex: 2, text: _dayText(entry)),
+                        _ValueCell(flex: 2, text: _participantText(entry)),
+                        _ValueCell(flex: 1, text: entry.startTime),
+                        _ValueCell(flex: 1, text: entry.finishTime ?? ''),
+                        _ValueCell(
+                          flex: 2,
+                          text: _procedureText(entry),
                         ),
-                      ),
-                      Expanded(
-                        child: TextButton(
-                          key: Key('procedure_session_delete_${entry.id}'),
-                          onPressed: () => onDelete(entry.id),
-                          child: const Text('Удл.'),
+                        _ValueCell(
+                          flex: 2,
+                          text: _assistantText(entry),
                         ),
-                      ),
-                    ],
+                        Expanded(
+                          child: TextButton(
+                            key: Key('procedure_session_edit_${entry.id}'),
+                            onPressed: () => onEdit(entry.id),
+                            child: const Text('Изм.'),
+                          ),
+                        ),
+                        Expanded(
+                          child: TextButton(
+                            key: Key('procedure_session_delete_${entry.id}'),
+                            onPressed: () => onDelete(entry.id),
+                            child: const Text('Удл.'),
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               );

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -489,6 +489,78 @@ void main() {
         context.procedureSessionsRepository.sessions.single.startTime, '09:00');
   });
 
+  testWidgets(
+    'procedure sessions row becomes selected on mouse down before tap completes',
+    (tester) async {
+      final context = _buildTestContext(
+        participants: [
+          Participant(id: '1', name: 'Иван'),
+        ],
+        assistants: [
+          Assistant(id: '2', name: 'Петр'),
+        ],
+        procedureKinds: [
+          ProcedureKind(
+            id: '1',
+            patternId: ProcedureKindPatterns.curated.patternId,
+            name: 'Бочка',
+            capacity: 6,
+            participantBusyTime: 30,
+            assistantBusyTime: 10,
+            resourceBusyTime: 5,
+          ),
+        ],
+        workdays: [
+          Workday(
+            id: '1',
+            name: 'День А',
+            calendarDate: DateTime(2026, 7, 11),
+          ),
+        ],
+        procedureSessions: [
+          ProcedureSessionRaw(
+            id: '1',
+            dayId: '1',
+            participantId: '1',
+            startTime: '09:00',
+            procedureKindId: '1',
+            assistantId: '2',
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+      await tester.pumpAndSettle();
+
+      final row = find.byKey(const Key('procedure_session_row_1'));
+      final rowContent =
+          find.byKey(const Key('procedure_session_row_content_1'));
+      final gesture = await tester.createGesture(
+        kind: PointerDeviceKind.mouse,
+        buttons: kPrimaryMouseButton,
+      );
+      final center = tester.getCenter(row);
+
+      await gesture.addPointer(location: center);
+      await gesture.moveTo(center);
+      await tester.pump();
+      await gesture.down(center);
+      await tester.pump();
+
+      final container = tester.widget<Container>(rowContent);
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.color, const Color(0xFFE7F1FB));
+      expect(
+        find.byKey(const Key('procedure_session_edit_dialog')),
+        findsNothing,
+      );
+
+      await gesture.up();
+      await gesture.removePointer();
+      await tester.pump(const Duration(milliseconds: 50));
+    },
+  );
+
   testWidgets('procedure kinds dialog shows updated table headers', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary
- make procedure session row selection update on primary pointer down
- preserve double-click editing behavior for assigned procedure rows
- add regression coverage for mouse-down selection before tap completion

## Testing
- cd packages/bochki_schedule_app && flutter test

Closes #59