### PR TITLE
feat(schedule): add person summary tooltips

### DIFF
--- a/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_sessions_view_model.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_sessions_view_model.dart
@@ -118,6 +118,31 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
   String? get selectedParticipantId => _selectedParticipantId;
   bool get showConflictsOnly => _showConflictsOnly;
 
+  String participantSummaryTooltip({
+    required String humanId,
+    required String humanName,
+  }) {
+    final countsByDayId = <String, int>{};
+    for (final entry in _allEntries) {
+      if (entry.participantId != humanId) {
+        continue;
+      }
+      countsByDayId.update(entry.dayId, (count) => count + 1,
+          ifAbsent: () => 1);
+    }
+
+    if (countsByDayId.isEmpty) {
+      return '$humanName\nНет процедур в роли участника';
+    }
+
+    return [
+      humanName,
+      for (final workday in _workdays)
+        if (countsByDayId[workday.id] case final count?)
+          '${workday.name}: $count',
+    ].join('\n');
+  }
+
   Future<void> load() async {
     _isLoading = true;
     _loadErrorMessage = null;

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -897,9 +897,13 @@ class _ProcedureSessionsTableState extends State<_ProcedureSessionsTable> {
           child: Row(
             children: [
               _TableCell(width: _dataColumnWidths[0], text: _dayText(entry)),
-              _TableCell(
+              _buildPersonSummaryCell(
                 width: _dataColumnWidths[1],
-                text: _participantText(entry),
+                entryId: entry.id,
+                column: 'participant',
+                humanId: entry.participant?.id,
+                humanName: entry.participant?.name,
+                fallbackText: _participantText(entry),
               ),
               _TableCell(width: _dataColumnWidths[2], text: entry.startTime),
               _TableCell(
@@ -910,9 +914,14 @@ class _ProcedureSessionsTableState extends State<_ProcedureSessionsTable> {
                 width: _dataColumnWidths[4],
                 text: _procedureText(entry),
               ),
-              _TableCell(
+              _buildPersonSummaryCell(
                 width: _dataColumnWidths[5],
-                text: _assistantText(entry),
+                entryId: entry.id,
+                column: 'assistant',
+                humanId: entry.requiresAssistant ? entry.assistant?.id : null,
+                humanName:
+                    entry.requiresAssistant ? entry.assistant?.name : null,
+                fallbackText: _assistantText(entry),
               ),
               _TableCell(
                 width: _conflictColumnWidth,
@@ -979,6 +988,31 @@ class _ProcedureSessionsTableState extends State<_ProcedureSessionsTable> {
       return '';
     }
     return entry.assistant?.name ?? 'Ошибка: ассистент не найден';
+  }
+
+  Widget _buildPersonSummaryCell({
+    required double width,
+    required String entryId,
+    required String column,
+    required String? humanId,
+    required String? humanName,
+    required String fallbackText,
+  }) {
+    final cell = _TableCell(width: width, text: fallbackText);
+    if (humanId == null || humanName == null) {
+      return cell;
+    }
+
+    return Tooltip(
+      key: Key('procedure_session_${column}_summary_$entryId'),
+      message: widget.viewModel.participantSummaryTooltip(
+        humanId: humanId,
+        humanName: humanName,
+      ),
+      waitDuration: const Duration(milliseconds: 300),
+      exitDuration: Duration.zero,
+      child: cell,
+    );
   }
 }
 

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -576,6 +576,121 @@ void main() {
     expect(tester.getSize(secondHeader).width, 195);
   });
 
+  testWidgets('person summary tooltips use all assigned procedures', (
+    tester,
+  ) async {
+    final context = _buildTestContext(
+      participants: [
+        Participant(id: '1', name: 'Анна'),
+        Participant(id: '3', name: 'Борис'),
+      ],
+      assistants: [Assistant(id: '2', name: 'Алексей')],
+      procedureKinds: [
+        ProcedureKind(
+          id: '1',
+          patternId: ProcedureKindPatterns.curated.patternId,
+          name: 'Парная процедура',
+          capacity: 2,
+          participantBusyTime: 30,
+          assistantBusyTime: 10,
+          resourceBusyTime: 5,
+        ),
+        ProcedureKind(
+          id: '2',
+          patternId: ProcedureKindPatterns.single.patternId,
+          name: 'Одиночная процедура',
+          capacity: 1,
+          participantBusyTime: 30,
+          resourceBusyTime: 5,
+        ),
+      ],
+      workdays: [
+        Workday(
+          id: '1',
+          name: 'Понедельник',
+          calendarDate: DateTime(2026, 7, 20),
+        ),
+        Workday(
+          id: '2',
+          name: 'Вторник',
+          calendarDate: DateTime(2026, 7, 21),
+        ),
+      ],
+      procedureSessions: [
+        ProcedureSessionRaw(
+            id: '1',
+            dayId: '1',
+            participantId: '1',
+            startTime: '09:00',
+            procedureKindId: '2'),
+        ProcedureSessionRaw(
+            id: '2',
+            dayId: '1',
+            participantId: '1',
+            startTime: '10:00',
+            procedureKindId: '2'),
+        ProcedureSessionRaw(
+            id: '3',
+            dayId: '2',
+            participantId: '1',
+            startTime: '09:00',
+            procedureKindId: '1',
+            assistantId: '2'),
+        ProcedureSessionRaw(
+            id: '4',
+            dayId: '2',
+            participantId: '3',
+            startTime: '10:00',
+            procedureKindId: '1',
+            assistantId: '2'),
+      ],
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+
+    final participantSummary = find.byKey(
+      const Key('procedure_session_participant_summary_1'),
+    );
+    const annaSummary = 'Анна\nПонедельник: 2\nВторник: 1';
+    final participantTooltip = tester.widget<Tooltip>(participantSummary);
+    expect(participantTooltip.message, annaSummary);
+    expect(participantTooltip.waitDuration, const Duration(milliseconds: 300));
+    expect(participantTooltip.exitDuration, Duration.zero);
+
+    tester.state<TooltipState>(participantSummary).ensureTooltipVisible();
+    await tester.pumpAndSettle();
+    expect(find.text(annaSummary), findsOneWidget);
+
+    Tooltip.dismissAllToolTips();
+    await tester.pumpAndSettle();
+    expect(find.text(annaSummary), findsNothing);
+
+    await tester.tap(find.byKey(const Key('procedure_sessions_day_filter')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Понедельник').last);
+    await tester.pumpAndSettle();
+    tester.state<TooltipState>(participantSummary).ensureTooltipVisible();
+    await tester.pumpAndSettle();
+    expect(find.text(annaSummary), findsOneWidget);
+
+    Tooltip.dismissAllToolTips();
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('procedure_sessions_day_filter')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Все').last);
+    await tester.pumpAndSettle();
+    final assistantSummary = find.byKey(
+      const Key('procedure_session_assistant_summary_4'),
+    );
+    tester.state<TooltipState>(assistantSummary).ensureTooltipVisible();
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Алексей\nНет процедур в роли участника'),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('procedure sessions filters by part of day', (tester) async {
     final context = _buildTestContext(
       participants: [


### PR DESCRIPTION
Closes #74\n\n- adds 300 ms hover tooltips for participant and assistant cells\n- summarizes all assignments where the person is a participant, ordered by workday\n- covers tooltip content, filters, assistant behavior, and timing configuration