### PR TITLE
fix(ui): show directories menu instantly

### DIFF
--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -427,6 +427,7 @@ class _BochkiShellState extends State<BochkiShell> {
                   PopupMenuButton<DirectorySection>(
                     key: const Key('directories_menu_button'),
                     tooltip: 'Справочники',
+                    popUpAnimationStyle: AnimationStyle.noAnimation,
                     onSelected: _selectDirectorySection,
                     itemBuilder: (context) => const [
                       PopupMenuItem<DirectorySection>(

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -343,6 +343,32 @@ void main() {
     expect(find.text('Ok'), findsOneWidget);
   });
 
+  testWidgets('directories menu opens and closes without animation', (
+    tester,
+  ) async {
+    final context = _buildTestContext();
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+
+    final menu = tester.widget<PopupMenuButton<DirectorySection>>(
+      find.byKey(const Key('directories_menu_button')),
+    );
+    expect(menu.popUpAnimationStyle, AnimationStyle.noAnimation);
+
+    await tester.tap(find.byKey(const Key('directories_menu_button')));
+    await tester.pump();
+    expect(find.byType(PopupMenuItem<DirectorySection>), findsNWidgets(5));
+
+    await tester.tap(find.text('Участники').last);
+    await tester.pump();
+    expect(find.byType(PopupMenuItem<DirectorySection>), findsNothing);
+    expect(
+      find.byKey(const Key('participants_directory_dialog')),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('shell opens assistants dialog from menu', (tester) async {
     final context = _buildTestContext();
 


### PR DESCRIPTION
Closes #69

## Changes
- disables open and close animation for the Directories popup menu
- adds a widget test for the zero-animation style and immediate open/close behavior

## Verification
- melos run format-check
- melos run analyze
- melos run test