### PR TITLE
fix(directory): save inline edits when confirming dialog

### DIFF
--- a/packages/bochki_schedule_app/lib/src/features/directory/named_directory_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/directory/named_directory_dialog.dart
@@ -252,6 +252,29 @@ class _NamedDirectoryDialogState<T extends NamedDirectoryEntry>
     }
   }
 
+  Future<void> _saveAndClose() async {
+    final viewModel = widget.viewModel;
+    if (viewModel.isLoading || viewModel.isSaving) {
+      return;
+    }
+
+    final transition = _reducer.reduce(
+      state: _tableState,
+      event: const DirectoryTableEvent.clickOutside(),
+      rows: _rows,
+    );
+    _setTableState(transition.state);
+
+    final submitRequest = transition.submitRequest;
+    if (submitRequest != null && !await _submit(submitRequest)) {
+      return;
+    }
+
+    if (mounted) {
+      Navigator.of(context).pop();
+    }
+  }
+
   Offset _toTableLocalPosition(Offset globalPosition) {
     final renderObject = _tableAreaKey.currentContext?.findRenderObject();
     if (renderObject is! RenderBox) {
@@ -924,7 +947,9 @@ class _NamedDirectoryDialogState<T extends NamedDirectoryEntry>
                         mainAxisAlignment: MainAxisAlignment.end,
                         children: [
                           FilledButton(
-                            onPressed: () => Navigator.of(context).pop(),
+                            onPressed: viewModel.isSaving
+                                ? null
+                                : () => unawaited(_saveAndClose()),
                             child: Text(_config.okButtonText),
                           ),
                         ],

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -1613,6 +1613,95 @@ void main() {
     expect(find.descendant(of: row, matching: find.text('▶')), findsOneWidget);
   });
 
+  testWidgets('Ok saves edited participant and closes the dialog',
+      (tester) async {
+    final context = _buildTestContext(
+      participants: [Participant(id: '1', name: 'Анна')],
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await _openParticipantsDialog(tester);
+    await _doubleMouseClick(tester, find.byKey(const Key('participant_row_1')));
+    await tester.enterText(
+      find.byKey(const Key('participant_name_field')),
+      'Анна Петрова',
+    );
+
+    await tester.tap(find.text('Ok'));
+    await tester.pumpAndSettle();
+
+    expect(context.repository.participants.single.name, 'Анна Петрова');
+    expect(
+        find.byKey(const Key('participants_directory_dialog')), findsNothing);
+  });
+
+  testWidgets('Ok keeps participant dialog open when saving fails',
+      (tester) async {
+    final context = _buildTestContext(
+      participants: [
+        Participant(id: '1', name: 'Анна'),
+        Participant(id: '2', name: 'Борис'),
+      ],
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await _openParticipantsDialog(tester);
+    await _doubleMouseClick(tester, find.byKey(const Key('participant_row_1')));
+    await tester.enterText(
+      find.byKey(const Key('participant_name_field')),
+      'Борис',
+    );
+
+    await tester.tap(find.text('Ok'));
+    await tester.pumpAndSettle();
+
+    expect(
+        find.byKey(const Key('participants_directory_dialog')), findsOneWidget);
+    expect(find.byKey(const Key('participant_name_field')), findsOneWidget);
+    expect(find.text('Участник с таким именем уже есть.'), findsOneWidget);
+  });
+
+  testWidgets('Ok cancels an empty new participant row', (tester) async {
+    final context = _buildTestContext();
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await _openParticipantsDialog(tester);
+    await tester.tap(find.byKey(const Key('participant_add_row')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Ok'));
+    await tester.pumpAndSettle();
+
+    expect(context.repository.participants, isEmpty);
+    expect(
+        find.byKey(const Key('participants_directory_dialog')), findsNothing);
+  });
+
+  testWidgets('Ok saves edited assistant and closes the dialog',
+      (tester) async {
+    final context = _buildTestContext(
+      assistants: [Assistant(id: '1', name: 'Иван')],
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await _openAssistantsDialog(tester);
+    await _doubleMouseClick(tester, find.byKey(const Key('assistant_row_1')));
+    await tester.enterText(
+      find.byKey(const Key('assistant_name_field')),
+      'Иван Петров',
+    );
+
+    await tester.tap(find.text('Ok'));
+    await tester.pumpAndSettle();
+
+    expect(context.assistantsRepository.assistants.single.name, 'Иван Петров');
+    expect(find.byKey(const Key('assistants_directory_dialog')), findsNothing);
+  });
+
   testWidgets('empty add row is cancelled on click outside', (tester) async {
     final context = _buildTestContext();
 


### PR DESCRIPTION
Closes #87

## Что изменено
- Кнопка Ok теперь сохраняет незавершённые inline-правки и закрывает диалог только после успеха.
- При ошибке валидации диалог остаётся открытым, а введённое значение сохраняется.
- Пустая новая строка при Ok отменяется без создания записи.
- Добавлены widget-тесты для участников и ассистентов.