### PR TITLE
feat(ui): separate procedure filters from results

### DIFF
--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -551,6 +551,8 @@ class _BochkiShellState extends State<BochkiShell> {
 }
 
 class _ProcedureSessionsHome extends StatelessWidget {
+  static const Color _filtersResultsDividerColor = Color(0xFFC4CDD5);
+
   const _ProcedureSessionsHome({
     required this.viewModel,
     required this.onEdit,
@@ -578,7 +580,15 @@ class _ProcedureSessionsHome extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 _ProcedureSessionFilters(viewModel: viewModel),
-                const SizedBox(height: 20),
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 10),
+                  child: Divider(
+                    key: Key('procedure_sessions_filters_results_divider'),
+                    height: 1,
+                    thickness: 1,
+                    color: _filtersResultsDividerColor,
+                  ),
+                ),
                 Expanded(
                   child: viewModel.isLoading
                       ? const Center(child: CircularProgressIndicator())

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -71,9 +71,15 @@ void main() {
     final participantField = find.byKey(
       const Key('procedure_sessions_participant_filter'),
     );
+    final filters = find.byKey(
+      const Key('procedure_sessions_filters_scroll_view'),
+    );
+    final divider = find.byKey(
+      const Key('procedure_sessions_filters_results_divider'),
+    );
 
-    expect(find.byKey(const Key('procedure_sessions_filters_scroll_view')),
-        findsOneWidget);
+    expect(filters, findsOneWidget);
+    expect(divider, findsOneWidget);
     expect(find.text('День'), findsOneWidget);
     expect(find.text('Часть дня'), findsOneWidget);
     expect(find.text('Процедура'), findsOneWidget);
@@ -84,6 +90,14 @@ void main() {
     expect(tester.getCenter(dayField).dy, tester.getCenter(procedureField).dy);
     expect(tester.getSize(procedureField).width,
         greaterThan(tester.getSize(partOfDayField).width));
+    expect(
+      tester.getTopLeft(divider).dy,
+      greaterThan(tester.getBottomLeft(filters).dy),
+    );
+    expect(tester.getSize(divider).width, lessThan(900));
+    final dividerWidget = tester.widget<Divider>(divider);
+    expect(dividerWidget.color, const Color(0xFFC4CDD5));
+    expect(dividerWidget.thickness, 1);
     expect(tester.takeException(), isNull);
   });
 


### PR DESCRIPTION
## Summary

- add a full-width divider between assigned-procedure filters and results
- preserve a 10 px vertical gap on both sides and use a more visible 1 px divider
- cover divider structure and narrow layout with a widget test

Closes #79

## Validation

- flutter test
- dart analyze