### PR TITLE
feat(app): add startup diagnostics screen

### DIFF
--- a/packages/bochki_schedule_app/lib/main.dart
+++ b/packages/bochki_schedule_app/lib/main.dart
@@ -7,47 +7,65 @@ import 'package:flutter/widgets.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'src/app_launch_arguments.dart';
-import 'src/presentation/startup_error_app.dart';
+import 'src/presentation/startup_diagnostics.dart';
+import 'src/presentation/startup_launcher.dart';
 
 Future<void> main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
-  await _configureWindow();
+  final diagnostics = StartupDiagnostics();
+  final errorReporter = _ApplicationErrorReporter(diagnostics);
+  FlutterError.onError = errorReporter.recordFlutterError;
+  PlatformDispatcher.instance.onError = errorReporter.recordPlatformError;
 
-  AppServices? services;
+  runApp(
+    StartupLauncher(
+      diagnostics: diagnostics,
+      configureWindow: _configureWindow,
+      bootstrap: (diagnostics) => AppBootstrap.initialize(
+        appDataDirectory: resolveAppDataDirectoryOverride(args),
+        diagnostics: diagnostics,
+      ),
+      onServicesReady: errorReporter.attachServices,
+    ),
+  );
+}
 
-  try {
-    services = await AppBootstrap.initialize(
-      appDataDirectory: resolveAppDataDirectoryOverride(args),
+final class _ApplicationErrorReporter {
+  _ApplicationErrorReporter(this._diagnostics);
+
+  final StartupDiagnostics _diagnostics;
+  AppServices? _services;
+
+  void attachServices(AppServices services) {
+    _services = services;
+  }
+
+  void recordFlutterError(FlutterErrorDetails details) {
+    FlutterError.presentError(details);
+    _diagnostics.error(
+      'Flutter framework',
+      details.exception,
+      details.stack ?? StackTrace.current,
     );
-    FlutterError.onError = (details) {
-      FlutterError.presentError(details);
-      unawaited(
-        services?.logger.error(
-          'Flutter framework error',
-          error: details.exception,
-          stackTrace: details.stack,
-        ),
-      );
-    };
-    PlatformDispatcher.instance.onError = (error, stackTrace) {
-      unawaited(
-        services?.logger.error(
-          'Unhandled platform error',
-          error: error,
-          stackTrace: stackTrace,
-        ),
-      );
-      return true;
-    };
-
-    runApp(BochkiScheduleApp(services: services));
-  } catch (error, stackTrace) {
-    await services?.logger.error(
-      'Application bootstrap failed',
-      error: error,
-      stackTrace: stackTrace,
+    unawaited(
+      _services?.logger.error(
+        'Flutter framework error',
+        error: details.exception,
+        stackTrace: details.stack,
+      ),
     );
-    runApp(StartupErrorApp(error: error));
+  }
+
+  bool recordPlatformError(Object error, StackTrace stackTrace) {
+    _diagnostics.error('Платформа', error, stackTrace);
+    unawaited(
+      _services?.logger.error(
+        'Unhandled platform error',
+        error: error,
+        stackTrace: stackTrace,
+      ),
+    );
+    return true;
   }
 }
 

--- a/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
+++ b/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 import 'app_services.dart';
+import 'presentation/startup_diagnostics.dart';
 import 'data/humans/project_document_humans_repository.dart';
 import 'data/print_preset_params/project_document_print_preset_params_repository.dart';
 import 'data/print_schedule/docx_print_schedule_exporter.dart';
@@ -51,17 +52,33 @@ import 'domain/workdays/update_workday_use_case.dart';
 final class AppBootstrap {
   static Future<AppServices> initialize({
     Directory? appDataDirectory,
+    StartupDiagnostics? diagnostics,
   }) async {
+    diagnostics?.info('Bootstrap', 'Определение каталога данных приложения.');
     final resolvedAppDataDirectory =
-        appDataDirectory ?? await _resolveDefaultAppDataDirectory();
+        appDataDirectory ?? await _resolveDefaultAppDataDirectory(diagnostics);
+    diagnostics?.info(
+      'Каталог данных',
+      'Каталог данных: ${resolvedAppDataDirectory.path}',
+    );
+    diagnostics?.info(
+        'Каталог данных', 'Проверка доступности каталога данных.');
+    await resolvedAppDataDirectory.create(recursive: true);
+    diagnostics?.info('Каталог данных', 'Каталог данных доступен.');
+    diagnostics?.info('Логирование', 'Подготовка файла журнала запуска.');
     final logger = FileAppLogger(
       logFile: File(p.join(resolvedAppDataDirectory.path, 'logs', 'app.log')),
+    );
+    diagnostics?.info(
+      'Данные проекта',
+      'Чтение файла: ${p.join(resolvedAppDataDirectory.path, 'project.json')}',
     );
     final projectDocumentRepository = JsonProjectDocumentRepository(
       projectFile: File(p.join(resolvedAppDataDirectory.path, 'project.json')),
       safeFileWriter: const AtomicFileWriter(),
     );
     final initialDocument = await projectDocumentRepository.load();
+    diagnostics?.info('Данные проекта', 'Файл данных успешно прочитан.');
     final syncCoordinator = ProjectDocumentSyncCoordinator(
       repository: projectDocumentRepository,
       initialDocument: initialDocument,
@@ -117,11 +134,13 @@ final class AppBootstrap {
     final didNormalizeLegacyProcedureKinds =
         await procedureKindsRepository.normalizeLegacyResourceBusyTimes();
     if (didNormalizeLegacyProcedureKinds) {
+      diagnostics?.info('Миграция данных', 'Нормализация устаревших данных.');
       await logger.info(
         'Normalized legacy procedure kinds resourceBusyTime values.',
       );
       await syncCoordinator.flushPending();
     }
+    diagnostics?.info('Сервисы', 'Создание сервисов приложения.');
     final listHumansUseCase = ListHumansUseCase(humansRepository);
     final listParticipantsUseCase = ListParticipantsUseCase(
       participantsRepository,
@@ -237,6 +256,8 @@ final class AppBootstrap {
     await logger.info(
       'Bootstrap completed. appDataDirectory=${resolvedAppDataDirectory.path}',
     );
+    diagnostics?.info(
+        'Bootstrap', 'Инициализация приложения завершена успешно.');
 
     return AppServices(
       appDataDirectory: resolvedAppDataDirectory,
@@ -276,8 +297,12 @@ final class AppBootstrap {
     );
   }
 
-  static Future<Directory> _resolveDefaultAppDataDirectory() async {
+  static Future<Directory> _resolveDefaultAppDataDirectory(
+    StartupDiagnostics? diagnostics,
+  ) async {
     if (Platform.isMacOS) {
+      diagnostics?.info(
+          'Каталог данных', 'Получение каталога Application Support macOS.');
       final applicationSupportDirectory =
           await getApplicationSupportDirectory();
       final directory = Directory(
@@ -287,6 +312,8 @@ final class AppBootstrap {
       return directory;
     }
 
+    diagnostics?.info(
+        'Каталог данных', 'Получение системного каталога данных.');
     return LaunchAppDataDirectoryProvider().getAppDataDirectory();
   }
 }

--- a/packages/bochki_schedule_app/lib/src/presentation/startup_diagnostics.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/startup_diagnostics.dart
@@ -1,0 +1,100 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+enum StartupDiagnosticLevel { info, error }
+
+final class StartupDiagnosticEntry {
+  const StartupDiagnosticEntry({
+    required this.timestamp,
+    required this.level,
+    required this.stage,
+    required this.message,
+    this.error,
+    this.stackTrace,
+  });
+
+  final DateTime timestamp;
+  final StartupDiagnosticLevel level;
+  final String stage;
+  final String message;
+  final Object? error;
+  final StackTrace? stackTrace;
+}
+
+/// Keeps launch diagnostics in memory so an unavailable data directory cannot
+/// prevent the user from seeing the cause of a failed startup.
+final class StartupDiagnostics extends ChangeNotifier {
+  StartupDiagnostics({DateTime Function()? clock})
+      : _clock = clock ?? DateTime.now;
+
+  final DateTime Function() _clock;
+  final List<StartupDiagnosticEntry> _entries = <StartupDiagnosticEntry>[];
+
+  List<StartupDiagnosticEntry> get entries => List.unmodifiable(_entries);
+
+  void info(String stage, String message) {
+    _add(
+      StartupDiagnosticEntry(
+        timestamp: _clock().toUtc(),
+        level: StartupDiagnosticLevel.info,
+        stage: stage,
+        message: message,
+      ),
+    );
+  }
+
+  void error(String stage, Object error, StackTrace stackTrace) {
+    _add(
+      StartupDiagnosticEntry(
+        timestamp: _clock().toUtc(),
+        level: StartupDiagnosticLevel.error,
+        stage: stage,
+        message: describeStartupError(error),
+        error: error,
+        stackTrace: stackTrace,
+      ),
+    );
+  }
+
+  String buildReport() {
+    final buffer = StringBuffer('Диагностика запуска ПО Расписание Бочки\n');
+    for (final entry in _entries) {
+      final level =
+          entry.level == StartupDiagnosticLevel.info ? 'INFO' : 'ERROR';
+      buffer.writeln(
+        '[${entry.timestamp.toIso8601String()}] $level [${entry.stage}] ${entry.message}',
+      );
+      if (entry.error != null) {
+        buffer.writeln('Ошибка: ${entry.error.runtimeType}: ${entry.error}');
+      }
+      if (entry.stackTrace != null) {
+        buffer.writeln('Stack trace:\n${entry.stackTrace}');
+      }
+    }
+    return buffer.toString().trimRight();
+  }
+
+  void _add(StartupDiagnosticEntry entry) {
+    _entries.add(entry);
+    notifyListeners();
+  }
+}
+
+String describeStartupError(Object error) {
+  if (error is FileSystemException) {
+    final path = error.path;
+    final fileDescription = path == null || path.isEmpty
+        ? 'файлу или папке приложения'
+        : 'пути:\n$path';
+    return 'Не удалось получить доступ к $fileDescription.\n${error.message}';
+  }
+
+  if (error is FormatException) {
+    return 'Не удалось прочитать файл данных приложения. '
+        'Возможно, project.json повреждён или имеет неподдерживаемый формат.\n'
+        '${error.message}';
+  }
+
+  return error.toString();
+}

--- a/packages/bochki_schedule_app/lib/src/presentation/startup_error_app.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/startup_error_app.dart
@@ -1,92 +1,139 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
-String describeStartupError(Object error) {
-  if (error is FileSystemException) {
-    final path = error.path;
-    final fileDescription = path == null || path.isEmpty
-        ? 'файлу или папке приложения'
-        : 'пути:\n$path';
-    return 'Не удалось получить доступ к $fileDescription.\n${error.message}';
-  }
+import 'startup_diagnostics.dart';
 
-  if (error is FormatException) {
-    return 'Не удалось прочитать файл данных приложения. '
-        'Возможно, project.json повреждён или имеет неподдерживаемый формат.\n'
-        '${error.message}';
-  }
-
-  return error.toString();
-}
+enum StartupStatus { starting, ready, failed, continued }
 
 class StartupErrorApp extends StatelessWidget {
   const StartupErrorApp({
-    required this.error,
+    required this.diagnostics,
+    required this.status,
+    this.onContinue,
     super.key,
   });
 
-  final Object error;
+  final StartupDiagnostics diagnostics;
+  final StartupStatus status;
+  final VoidCallback? onContinue;
+
+  bool get _hasFailed => status == StartupStatus.failed;
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'ПО Расписание Бочки',
       debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF406882)),
+        scaffoldBackgroundColor: const Color(0xFFF6F7F9),
+      ),
       home: Scaffold(
-        backgroundColor: const Color(0xFFF6F7F9),
-        body: Center(
-          child: Container(
-            width: 520,
+        body: SafeArea(
+          child: SingleChildScrollView(
             padding: const EdgeInsets.all(24),
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(18),
-              border: Border.all(color: const Color(0xFFD0D7DE)),
-            ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(
-                  Icons.error_outline,
-                  size: 48,
-                  color: Color(0xFFB00020),
+            child: Center(
+              child: Container(
+                width: 720,
+                padding: const EdgeInsets.all(24),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(18),
+                  border: Border.all(color: const Color(0xFFD0D7DE)),
                 ),
-                const SizedBox(height: 16),
-                const Text(
-                  'Не удалось запустить приложение',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                const SizedBox(height: 12),
-                const Text(
-                  'Произошла критическая ошибка во время запуска.',
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 20),
-                Container(
-                  width: double.infinity,
-                  constraints: const BoxConstraints(maxHeight: 180),
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFFFF4F4),
-                    borderRadius: BorderRadius.circular(8),
-                    border: Border.all(color: const Color(0xFFF0BBBB)),
-                  ),
-                  child: SingleChildScrollView(
-                    child: SelectableText(
-                      describeStartupError(error),
-                      style: const TextStyle(
-                        color: Color(0xFF7A1C1C),
-                        fontFamily: 'monospace',
+                child: AnimatedBuilder(
+                  animation: diagnostics,
+                  builder: (context, _) => Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Icon(
+                        _hasFailed
+                            ? Icons.error_outline
+                            : Icons.play_circle_outline,
+                        size: 48,
+                        color: _hasFailed
+                            ? const Color(0xFFB00020)
+                            : const Color(0xFF406882),
                       ),
-                    ),
+                      const SizedBox(height: 16),
+                      Text(
+                        _hasFailed
+                            ? 'Не удалось запустить приложение'
+                            : 'Проверка запуска приложения',
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                            fontSize: 24, fontWeight: FontWeight.w700),
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        _hasFailed
+                            ? 'Перезапустите приложение. Если ошибка повторится, скопируйте информацию и отправьте её в поддержку.'
+                            : status == StartupStatus.ready
+                                ? 'Проверка запуска завершена успешно. Проверьте журнал и продолжите работу.'
+                                : 'Выполняется подготовка приложения. Журнал обновляется по мере запуска.',
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 20),
+                      Container(
+                        key: const Key('startup_diagnostics_log'),
+                        constraints: const BoxConstraints(maxHeight: 280),
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: _hasFailed
+                              ? const Color(0xFFFFF4F4)
+                              : const Color(0xFFF4F8FA),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(
+                            color: _hasFailed
+                                ? const Color(0xFFF0BBBB)
+                                : const Color(0xFFB9D2DF),
+                          ),
+                        ),
+                        child: SingleChildScrollView(
+                          child: SelectableText(
+                            diagnostics.buildReport(),
+                            style: const TextStyle(fontFamily: 'monospace'),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 20),
+                      if (status == StartupStatus.starting)
+                        const Center(child: CircularProgressIndicator())
+                      else if (_hasFailed)
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: FilledButton.icon(
+                            key: const Key('copy_startup_diagnostics_button'),
+                            onPressed: () async {
+                              await Clipboard.setData(
+                                ClipboardData(text: diagnostics.buildReport()),
+                              );
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                      content: Text('Информация скопирована.')),
+                                );
+                              }
+                            },
+                            icon: const Icon(Icons.copy),
+                            label: const Text('Копировать информацию'),
+                          ),
+                        )
+                      else
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: FilledButton(
+                            key: const Key('continue_after_startup_button'),
+                            onPressed: onContinue,
+                            child: const Text('Всё ок. Продолжить'),
+                          ),
+                        ),
+                    ],
                   ),
                 ),
-              ],
+              ),
             ),
           ),
         ),

--- a/packages/bochki_schedule_app/lib/src/presentation/startup_launcher.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/startup_launcher.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+import '../app.dart';
+import '../app_services.dart';
+import 'startup_diagnostics.dart';
+import 'startup_error_app.dart';
+
+typedef StartupBootstrap = Future<AppServices> Function(
+  StartupDiagnostics diagnostics,
+);
+
+class StartupLauncher extends StatefulWidget {
+  const StartupLauncher({
+    required this.diagnostics,
+    required this.configureWindow,
+    required this.bootstrap,
+    this.onServicesReady,
+    super.key,
+  });
+
+  final StartupDiagnostics diagnostics;
+  final Future<void> Function() configureWindow;
+  final StartupBootstrap bootstrap;
+  final ValueChanged<AppServices>? onServicesReady;
+
+  @override
+  State<StartupLauncher> createState() => _StartupLauncherState();
+}
+
+class _StartupLauncherState extends State<StartupLauncher> {
+  StartupStatus _status = StartupStatus.starting;
+  AppServices? _services;
+
+  @override
+  void initState() {
+    super.initState();
+    _start();
+  }
+
+  Future<void> _start() async {
+    try {
+      widget.diagnostics.info('Окно', 'Настройка окна приложения.');
+      await widget.configureWindow();
+      widget.diagnostics.info('Окно', 'Настройка окна завершена.');
+      widget.diagnostics
+          .info('Инициализация', 'Запуск инициализации приложения.');
+      final services = await widget.bootstrap(widget.diagnostics);
+      widget.onServicesReady?.call(services);
+      if (!mounted) {
+        await services.shutdown();
+        return;
+      }
+      setState(() {
+        _services = services;
+        _status = StartupStatus.ready;
+      });
+    } catch (error, stackTrace) {
+      widget.diagnostics.error('Инициализация', error, stackTrace);
+      if (mounted) {
+        setState(() => _status = StartupStatus.failed);
+      }
+    }
+  }
+
+  void _continueToApplication() {
+    setState(() => _status = StartupStatus.continued);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final services = _services;
+    if (_status == StartupStatus.continued && services != null) {
+      return BochkiScheduleApp(services: services);
+    }
+
+    return StartupErrorApp(
+      diagnostics: widget.diagnostics,
+      status: _status,
+      onContinue:
+          _status == StartupStatus.ready ? _continueToApplication : null,
+    );
+  }
+}

--- a/packages/bochki_schedule_app/test/presentation/startup_error_app_test.dart
+++ b/packages/bochki_schedule_app/test/presentation/startup_error_app_test.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
+import 'package:bochki_schedule_app/src/presentation/startup_diagnostics.dart';
 import 'package:bochki_schedule_app/src/presentation/startup_error_app.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -21,5 +23,67 @@ void main() {
 
     expect(description, contains('project.json'));
     expect(description, contains('Unexpected character'));
+  });
+
+  test('builds a copyable report with the error and its stack trace', () {
+    final diagnostics = StartupDiagnostics(
+      clock: () => DateTime.utc(2026, 7, 21),
+    );
+    diagnostics.info('Каталог данных', 'Каталог данных: /tmp/bochki');
+    diagnostics.error(
+      'Данные проекта',
+      const FileSystemException('Operation not permitted', '/tmp/bochki'),
+      StackTrace.fromString('trace line'),
+    );
+
+    final report = diagnostics.buildReport();
+
+    expect(report, contains('Каталог данных: /tmp/bochki'));
+    expect(report, contains('Operation not permitted'));
+    expect(report, contains('trace line'));
+  });
+
+  testWidgets('shows continue button only after a successful startup',
+      (tester) async {
+    final diagnostics = StartupDiagnostics();
+    diagnostics.info(
+        'Bootstrap', 'Инициализация приложения завершена успешно.');
+
+    await tester.pumpWidget(
+      StartupErrorApp(
+        diagnostics: diagnostics,
+        status: StartupStatus.ready,
+        onContinue: () {},
+      ),
+    );
+
+    expect(find.byKey(const Key('startup_diagnostics_log')), findsOneWidget);
+    expect(
+        find.byKey(const Key('continue_after_startup_button')), findsOneWidget);
+    expect(
+        find.byKey(const Key('copy_startup_diagnostics_button')), findsNothing);
+  });
+
+  testWidgets('shows copy button and no continue button after a failed startup',
+      (tester) async {
+    final diagnostics = StartupDiagnostics();
+    diagnostics.error(
+      'Данные проекта',
+      const FormatException('Unexpected character'),
+      StackTrace.fromString('trace line'),
+    );
+
+    await tester.pumpWidget(
+      StartupErrorApp(
+        diagnostics: diagnostics,
+        status: StartupStatus.failed,
+      ),
+    );
+
+    expect(find.byKey(const Key('copy_startup_diagnostics_button')),
+        findsOneWidget);
+    expect(
+        find.byKey(const Key('continue_after_startup_button')), findsNothing);
+    expect(find.textContaining('Перезапустите приложение'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Что сделано

- запусковой экран показывается до настройки окна и загрузки файлов данных;
- этапы запуска, пути, ошибки и stack trace сохраняются в независимой in-memory диагностике;
- успешный запуск требует нажатия «Всё ок. Продолжить»;
- при ошибке отображаются инструкция и кнопка копирования отчёта;
- добавлены unit/widget-тесты диагностики и стартового экрана.

Closes #72