### PR TITLE
feat: add short names for assistants

### DIFF
--- a/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
+++ b/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
@@ -131,6 +131,13 @@ final class AppBootstrap {
     syncCoordinator.registerPart(printPresetParamsRepository);
     syncCoordinator.registerPart(programSettingsRepository);
     syncCoordinator.registerPart(procedureSessionsRepository);
+    final didNormalizeLegacyHumanShortNames =
+        await humansRepository.normalizeLegacyShortNames();
+    if (didNormalizeLegacyHumanShortNames) {
+      diagnostics?.info('Миграция данных', 'Нормализация кратких имён людей.');
+      await logger.info('Normalized legacy human short names.');
+      await syncCoordinator.flushPending();
+    }
     final didNormalizeLegacyProcedureKinds =
         await procedureKindsRepository.normalizeLegacyProcedureKinds();
     if (didNormalizeLegacyProcedureKinds) {

--- a/packages/bochki_schedule_app/lib/src/data/assistants/project_document_assistants_repository.dart
+++ b/packages/bochki_schedule_app/lib/src/data/assistants/project_document_assistants_repository.dart
@@ -53,9 +53,13 @@ final class ProjectDocumentAssistantsRepository
       return entry;
     }
 
+    final shortName =
+        entry.name != current.name && current.shortName == current.name
+            ? entry.name
+            : entry.shortName;
     await _humansRepository.update(current.copyWith(
       name: entry.name,
-      shortName: entry.shortName,
+      shortName: shortName,
       isAssistant: true,
     ));
     return entry;

--- a/packages/bochki_schedule_app/lib/src/data/assistants/project_document_assistants_repository.dart
+++ b/packages/bochki_schedule_app/lib/src/data/assistants/project_document_assistants_repository.dart
@@ -20,6 +20,7 @@ final class ProjectDocumentAssistantsRepository
           (human) => Assistant(
             id: human.id,
             name: human.name,
+            shortName: human.shortName,
           ),
         )
         .toList(growable: false);
@@ -34,7 +35,8 @@ final class ProjectDocumentAssistantsRepository
       isParticipant: false,
       isAssistant: true,
     );
-    return Assistant(id: human.id, name: human.name);
+    return Assistant(
+        id: human.id, name: human.name, shortName: human.shortName);
   }
 
   @override
@@ -51,12 +53,11 @@ final class ProjectDocumentAssistantsRepository
       return entry;
     }
 
-    await _humansRepository.update(
-      current.copyWith(
-        name: entry.name,
-        isAssistant: true,
-      ),
-    );
+    await _humansRepository.update(current.copyWith(
+      name: entry.name,
+      shortName: entry.shortName,
+      isAssistant: true,
+    ));
     return entry;
   }
 

