### PR TITLE
fix(app): support sandboxed macOS startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ fvm flutter run -d windows
 make windows-release
 ```
 
-По умолчанию desktop-сборка хранит `project.json` и `logs/app.log` рядом с файлом запуска.
+По умолчанию Windows-сборка хранит `project.json` и `logs/app.log` рядом с файлом запуска.
+macOS-сборка хранит их в Application Support приложения (в sandbox-контейнере:
+`~/Library/Containers/com.alekseibq.bochkiScheduleApp/Data/Library/Application Support/bochki_schedule_app/`).
 Если нужен явный путь для CI или локального smoke-run, передайте `--app-data-dir=<path>`.
 
 ## Команды workspace

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,7 +45,8 @@ For local Linux desktop integration runs, install:
 
 ## Desktop Launch Path
 
-When the desktop app is launched without arguments, it stores `project.json` in the same folder as the launched binary or macOS bundle location.
+When the app is launched without arguments, Windows stores `project.json` next to the launched binary.
+On macOS, it stores `project.json` in the app's Application Support directory inside the sandbox container.
 For CI or local smoke runs, pass `--app-data-dir=<path>` so the app writes into an explicit temporary directory.
 
 ## macOS Release Artifacts

--- a/packages/bochki_schedule_app/lib/main.dart
+++ b/packages/bochki_schedule_app/lib/main.dart
@@ -47,7 +47,7 @@ Future<void> main(List<String> args) async {
       error: error,
       stackTrace: stackTrace,
     );
-    runApp(const StartupErrorApp());
+    runApp(StartupErrorApp(error: error));
   }
 }
 

--- a/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
+++ b/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
 import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 
 import 'app_services.dart';
 import 'data/humans/project_document_humans_repository.dart';
@@ -51,8 +52,8 @@ final class AppBootstrap {
   static Future<AppServices> initialize({
     Directory? appDataDirectory,
   }) async {
-    final resolvedAppDataDirectory = appDataDirectory ??
-        await LaunchAppDataDirectoryProvider().getAppDataDirectory();
+    final resolvedAppDataDirectory =
+        appDataDirectory ?? await _resolveDefaultAppDataDirectory();
     final logger = FileAppLogger(
       logFile: File(p.join(resolvedAppDataDirectory.path, 'logs', 'app.log')),
     );
@@ -273,5 +274,19 @@ final class AppBootstrap {
       flushPending: syncCoordinator.flushPending,
       shutdown: syncCoordinator.shutdown,
     );
+  }
+
+  static Future<Directory> _resolveDefaultAppDataDirectory() async {
+    if (Platform.isMacOS) {
+      final applicationSupportDirectory =
+          await getApplicationSupportDirectory();
+      final directory = Directory(
+        p.join(applicationSupportDirectory.path, 'bochki_schedule_app'),
+      );
+      await directory.create(recursive: true);
+      return directory;
+    }
+
+    return LaunchAppDataDirectoryProvider().getAppDataDirectory();
   }
 }

--- a/packages/bochki_schedule_app/lib/src/presentation/startup_error_app.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/startup_error_app.dart
@@ -1,7 +1,32 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
+String describeStartupError(Object error) {
+  if (error is FileSystemException) {
+    final path = error.path;
+    final fileDescription = path == null || path.isEmpty
+        ? 'файлу или папке приложения'
+        : 'пути:\n$path';
+    return 'Не удалось получить доступ к $fileDescription.\n${error.message}';
+  }
+
+  if (error is FormatException) {
+    return 'Не удалось прочитать файл данных приложения. '
+        'Возможно, project.json повреждён или имеет неподдерживаемый формат.\n'
+        '${error.message}';
+  }
+
+  return error.toString();
+}
+
 class StartupErrorApp extends StatelessWidget {
-  const StartupErrorApp({super.key});
+  const StartupErrorApp({
+    required this.error,
+    super.key,
+  });
+
+  final Object error;
 
   @override
   Widget build(BuildContext context) {
@@ -19,16 +44,16 @@ class StartupErrorApp extends StatelessWidget {
               borderRadius: BorderRadius.circular(18),
               border: Border.all(color: const Color(0xFFD0D7DE)),
             ),
-            child: const Column(
+            child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Icon(
+                const Icon(
                   Icons.error_outline,
                   size: 48,
                   color: Color(0xFFB00020),
                 ),
-                SizedBox(height: 16),
-                Text(
+                const SizedBox(height: 16),
+                const Text(
                   'Не удалось запустить приложение',
                   textAlign: TextAlign.center,
                   style: TextStyle(
@@ -36,10 +61,30 @@ class StartupErrorApp extends StatelessWidget {
                     fontWeight: FontWeight.w700,
                   ),
                 ),
-                SizedBox(height: 12),
-                Text(
-                  'Произошла критическая ошибка во время запуска. Подробности смотрите в логах приложения.',
+                const SizedBox(height: 12),
+                const Text(
+                  'Произошла критическая ошибка во время запуска.',
                   textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 20),
+                Container(
+                  width: double.infinity,
+                  constraints: const BoxConstraints(maxHeight: 180),
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFFFF4F4),
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: const Color(0xFFF0BBBB)),
+                  ),
+                  child: SingleChildScrollView(
+                    child: SelectableText(
+                      describeStartupError(error),
+                      style: const TextStyle(
+                        color: Color(0xFF7A1C1C),
+                        fontFamily: 'monospace',
+                      ),
+                    ),
+                  ),
                 ),
               ],
             ),

--- a/packages/bochki_schedule_app/pubspec.lock
+++ b/packages/bochki_schedule_app/pubspec.lock
@@ -192,6 +192,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "4adf4fd5423ec60a29506c76581bc05854c55e3a0b72d35bb28d661c9686edf2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.15"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   platform:
     dependency: transitive
     description:
@@ -357,6 +405,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.3"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=3.5.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.24.0"

--- a/packages/bochki_schedule_app/pubspec.yaml
+++ b/packages/bochki_schedule_app/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   path: ^1.9.0
+  path_provider: ^2.1.5
   window_manager: ^0.4.3
 
 dev_dependencies:

--- a/packages/bochki_schedule_app/test/presentation/startup_error_app_test.dart
+++ b/packages/bochki_schedule_app/test/presentation/startup_error_app_test.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+
+import 'package:bochki_schedule_app/src/presentation/startup_error_app.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('describes a file system startup error with its path', () {
+    final description = describeStartupError(
+      const FileSystemException('Operation not permitted', '/Applications'),
+    );
+
+    expect(description, contains('Не удалось получить доступ'));
+    expect(description, contains('/Applications'));
+    expect(description, contains('Operation not permitted'));
+  });
+
+  test('describes a malformed project document', () {
+    final description = describeStartupError(
+      const FormatException('Unexpected character'),
+    );
+
+    expect(description, contains('project.json'));
+    expect(description, contains('Unexpected character'));
+  });
+}


### PR DESCRIPTION
## Summary
- store macOS app data in Application Support instead of beside the app bundle
- show startup failure details directly in the UI
- keep Windows launch-directory storage unchanged

## Tests
- flutter test test/presentation/startup_error_app_test.dart test/app_bootstrap_test.dart
- flutter analyze