### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.10.0
+
+Release date: 2026-07-21
+
+### Highlights
+
+- Added procedure-assignment summary tooltips for participants and assistants.
+- Made the Directories menu appear and close instantly.
+
+### Details
+
+- `feat(schedule): add person summary tooltips (#76)`
+- `fix(ui): show directories menu instantly (#77)`
+
 ## v0.9.0
 
 Release date: 2026-07-21

--- a/packages/bochki_schedule_app/pubspec.lock
+++ b/packages/bochki_schedule_app/pubspec.lock
@@ -23,14 +23,14 @@ packages:
       path: "../bochki_schedule_domain"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.10.0"
   bochki_schedule_infra:
     dependency: "direct main"
     description:
       path: "../bochki_schedule_infra"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.10.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/packages/bochki_schedule_app/pubspec.yaml
+++ b/packages/bochki_schedule_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_app
 description: Application package for the Bochki Schedule desktop app.
 publish_to: none
-version: 0.9.0
+version: 0.10.0
 
 environment:
   sdk: ^3.5.0

--- a/packages/bochki_schedule_domain/pubspec.yaml
+++ b/packages/bochki_schedule_domain/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_domain
 description: Domain package for Bochki Schedule.
 publish_to: none
-version: 0.9.0
+version: 0.10.0
 
 environment:
   sdk: ^3.5.0

--- a/packages/bochki_schedule_infra/pubspec.lock
+++ b/packages/bochki_schedule_infra/pubspec.lock
@@ -39,7 +39,7 @@ packages:
       path: "../bochki_schedule_domain"
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.10.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/packages/bochki_schedule_infra/pubspec.yaml
+++ b/packages/bochki_schedule_infra/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_infra
 description: Infrastructure package for Bochki Schedule.
 publish_to: none
-version: 0.9.0
+version: 0.10.0
 
 environment:
   sdk: ^3.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bochki_schedule_workspace
 publish_to: none
-version: 0.9.0
+version: 0.10.0
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
## Release preparation
- bumps workspace and package versions to 0.10.0
- updates the changelog for #76 and #77
- refreshes local package lockfile versions

## Verification
- dart pub get
- melos run format-check