--- a/packages/bochki_schedule_app/lib/src/data/humans/human_dto.dart
+++ b/packages/bochki_schedule_app/lib/src/data/humans/human_dto.dart
@@ -4,6 +4,7 @@ final class HumanDto {
   const HumanDto({
     required this.id,
     required this.name,
+    required this.shortName,
     required this.isParticipant,
     required this.isAssistant,
     required this.deleted,
@@ -13,6 +14,8 @@ final class HumanDto {
     return HumanDto(
       id: (json['id'] as num?)?.toInt() ?? 0,
       name: (json['name'] as String?) ?? '',
+      shortName:
+          (json['shortName'] as String?) ?? (json['name'] as String?) ?? '',
       isParticipant: json['isParticipant'] as bool? ?? false,
       isAssistant: json['isAssistant'] as bool? ?? false,
       deleted: json['deleted'] as bool? ?? false,
@@ -26,6 +29,7 @@ final class HumanDto {
     return HumanDto(
       id: int.parse(human.id),
       name: human.name,
+      shortName: human.shortName,
       isParticipant: human.isParticipant,
       isAssistant: human.isAssistant,
       deleted: deleted,
@@ -34,6 +38,7 @@ final class HumanDto {
 
   final int id;
   final String name;
+  final String shortName;
   final bool isParticipant;
   final bool isAssistant;
   final bool deleted;
@@ -42,6 +47,7 @@ final class HumanDto {
     return Human(
       id: id.toString(),
       name: name,
+      shortName: shortName,
       isParticipant: isParticipant,
       isAssistant: isAssistant,
     );
@@ -50,6 +56,7 @@ final class HumanDto {
   HumanDto copyWith({
     int? id,
     String? name,
+    String? shortName,
     bool? isParticipant,
     bool? isAssistant,
     bool? deleted,
@@ -57,6 +64,7 @@ final class HumanDto {
     return HumanDto(
       id: id ?? this.id,
       name: name ?? this.name,
+      shortName: shortName ?? this.shortName,
       isParticipant: isParticipant ?? this.isParticipant,
       isAssistant: isAssistant ?? this.isAssistant,
       deleted: deleted ?? this.deleted,
@@ -67,6 +75,7 @@ final class HumanDto {
     return <String, Object?>{
       'id': id,
       'name': name,
+      'shortName': shortName,
       'isParticipant': isParticipant,
       'isAssistant': isAssistant,
       'deleted': deleted,

--- a/packages/bochki_schedule_app/lib/src/data/humans/project_document_humans_repository.dart
+++ b/packages/bochki_schedule_app/lib/src/data/humans/project_document_humans_repository.dart
@@ -18,11 +18,23 @@ final class ProjectDocumentHumansRepository
         _onChanged = onChanged,
         _entries = initialDocument.humans
             .map(HumanDto.fromJson)
-            .toList(growable: true);
+            .toList(growable: true),
+        _needsShortNameMigration = initialDocument.humans.any(
+          (human) => !human.containsKey('shortName'),
+        );
 
   final ProjectDocumentIdAllocator _idAllocator;
   final void Function() _onChanged;
   final List<HumanDto> _entries;
+  final bool _needsShortNameMigration;
+
+  Future<bool> normalizeLegacyShortNames() async {
+    if (!_needsShortNameMigration) {
+      return false;
+    }
+    _markRepositoryChanged();
+    return true;
+  }
 
   @override
   Future<List<Human>> list() async {
@@ -56,11 +68,13 @@ final class ProjectDocumentHumansRepository
     if (index != -1) {
       final current = _entries[index];
       if (current.name != human.name ||
+          current.shortName != human.shortName ||
           current.isParticipant != human.isParticipant ||
           current.isAssistant != human.isAssistant ||
           current.deleted) {
         _entries[index] = current.copyWith(
           name: human.name,
+          shortName: human.shortName,
           isParticipant: human.isParticipant,
           isAssistant: human.isAssistant,
           deleted: false,

--- a/packages/bochki_schedule_app/lib/src/data/humans/project_document_humans_repository.dart
+++ b/packages/bochki_schedule_app/lib/src/data/humans/project_document_humans_repository.dart
@@ -67,14 +67,19 @@ final class ProjectDocumentHumansRepository
     final index = _entries.indexWhere((candidate) => candidate.id == humanId);
     if (index != -1) {
       final current = _entries[index];
+      final shortName = human.name != current.name &&
+              human.shortName == current.shortName &&
+              current.shortName == current.name
+          ? human.name
+          : human.shortName;
       if (current.name != human.name ||
-          current.shortName != human.shortName ||
+          current.shortName != shortName ||
           current.isParticipant != human.isParticipant ||
           current.isAssistant != human.isAssistant ||
           current.deleted) {
         _entries[index] = current.copyWith(
           name: human.name,
-          shortName: human.shortName,
+          shortName: shortName,
           isParticipant: human.isParticipant,
           isAssistant: human.isAssistant,
           deleted: false,

--- a/packages/bochki_schedule_app/lib/src/data/participants/project_document_participants_repository.dart
+++ b/packages/bochki_schedule_app/lib/src/data/participants/project_document_participants_repository.dart
@@ -54,6 +54,7 @@ final class ProjectDocumentParticipantsRepository
     await _humansRepository.update(
       current.copyWith(
         name: entry.name,
+        shortName: entry.name,
         isParticipant: true,
       ),
     );

--- a/packages/bochki_schedule_app/lib/src/domain/assistants/assistant.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/assistants/assistant.dart
@@ -6,7 +6,9 @@ final class Assistant extends NamedDirectoryEntry {
   Assistant({
     required String id,
     required String name,
-  }) : super(
+    String? shortName,
+  })  : shortName = _normalizeShortName(shortName, name),
+        super(
           id: NamedDirectoryEntry.normalizeId(id),
           name: NamedDirectoryEntry.normalizeName(name),
         ) {
@@ -21,6 +23,8 @@ final class Assistant extends NamedDirectoryEntry {
       );
     }
   }
+
+  final String shortName;
 
   static String normalizeId(String value) {
     return NamedDirectoryEntry.normalizeId(value);
@@ -37,10 +41,20 @@ final class Assistant extends NamedDirectoryEntry {
   Assistant copyWith({
     String? id,
     String? name,
+    String? shortName,
   }) {
     return Assistant(
       id: id ?? this.id,
       name: name ?? this.name,
+      shortName: shortName ?? this.shortName,
     );
+  }
+
+  static String _normalizeShortName(String? value, String name) {
+    final normalizedName = normalizeName(name);
+    final normalizedShortName = (value ?? '').trim();
+    return normalizedShortName.isEmpty || normalizedShortName == normalizedName
+        ? normalizedName
+        : normalizedShortName;
   }
 }

--- a/packages/bochki_schedule_app/lib/src/domain/assistants/update_assistant_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/assistants/update_assistant_use_case.dart
@@ -1,43 +1,51 @@
-import '../named_directory/update_named_directory_entry_use_case.dart';
+import '../named_directory/named_directory_entry.dart';
 
 import 'assistant.dart';
 import 'assistants_repository.dart';
 import 'assistants_validation_exception.dart';
 
 final class UpdateAssistantUseCase {
-  UpdateAssistantUseCase(AssistantsRepository repository)
-      : _delegate = UpdateNamedDirectoryEntryUseCase<Assistant>(
-          repository,
-          entryFactory: _entryFactory,
-          emptyIdMessage: 'Идентификатор ассистента не должен быть пустым.',
-          emptyNameMessage: 'Введите имя ассистента.',
-          duplicateNameMessage: 'Ассистент с таким именем уже есть.',
-          exceptionFactory: _validationException,
-        );
+  UpdateAssistantUseCase(this._repository);
 
-  final UpdateNamedDirectoryEntryUseCase<Assistant> _delegate;
+  final AssistantsRepository _repository;
 
   Future<Assistant> execute({
     required String assistantId,
-    required String rawName,
-  }) {
-    return _delegate.execute(
-      entryId: assistantId,
-      rawName: rawName,
-    );
-  }
+    String? rawName,
+    String? rawShortName,
+  }) async {
+    final normalizedId = Assistant.normalizeId(assistantId);
+    if (normalizedId.isEmpty) {
+      throw const AssistantsValidationException(
+        'Идентификатор ассистента не должен быть пустым.',
+      );
+    }
 
-  static Assistant _entryFactory({
-    required String id,
-    required String name,
-  }) {
-    return Assistant(
-      id: id,
+    final assistants = await _repository.list();
+    final current =
+        assistants.where((entry) => entry.id == normalizedId).firstOrNull;
+    if (current == null) {
+      throw const AssistantsValidationException('Ассистент не найден.');
+    }
+
+    final name = Assistant.normalizeName(rawName ?? current.name);
+    if (name.isEmpty) {
+      throw const AssistantsValidationException('Введите имя ассистента.');
+    }
+    final sortKey = NamedDirectoryEntry.sortKeyForName(name);
+    if (assistants.any((entry) =>
+        entry.id != normalizedId &&
+        NamedDirectoryEntry.sortKeyForName(entry.name) == sortKey)) {
+      throw const AssistantsValidationException(
+          'Ассистент с таким именем уже есть.');
+    }
+
+    final shortName = rawShortName ??
+        (current.shortName == current.name ? name : current.shortName);
+    return _repository.update(Assistant(
+      id: normalizedId,
       name: name,
-    );
-  }
-
-  static AssistantsValidationException _validationException(String message) {
-    return AssistantsValidationException(message);
+      shortName: shortName,
+    ));
   }
 }

--- a/packages/bochki_schedule_app/lib/src/domain/humans/human.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/humans/human.dart
@@ -4,27 +4,40 @@ final class Human extends NamedDirectoryEntry {
   Human({
     required String id,
     required String name,
+    String? shortName,
     required this.isParticipant,
     required this.isAssistant,
-  }) : super(
+  })  : shortName = _normalizeShortName(shortName, name),
+        super(
           id: NamedDirectoryEntry.normalizeId(id),
           name: NamedDirectoryEntry.normalizeName(name),
         );
 
+  final String shortName;
   final bool isParticipant;
   final bool isAssistant;
 
   Human copyWith({
     String? id,
     String? name,
+    String? shortName,
     bool? isParticipant,
     bool? isAssistant,
   }) {
     return Human(
       id: id ?? this.id,
       name: name ?? this.name,
+      shortName: shortName ?? this.shortName,
       isParticipant: isParticipant ?? this.isParticipant,
       isAssistant: isAssistant ?? this.isAssistant,
     );
+  }
+
+  static String _normalizeShortName(String? value, String name) {
+    final normalizedName = NamedDirectoryEntry.normalizeName(name);
+    final normalizedShortName = (value ?? '').trim();
+    return normalizedShortName.isEmpty || normalizedShortName == normalizedName
+        ? normalizedName
+        : normalizedShortName;
   }
 }

--- a/packages/bochki_schedule_app/lib/src/features/assistants/assistants_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/assistants/assistants_dialog.dart
@@ -28,9 +28,16 @@ class AssistantsDialog extends NamedDirectoryDialog<Assistant> {
       DirectoryColumnSpec<Assistant>(
         id: 'name',
         label: 'Имя',
-        cellText: _cellText,
+        cellText: _nameCellText,
+      ),
+      DirectoryColumnSpec<Assistant>(
+        id: 'shortName',
+        label: 'Краткое имя',
+        cellText: _shortNameCellText,
+        editValue: _shortNameCellText,
       ),
     ],
+    showColumnHeaders: true,
     rowActions: [
       DirectoryRowActionSpec<Assistant>(
         id: 'edit',
@@ -49,7 +56,13 @@ class AssistantsDialog extends NamedDirectoryDialog<Assistant> {
 
   static String _sectionTitle(int count) => 'Ассистенты ($count)';
 
-  static String _cellText(Assistant assistant) => assistant.name;
+  static String _nameCellText(Assistant assistant) => assistant.name;
+
+  static String _shortNameCellText(Assistant assistant) {
+    return assistant.shortName.trim() == assistant.name
+        ? ''
+        : assistant.shortName;
+  }
 
   static String _deleteConfirmationMessage(Assistant assistant) {
     return 'Ассистент "${assistant.name}" будет скрыт из списка.';

--- a/packages/bochki_schedule_app/lib/src/features/assistants/assistants_view_model.dart
+++ b/packages/bochki_schedule_app/lib/src/features/assistants/assistants_view_model.dart
@@ -17,10 +17,12 @@ final class AssistantsViewModel extends NamedDirectoryViewModel<Assistant> {
           updateEntry: ({
             required String entryId,
             required String rawName,
+            required String fieldId,
           }) {
             return updateAssistantUseCase.execute(
               assistantId: entryId,
-              rawName: rawName,
+              rawName: fieldId == 'name' ? rawName : null,
+              rawShortName: fieldId == 'shortName' ? rawName : null,
             );
           },
           deleteEntry: deleteAssistantUseCase.execute,
@@ -42,10 +44,12 @@ final class AssistantsViewModel extends NamedDirectoryViewModel<Assistant> {
   Future<bool> updateAssistant({
     required String assistantId,
     required String rawName,
+    String fieldId = 'name',
   }) {
     return updateEntry(
       entryId: assistantId,
       rawName: rawName,
+      fieldId: fieldId,
     );
   }
 

--- a/packages/bochki_schedule_app/lib/src/features/directory/named_directory_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/directory/named_directory_dialog.dart
@@ -42,6 +42,7 @@ class _NamedDirectoryDialogState<T extends NamedDirectoryEntry>
   final DirectoryTableReducer _reducer = const DirectoryTableReducer();
 
   DirectoryTableState _tableState = const DirectoryTableNoSelection();
+  String _editingColumnId = 'name';
   Future<bool>? _pendingSubmit;
 
   NamedDirectoryDialogConfig<T> get _config => widget.config;
@@ -128,6 +129,9 @@ class _NamedDirectoryDialogState<T extends NamedDirectoryEntry>
 
     setState(() {
       _tableState = nextState;
+      if (!nextState.isEditing) {
+        _editingColumnId = 'name';
+      }
       _syncControllerFromState(nextState);
     });
 
@@ -188,6 +192,7 @@ class _NamedDirectoryDialogState<T extends NamedDirectoryEntry>
         DirectoryTableSubmitMode.update => await viewModel.updateEntry(
             entryId: request.entryId!,
             rawName: request.rawValue,
+            fieldId: _editingColumnId,
           ),
       };
 
@@ -274,10 +279,24 @@ class _NamedDirectoryDialogState<T extends NamedDirectoryEntry>
 
   @override
   void beginEdit(String entryId) {
+    _editingColumnId = 'name';
     _setTableState(
       _reducer.resolveSubmitSuccess(
         target: DirectoryTableSuccessTarget.editRow(entryId),
         rows: _rows,
+      ),
+      clearFormError: true,
+    );
+  }
+
+  void _beginEditCell(T entry, DirectoryColumnSpec<T> column) {
+    final value = column.editValue?.call(entry) ?? column.cellText(entry);
+    _editingColumnId = column.id;
+    _setTableState(
+      DirectoryTableEditRow(
+        entryId: entry.id,
+        initialValue: value,
+        currentValue: value,
       ),
       clearFormError: true,
     );
@@ -507,7 +526,7 @@ class _NamedDirectoryDialogState<T extends NamedDirectoryEntry>
         return KeyEventResult.ignored;
       },
       child: TextField(
-        key: Key('${_config.entryKeyPrefix}_name_field'),
+        key: Key('${_config.entryKeyPrefix}_${_editingColumnId}_field'),
         focusNode: _editorFocusNode,
         controller: _nameController,
         autofocus: true,
@@ -531,16 +550,29 @@ class _NamedDirectoryDialogState<T extends NamedDirectoryEntry>
     );
   }
 
-  List<Widget> _buildDisplayColumns(BuildContext context, T entry) {
+  List<Widget> _buildDisplayColumns(
+    BuildContext context,
+    T entry, {
+    required bool isEditing,
+    required NamedDirectoryViewModel<T> viewModel,
+  }) {
     return [
       for (final column in _config.columns)
         Expanded(
           flex: column.flex,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            child: Text(
-              column.cellText(entry),
-              style: Theme.of(context).textTheme.bodyLarge,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onDoubleTap: viewModel.isSaving || isEditing
+                ? null
+                : () => _beginEditCell(entry, column),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              child: isEditing && column.id == _editingColumnId
+                  ? _buildNameEditor(viewModel)
+                  : Text(
+                      column.cellText(entry),
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
             ),
           ),
         ),
@@ -594,10 +626,7 @@ class _NamedDirectoryDialogState<T extends NamedDirectoryEntry>
             : () => _dispatch(DirectoryTableEvent.clickRow(entry.id)),
         onDoubleTap: viewModel.isSaving
             ? null
-            : () => _dispatch(
-                  DirectoryTableEvent.doubleClickRow(entry.id),
-                  clearFormError: true,
-                ),
+            : () => _beginEditCell(entry, _config.columns.first),
         onSecondaryTapDown: viewModel.isSaving
             ? null
             : (details) => _dispatch(
@@ -629,10 +658,12 @@ class _NamedDirectoryDialogState<T extends NamedDirectoryEntry>
                     padding: const EdgeInsets.symmetric(vertical: 2),
                     child: Row(
                       children: [
-                        if (isEditing)
-                          Expanded(child: _buildNameEditor(viewModel))
-                        else
-                          ..._buildDisplayColumns(context, entry),
+                        ..._buildDisplayColumns(
+                          context,
+                          entry,
+                          isEditing: isEditing,
+                          viewModel: viewModel,
+                        ),
                         if (_rowButtonActions.isNotEmpty)
                           _buildRowButtons(entry),
                       ],

--- a/packages/bochki_schedule_app/lib/src/features/directory/named_directory_dialog_config.dart
+++ b/packages/bochki_schedule_app/lib/src/features/directory/named_directory_dialog_config.dart
@@ -12,12 +12,14 @@ class DirectoryColumnSpec<T extends NamedDirectoryEntry> {
     required this.id,
     required this.label,
     required this.cellText,
+    this.editValue,
     this.flex = 1,
   });
 
   final String id;
   final String label;
   final String Function(T entry) cellText;
+  final String Function(T entry)? editValue;
   final int flex;
 }
 

--- a/packages/bochki_schedule_app/lib/src/features/directory/named_directory_view_model.dart
+++ b/packages/bochki_schedule_app/lib/src/features/directory/named_directory_view_model.dart
@@ -11,6 +11,7 @@ typedef NamedDirectoryUpdater<T extends NamedDirectoryEntry> = Future<T>
     Function({
   required String entryId,
   required String rawName,
+  required String fieldId,
 });
 typedef NamedDirectoryDeleter = Future<void> Function(String entryId);
 
@@ -76,11 +77,13 @@ class NamedDirectoryViewModel<T extends NamedDirectoryEntry>
   Future<bool> updateEntry({
     required String entryId,
     required String rawName,
+    String fieldId = 'name',
   }) async {
     return _runFormCommand(() async {
       final entry = await _updateEntry(
         entryId: entryId,
         rawName: rawName,
+        fieldId: fieldId,
       );
       _entries = _entries
           .map(

--- a/packages/bochki_schedule_app/lib/src/features/participants/participants_view_model.dart
+++ b/packages/bochki_schedule_app/lib/src/features/participants/participants_view_model.dart
@@ -17,6 +17,7 @@ final class ParticipantsViewModel extends NamedDirectoryViewModel<Participant> {
           updateEntry: ({
             required String entryId,
             required String rawName,
+            required String fieldId,
           }) {
             return updateParticipantUseCase.execute(
               participantId: entryId,

--- a/packages/bochki_schedule_app/test/data/assistants/project_document_assistants_repository_test.dart
+++ b/packages/bochki_schedule_app/test/data/assistants/project_document_assistants_repository_test.dart
@@ -51,6 +51,7 @@ void main() {
       <String, Object?>{
         'id': 1,
         'name': 'Анна',
+        'shortName': 'Анна',
         'isParticipant': false,
         'isAssistant': true,
         'deleted': false,
@@ -58,6 +59,7 @@ void main() {
       <String, Object?>{
         'id': 2,
         'name': 'Борис',
+        'shortName': 'Борис',
         'isParticipant': false,
         'isAssistant': true,
         'deleted': true,
@@ -123,6 +125,7 @@ void main() {
       <String, Object?>{
         'id': 2,
         'name': 'Анна',
+        'shortName': 'Анна',
         'isParticipant': false,
         'isAssistant': true,
         'deleted': false,
@@ -130,6 +133,7 @@ void main() {
       <String, Object?>{
         'id': 1,
         'name': 'Борис',
+        'shortName': 'Борис',
         'isParticipant': true,
         'isAssistant': false,
         'deleted': false,
@@ -137,6 +141,7 @@ void main() {
       <String, Object?>{
         'id': 3,
         'name': 'Василиса',
+        'shortName': 'Василиса',
         'isParticipant': false,
         'isAssistant': true,
         'deleted': false,

--- a/packages/bochki_schedule_app/test/data/humans/project_document_humans_repository_test.dart
+++ b/packages/bochki_schedule_app/test/data/humans/project_document_humans_repository_test.dart
@@ -4,6 +4,54 @@ import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('normalizes missing short names for every persisted human', () async {
+    var changeNotifications = 0;
+    final repository = ProjectDocumentHumansRepository(
+      initialDocument: const ProjectDocument(
+        humans: <Map<String, Object?>>[
+          <String, Object?>{
+            'id': 1,
+            'name': 'Анна',
+            'isParticipant': true,
+            'isAssistant': false,
+            'deleted': false,
+          },
+          <String, Object?>{
+            'id': 2,
+            'name': 'Борис',
+            'isParticipant': false,
+            'isAssistant': true,
+            'deleted': true,
+          },
+        ],
+      ),
+      idAllocator: ProjectDocumentIdAllocator(nextId: 3, onChanged: () {}),
+      onChanged: () => changeNotifications += 1,
+    );
+
+    expect(await repository.normalizeLegacyShortNames(), isTrue);
+    expect(repository.isDirty, isTrue);
+    expect(changeNotifications, 1);
+    expect(repository.applyToDocument(ProjectDocument.initial()).humans, [
+      <String, Object?>{
+        'id': 1,
+        'name': 'Анна',
+        'shortName': 'Анна',
+        'isParticipant': true,
+        'isAssistant': false,
+        'deleted': false,
+      },
+      <String, Object?>{
+        'id': 2,
+        'name': 'Борис',
+        'shortName': 'Борис',
+        'isParticipant': false,
+        'isAssistant': true,
+        'deleted': true,
+      },
+    ]);
+  });
+
   test('loads humans and persists role flags', () async {
     var changeNotifications = 0;
     final repository = ProjectDocumentHumansRepository(
@@ -109,6 +157,7 @@ void main() {
       <String, Object?>{
         'id': 2,
         'name': 'Борис Общий',
+        'shortName': 'Борис Общий',
         'isParticipant': true,
         'isAssistant': true,
         'deleted': false,

--- a/packages/bochki_schedule_app/test/data/humans/project_document_humans_repository_test.dart
+++ b/packages/bochki_schedule_app/test/data/humans/project_document_humans_repository_test.dart
@@ -150,6 +150,7 @@ void main() {
       <String, Object?>{
         'id': 1,
         'name': 'Анна',
+        'shortName': 'Анна',
         'isParticipant': false,
         'isAssistant': false,
         'deleted': true,

--- a/packages/bochki_schedule_app/test/data/project_document_participants_repository_test.dart
+++ b/packages/bochki_schedule_app/test/data/project_document_participants_repository_test.dart
@@ -51,6 +51,7 @@ void main() {
       <String, Object?>{
         'id': 1,
         'name': 'Анна',
+        'shortName': 'Анна',
         'isParticipant': true,
         'isAssistant': false,
         'deleted': false,
@@ -58,6 +59,7 @@ void main() {
       <String, Object?>{
         'id': 2,
         'name': 'Борис',
+        'shortName': 'Борис',
         'isParticipant': true,
         'isAssistant': false,
         'deleted': true,
@@ -122,6 +124,7 @@ void main() {
       <String, Object?>{
         'id': 2,
         'name': 'Анна',
+        'shortName': 'Анна',
         'isParticipant': true,
         'isAssistant': false,
         'deleted': false,
@@ -129,6 +132,7 @@ void main() {
       <String, Object?>{
         'id': 1,
         'name': 'Борис',
+        'shortName': 'Борис',
         'isParticipant': false,
         'isAssistant': true,
         'deleted': false,
@@ -136,6 +140,7 @@ void main() {
       <String, Object?>{
         'id': 3,
         'name': 'Василиса',
+        'shortName': 'Василиса',
         'isParticipant': true,
         'isAssistant': false,
         'deleted': false,

--- a/packages/bochki_schedule_app/test/domain/assistants/assistants_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/assistants/assistants_use_cases_test.dart
@@ -2,6 +2,24 @@ import 'package:bochki_schedule_app/bochki_schedule_app.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('updates a short name without requiring uniqueness', () async {
+    final repository = _InMemoryAssistantsRepository(
+      assistants: [
+        Assistant(id: '1', name: 'Анна'),
+        Assistant(id: '2', name: 'Борис', shortName: 'А'),
+      ],
+    );
+    final useCase = UpdateAssistantUseCase(repository);
+
+    final updated = await useCase.execute(
+      assistantId: '1',
+      rawShortName: ' А ',
+    );
+
+    expect(updated.name, 'Анна');
+    expect(updated.shortName, 'А');
+  });
+
   group('assistants use cases', () {
     test('list loads sorted assistants', () async {
       final repository = _InMemoryAssistantsRepository(

--- a/packages/bochki_schedule_app/test/features/directory/named_directory_dialog_test.dart
+++ b/packages/bochki_schedule_app/test/features/directory/named_directory_dialog_test.dart
@@ -20,6 +20,7 @@ void main() {
       updateEntry: ({
         required String entryId,
         required String rawName,
+        required String fieldId,
       }) async {
         return repository.update(
           Participant(id: entryId, name: rawName),


### PR DESCRIPTION
Closes #81\n\nДобавляет shortName для Human, мягкую миграцию при запуске, двухколоночный CRUD ассистентов и тесты.