### PR TITLE
fix(reports): render accompaniment statistics cells

### DIFF
--- a/packages/bochki_schedule_app/lib/src/data/procedure_statistics/docx_procedure_statistics_exporter.dart
+++ b/packages/bochki_schedule_app/lib/src/data/procedure_statistics/docx_procedure_statistics_exporter.dart
@@ -39,21 +39,20 @@ final class DocxProcedureStatisticsExporter
           '${_table(document.pages[i])}${i + 1 < document.pages.length ? '<w:p><w:r><w:br w:type="page"/></w:r></w:p>' : ''}'
       ].join()}<w:sectPr><w:pgSz w:w="11906" w:h="16838"/><w:pgMar w:top="720" w:right="720" w:bottom="720" w:left="720"/></w:sectPr></w:body></w:document>''';
   String _table(ProcedureStatisticsPage page) =>
-      '<w:tbl><w:tblPr><w:tblBorders><w:top w:val="single" w:sz="8"/><w:left w:val="single" w:sz="8"/><w:bottom w:val="single" w:sz="8"/><w:right w:val="single" w:sz="8"/><w:insideH w:val="single" w:sz="8"/><w:insideV w:val="single" w:sz="8"/></w:tblBorders></w:tblPr><w:tblGrid><w:gridCol w:w="2400"/><w:gridCol w:w="2300"/><w:gridCol w:w="2300"/><w:gridCol w:w="2300"/><w:gridCol w:w="2300"/></w:tblGrid>${_row([
+      '<w:tbl><w:tblPr><w:tblBorders><w:top w:val="single" w:sz="8"/><w:left w:val="single" w:sz="8"/><w:bottom w:val="single" w:sz="8"/><w:right w:val="single" w:sz="8"/><w:insideH w:val="single" w:sz="8"/><w:insideV w:val="single" w:sz="8"/></w:tblBorders></w:tblPr><w:tblGrid><w:gridCol w:w="2400"/><w:gridCol w:w="2300"/><w:gridCol w:w="2300"/><w:gridCol w:w="2300"/><w:gridCol w:w="2300"/></w:tblGrid>${_textRow([
             'Кто',
             ...page.workdays.map((day) => day?.name ?? '')
-          ], header: true)}${page.rows.map((row) => row.cells.isEmpty ? _row([
+          ], header: true)}${page.rows.map((row) => row.cells.isEmpty ? _textRow([
               row.name,
               '',
               '',
               '',
               ''
-            ], header: true) : _row([
-              row.name,
-              ...row.cells.map(_cell)
-            ])).join()}</w:tbl>';
-  String _row(List<String> values, {bool header = false}) =>
+            ], header: true) : _dataRow(row)).join()}</w:tbl>';
+  String _textRow(List<String> values, {bool header = false}) =>
       '<w:tr>${values.map((value) => _cellText(value, bold: header)).join()}</w:tr>';
+  String _dataRow(ProcedureStatisticsRow row) =>
+      '<w:tr>${_cellText(row.name)}${row.cells.map(_cell).join()}</w:tr>';
   String _cell(ProcedureStatisticsCell cell) =>
       '<w:tc><w:tcPr><w:tcW w:w="0" w:type="auto"/></w:tcPr>${cell.lines.isEmpty ? _paragraph('') : cell.lines.map((line) => switch (line) {
             ProcedureStatisticsTextLine(:final text) => _paragraph(text),

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_statistics/build_procedure_statistics_document_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_statistics/build_procedure_statistics_document_use_case.dart
@@ -92,10 +92,10 @@ final class BuildProcedureStatisticsDocumentUseCase {
   }
 
   String _fileName(List<Workday> workdays) {
-    if (workdays.isEmpty) return 'statistika-procedur.docx';
+    if (workdays.isEmpty) return 'statistika-po-soprovozhdeniyam.docx';
     String format(DateTime value) =>
         '${value.year.toString().padLeft(4, '0')}-${value.month.toString().padLeft(2, '0')}-${value.day.toString().padLeft(2, '0')}';
-    return 'statistika-procedur-${format(workdays.first.calendarDate)}-${format(workdays.last.calendarDate)}.docx';
+    return 'statistika-po-soprovozhdeniyam-${format(workdays.first.calendarDate)}-${format(workdays.last.calendarDate)}.docx';
   }
 
   ProcedureStatisticsRow _row(Human human, List<Workday?> workdays,

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -523,7 +523,7 @@ class _BochkiShellState extends State<BochkiShell> {
                     itemBuilder: (context) => const [
                       PopupMenuItem<ReportsSection>(
                         value: ReportsSection.statistics,
-                        child: Text('Статистика'),
+                        child: Text('Статистика по сопровождениям'),
                       ),
                       PopupMenuItem<ReportsSection>(
                         value: ReportsSection.procedureStatistics,

--- a/packages/bochki_schedule_app/test/data/procedure_statistics/docx_procedure_statistics_exporter_test.dart
+++ b/packages/bochki_schedule_app/test/data/procedure_statistics/docx_procedure_statistics_exporter_test.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:bochki_schedule_app/src/data/procedure_statistics/docx_procedure_statistics_exporter.dart';
+import 'package:bochki_schedule_app/src/domain/procedure_statistics/procedure_statistics_document.dart';
+import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('exports statistics cells as DOCX XML rather than escaped text',
+      () async {
+    final tempDirectory =
+        await Directory.systemTemp.createTemp('bochki_statistics_docx_test');
+    addTearDown(() => tempDirectory.delete(recursive: true));
+    final exporter = DocxProcedureStatisticsExporter(
+      safeFileWriter: const AtomicFileWriter(),
+    );
+
+    final file = await exporter.export(
+      document: const ProcedureStatisticsDocument(
+        fileName: 'statistika-po-soprovozhdeniyam-2026-07-13-2026-07-14.docx',
+        pages: [
+          ProcedureStatisticsPage(
+            workdays: [],
+            rows: [
+              ProcedureStatisticsRow(
+                name: 'Иванов & Иван',
+                cells: [
+                  ProcedureStatisticsCell([
+                    ProcedureStatisticsTextLine('1 Бег'),
+                    ProcedureStatisticsTextLine('Бочка - Анна'),
+                    ProcedureStatisticsDividerLine(),
+                    ProcedureStatisticsTextLine('Группа 2+'),
+                  ]),
+                  ProcedureStatisticsCell([]),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+      outputDirectory: tempDirectory,
+    );
+
+    expect(
+      file.path,
+      endsWith('statistika-po-soprovozhdeniyam-2026-07-13-2026-07-14.docx'),
+    );
+
+    final archive = ZipDecoder().decodeBytes(await file.readAsBytes());
+    final documentXml = archive.files
+        .firstWhere((entry) => entry.name == 'word/document.xml')
+        .content as List<int>;
+    final xml = utf8.decode(documentXml);
+
+    expect(xml, contains('<w:t xml:space="preserve">1 Бег</w:t>'));
+    expect(xml, contains('<w:t xml:space="preserve">Бочка - Анна</w:t>'));
+    expect(xml, contains('<w:pBdr><w:bottom w:val="single" w:sz="8"/>'));
+    expect(xml, contains('Иванов &amp; Иван'));
+    expect(xml, isNot(contains('&lt;w:tc&gt;')));
+    expect(xml, isNot(contains('&lt;/w:tc&gt;')));
+  });
+}


### PR DESCRIPTION
Closes #88.\n\n- renders generated DOCX cell XML directly instead of escaping it as text\n- renames the accompaniment statistics menu item and exported filenames\n- adds a regression test for multi-line and empty cells