### PR TITLE
feat: add saved schedule templates

### DIFF
--- a/packages/bochki_schedule_app/lib/src/app.dart
+++ b/packages/bochki_schedule_app/lib/src/app.dart
@@ -9,10 +9,12 @@ import 'presentation/shell/bochki_shell.dart';
 class BochkiScheduleApp extends StatefulWidget {
   const BochkiScheduleApp({
     required this.services,
+    this.onProjectLoaded,
     super.key,
   });
 
   final AppServices services;
+  final Future<void> Function()? onProjectLoaded;
 
   @override
   State<BochkiScheduleApp> createState() => _BochkiScheduleAppState();
@@ -63,7 +65,10 @@ class _BochkiScheduleAppState extends State<BochkiScheduleApp> {
         ),
         scaffoldBackgroundColor: const Color(0xFFF6F7F9),
       ),
-      home: BochkiShell(services: widget.services),
+      home: BochkiShell(
+        services: widget.services,
+        onProjectLoaded: widget.onProjectLoaded,
+      ),
     );
   }
 }

--- a/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
+++ b/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
@@ -55,6 +55,7 @@ import 'domain/procedure_statistics/open_procedure_statistics_file_use_case.dart
 import 'domain/procedure_statistics/build_procedure_statistics_table_use_case.dart';
 import 'domain/procedure_statistics/save_procedure_statistics_file_use_case.dart';
 import 'domain/schedule_gaps/build_schedule_gaps_use_case.dart';
+import 'domain/templates/template_service.dart';
 
 final class AppBootstrap {
   static Future<AppServices> initialize({
@@ -90,6 +91,14 @@ final class AppBootstrap {
       repository: projectDocumentRepository,
       initialDocument: initialDocument,
       logger: logger,
+    );
+    final templateService = TemplateService(
+      store: TemplateFileStore(
+        appDataDirectory: resolvedAppDataDirectory,
+        safeFileWriter: const AtomicFileWriter(),
+      ),
+      projectRepository: projectDocumentRepository,
+      flushPending: syncCoordinator.flushPending,
     );
     final idAllocator = ProjectDocumentIdAllocator(
       nextId: initialDocument.nextId,
@@ -347,6 +356,7 @@ final class AppBootstrap {
       quickReassignmentsUseCase: quickReassignmentsUseCase,
       flushPending: syncCoordinator.flushPending,
       shutdown: syncCoordinator.shutdown,
+      templateService: templateService,
     );
   }
 

--- a/packages/bochki_schedule_app/lib/src/app_services.dart
+++ b/packages/bochki_schedule_app/lib/src/app_services.dart
@@ -35,6 +35,7 @@ import 'domain/workdays/update_workday_use_case.dart';
 import 'domain/procedure_statistics/open_procedure_statistics_file_use_case.dart';
 import 'domain/procedure_statistics/build_procedure_statistics_table_use_case.dart';
 import 'domain/schedule_gaps/build_schedule_gaps_use_case.dart';
+import 'domain/templates/template_service.dart';
 
 final class AppServices {
   const AppServices({
@@ -75,6 +76,7 @@ final class AppServices {
     this.quickReassignmentsUseCase,
     required this.flushPending,
     required this.shutdown,
+    this.templateService,
   });
 
   final Directory appDataDirectory;
@@ -116,4 +118,5 @@ final class AppServices {
   final QuickReassignmentsUseCase? quickReassignmentsUseCase;
   final Future<void> Function() flushPending;
   final Future<void> Function() shutdown;
+  final TemplateService? templateService;
 }

--- a/packages/bochki_schedule_app/lib/src/domain/templates/template_service.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/templates/template_service.dart
@@ -1,0 +1,42 @@
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
+
+final class TemplateService {
+  TemplateService({
+    required TemplateFileStore store,
+    required ProjectDocumentRepository projectRepository,
+    required Future<void> Function() flushPending,
+  })  : _store = store,
+        _projectRepository = projectRepository,
+        _flushPending = flushPending;
+
+  final TemplateFileStore _store;
+  final ProjectDocumentRepository _projectRepository;
+  final Future<void> Function() _flushPending;
+
+  Future<List<TemplateFile>> list() => _store.list();
+  String validateTitle(String value) => _store.validateTitle(value);
+  Future<TemplateFile?> existing(String name) => _store.findExisting(name);
+
+  Future<TemplateFile?> existingForTitle(String title) async {
+    await _flushPending();
+    final preview = _store.preview(
+      title: title,
+      document: await _projectRepository.load(),
+    );
+    return _store.findExisting(preview.file.path.split('/').last);
+  }
+
+  Future<TemplateFile> save(String title) async {
+    await _flushPending();
+    return _store.save(title: title, document: await _projectRepository.load());
+  }
+
+  Future<void> load(TemplateFile template) async {
+    final document = await _store.read(template);
+    await _flushPending();
+    await _projectRepository.save(document);
+  }
+
+  Future<void> delete(TemplateFile template) => _store.delete(template);
+}

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
 
 import '../../app_services.dart';
 import '../../features/participants/participants_dialog.dart';
@@ -36,13 +37,17 @@ enum DirectorySection {
 
 enum ReportsSection { statistics, procedureStatistics, freeTime }
 
+enum TemplatesSection { create, load, delete }
+
 class BochkiShell extends StatefulWidget {
   const BochkiShell({
     required this.services,
+    this.onProjectLoaded,
     super.key,
   });
 
   final AppServices services;
+  final Future<void> Function()? onProjectLoaded;
 
   @override
   State<BochkiShell> createState() => _BochkiShellState();
@@ -56,6 +61,7 @@ class _BochkiShellState extends State<BochkiShell> {
   bool _programSettingsDialogOpen = false;
   bool _printPresetParamsDialogOpen = false;
   bool _quickReassignmentsDialogOpen = false;
+  bool _templatesDialogOpen = false;
   late final ProcedureSessionsViewModel _procedureSessionsViewModel;
   DesktopWindowCoordinator? _desktopWindows;
 
@@ -374,6 +380,178 @@ class _BochkiShellState extends State<BochkiShell> {
     }
   }
 
+  Future<void> _selectTemplateSection(TemplatesSection section) async {
+    if (widget.services.templateService == null) return;
+    if (_templatesDialogOpen) return;
+    setState(() => _templatesDialogOpen = true);
+    try {
+      switch (section) {
+        case TemplatesSection.create:
+          await _createTemplate();
+          return;
+        case TemplatesSection.load:
+          await _chooseTemplate(isDelete: false);
+          return;
+        case TemplatesSection.delete:
+          await _chooseTemplate(isDelete: true);
+          return;
+      }
+    } finally {
+      if (mounted) setState(() => _templatesDialogOpen = false);
+    }
+  }
+
+  Future<void> _createTemplate() async {
+    final templateService = widget.services.templateService;
+    if (templateService == null) return;
+    final controller = TextEditingController();
+    try {
+      final title = await showDialog<String>(
+        context: context,
+        barrierDismissible: false,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('Создать шаблон'),
+          content: TextField(
+            key: const Key('template_title_field'),
+            controller: controller,
+            autofocus: true,
+            decoration: const InputDecoration(labelText: 'Название шаблона'),
+          ),
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.pop(dialogContext),
+                child: const Text('Отмена')),
+            FilledButton(
+                onPressed: () => Navigator.pop(dialogContext, controller.text),
+                child: const Text('Сохранить')),
+          ],
+        ),
+      );
+      if (title == null) return;
+      final error = templateService.validateTitle(title);
+      if (error.isNotEmpty) {
+        _showError(error);
+        return;
+      }
+      final existing = await templateService.existingForTitle(title);
+      if (existing != null &&
+          !await _confirm('Перезаписать шаблон?',
+              'Шаблон «${existing.displayName}» уже существует.')) return;
+      await templateService.save(title);
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Шаблон сохранён.')));
+      }
+    } catch (error) {
+      _showError('Не удалось сохранить шаблон: $error');
+    } finally {
+      controller.dispose();
+    }
+  }
+
+  Future<void> _chooseTemplate({required bool isDelete}) async {
+    final templateService = widget.services.templateService;
+    if (templateService == null) return;
+    final templates = await templateService.list();
+    if (!mounted) return;
+    TemplateFile? selected;
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (context, setDialogState) => AlertDialog(
+          title:
+              Text(isDelete ? 'Удалить шаблон' : 'Загрузить данные из шаблона'),
+          content: SizedBox(
+            width: 520,
+            height: 300,
+            child: templates.isEmpty
+                ? const Center(child: Text('Сохранённых шаблонов нет.'))
+                : ListView.builder(
+                    itemCount: templates.length,
+                    itemBuilder: (_, index) {
+                      final template = templates[index];
+                      return RadioListTile<TemplateFile>(
+                        value: template,
+                        groupValue: selected,
+                        title: Text(template.displayName),
+                        onChanged: (value) =>
+                            setDialogState(() => selected = value),
+                      );
+                    },
+                  ),
+          ),
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.pop(dialogContext),
+                child: const Text('Отмена')),
+            FilledButton(
+              style: isDelete
+                  ? FilledButton.styleFrom(backgroundColor: Colors.red)
+                  : null,
+              onPressed:
+                  selected == null ? null : () => Navigator.pop(dialogContext),
+              child: Text(isDelete ? 'Удалить' : 'Загрузить'),
+            ),
+          ],
+        ),
+      ),
+    );
+    final template = selected;
+    if (template == null || !mounted) return;
+    if (isDelete) {
+      if (!await _confirm('Удалить шаблон?',
+          'Шаблон «${template.displayName}» будет удалён без возможности восстановления.',
+          destructive: true)) return;
+      await templateService.delete(template);
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Шаблон удалён.')));
+      }
+      return;
+    }
+    if (!await _confirm('Загрузить шаблон?',
+        'Текущие данные будут заменены шаблоном «${template.displayName}».')) {
+      return;
+    }
+    try {
+      await templateService.load(template);
+      await widget.onProjectLoaded?.call();
+    } catch (error) {
+      _showError('Не удалось загрузить шаблон: $error');
+    }
+  }
+
+  Future<bool> _confirm(String title, String content,
+          {bool destructive = false}) async =>
+      await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: Text(title),
+          content: Text(content),
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: const Text('Отмена')),
+            FilledButton(
+              style: destructive
+                  ? FilledButton.styleFrom(backgroundColor: Colors.red)
+                  : null,
+              onPressed: () => Navigator.pop(context, true),
+              child: Text(destructive ? 'Удалить' : 'Загрузить'),
+            ),
+          ],
+        ),
+      ) ??
+      false;
+
+  void _showError(String message) {
+    if (mounted) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(message)));
+    }
+  }
+
   void _selectDirectorySection(DirectorySection section) {
     switch (section) {
       case DirectorySection.procedureKinds:
@@ -548,6 +726,40 @@ class _BochkiShellState extends State<BochkiShell> {
                           Icon(Icons.arrow_drop_down, size: 18),
                         ],
                       ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  PopupMenuButton<TemplatesSection>(
+                    key: const Key('templates_menu_button'),
+                    tooltip: 'Шаблоны',
+                    popUpAnimationStyle: AnimationStyle.noAnimation,
+                    onSelected: (section) =>
+                        unawaited(_selectTemplateSection(section)),
+                    itemBuilder: (context) => const [
+                      PopupMenuItem(
+                          value: TemplatesSection.create,
+                          child: Text('Создать шаблон')),
+                      PopupMenuItem(
+                          value: TemplatesSection.load,
+                          child: Text('Загрузить данные из шаблона')),
+                      PopupMenuItem(
+                          value: TemplatesSection.delete,
+                          child: Text('Удалить шаблон')),
+                    ],
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 10, vertical: 6),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(6),
+                        color: Colors.white.withOpacity(0.72),
+                        border: Border.all(color: const Color(0xFFD0D7DE)),
+                      ),
+                      child:
+                          const Row(mainAxisSize: MainAxisSize.min, children: [
+                        Text('Шаблоны'),
+                        SizedBox(width: 6),
+                        Icon(Icons.arrow_drop_down, size: 18),
+                      ]),
                     ),
                   ),
                   const SizedBox(width: 12),

--- a/packages/bochki_schedule_app/lib/src/presentation/startup_launcher.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/startup_launcher.dart
@@ -62,6 +62,19 @@ class _StartupLauncherState extends State<StartupLauncher> {
     }
   }
 
+  Future<void> _reloadProject() async {
+    final previous = _services;
+    if (previous == null) return;
+    await previous.shutdown();
+    final services = await widget.bootstrap(widget.diagnostics);
+    widget.onServicesReady?.call(services);
+    if (!mounted) {
+      await services.shutdown();
+      return;
+    }
+    setState(() => _services = services);
+  }
+
   void _continueToApplication() {
     setState(() => _status = StartupStatus.continued);
   }
@@ -70,7 +83,10 @@ class _StartupLauncherState extends State<StartupLauncher> {
   Widget build(BuildContext context) {
     final services = _services;
     if (_status == StartupStatus.continued && services != null) {
-      return BochkiScheduleApp(services: services);
+      return BochkiScheduleApp(
+        services: services,
+        onProjectLoaded: _reloadProject,
+      );
     }
 
     return StartupErrorApp(

--- a/packages/bochki_schedule_infra/lib/bochki_schedule_infra.dart
+++ b/packages/bochki_schedule_infra/lib/bochki_schedule_infra.dart
@@ -5,3 +5,4 @@ export 'src/app_paths.dart';
 export 'src/file_app_logger.dart';
 export 'src/project_document_store.dart';
 export 'src/safe_file_writer.dart';
+export 'src/template_file_store.dart';

--- a/packages/bochki_schedule_infra/lib/src/template_file_store.dart
+++ b/packages/bochki_schedule_infra/lib/src/template_file_store.dart
@@ -1,0 +1,151 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+import 'package:path/path.dart' as p;
+
+import 'safe_file_writer.dart';
+
+final class TemplateFile {
+  const TemplateFile({
+    required this.file,
+    required this.title,
+    required this.workdays,
+    required this.participants,
+    required this.assistants,
+  });
+
+  final File file;
+  final String title;
+  final int workdays;
+  final int participants;
+  final int assistants;
+
+  String get displayName => p.basenameWithoutExtension(file.path);
+}
+
+final class TemplateFileStore {
+  TemplateFileStore({
+    required Directory appDataDirectory,
+    required SafeFileWriter safeFileWriter,
+  })  : _directory = Directory(p.join(appDataDirectory.path, 'saved-patterns')),
+        _safeFileWriter = safeFileWriter;
+
+  static final RegExp _nameExpression = RegExp(
+    r'^(.+) -- ([0-9]+)-([0-9]+)-([0-9]+)\.json$',
+  );
+  static final RegExp _invalidTitleCharacters =
+      RegExp(r'[<>:"/\\|?*\x00-\x1F]');
+
+  final Directory _directory;
+  final SafeFileWriter _safeFileWriter;
+
+  Future<List<TemplateFile>> list() async {
+    if (!await _directory.exists()) return const [];
+    final templates = <TemplateFile>[];
+    await for (final entity in _directory.list(followLinks: false)) {
+      if (entity is! File) continue;
+      final parsed = _parse(p.basename(entity.path));
+      if (parsed != null) templates.add(parsed.withFile(entity));
+    }
+    templates.sort((a, b) =>
+        a.displayName.toLowerCase().compareTo(b.displayName.toLowerCase()));
+    return templates;
+  }
+
+  String validateTitle(String value) {
+    final title = value.trim();
+    if (title.isEmpty) return 'Введите название шаблона.';
+    if (title.contains(' -- ')) return 'Название не должно содержать « -- ».';
+    if (_invalidTitleCharacters.hasMatch(title))
+      return 'Название содержит недопустимые символы.';
+    return '';
+  }
+
+  Future<TemplateFile?> findExisting(String fileName) async {
+    final normalized = p.basename(fileName).toLowerCase();
+    for (final template in await list()) {
+      if (p.basename(template.file.path).toLowerCase() == normalized)
+        return template;
+    }
+    return null;
+  }
+
+  Future<TemplateFile> save(
+      {required String title, required ProjectDocument document}) async {
+    final error = validateTitle(title);
+    if (error.isNotEmpty) throw FormatException(error);
+    final template = _fromDocument(title.trim(), document);
+    final contents =
+        const JsonEncoder.withIndent('  ').convert(document.toJson());
+    await _safeFileWriter.writeString(template.file, contents);
+    return template;
+  }
+
+  TemplateFile preview(
+      {required String title, required ProjectDocument document}) {
+    final error = validateTitle(title);
+    if (error.isNotEmpty) throw FormatException(error);
+    return _fromDocument(title.trim(), document);
+  }
+
+  Future<ProjectDocument> read(TemplateFile template) async {
+    final decoded = jsonDecode(await template.file.readAsString());
+    if (decoded is! Map)
+      throw const FormatException('Файл шаблона должен содержать JSON-объект.');
+    final json = <String, Object?>{
+      for (final entry in decoded.entries) entry.key.toString(): entry.value
+    };
+    final version =
+        (json['schemaVersion'] as num?)?.toInt() ?? SchemaVersion.current;
+    if (version > SchemaVersion.current) {
+      throw FormatException(
+          'Шаблон создан более новой версией приложения (схема $version).');
+    }
+    return ProjectDocument.fromJson(json);
+  }
+
+  Future<void> delete(TemplateFile template) => template.file.delete();
+
+  TemplateFile _fromDocument(String title, ProjectDocument document) {
+    final workdays = _active(document.workdays).length;
+    final humans = _active(document.humans);
+    final participants =
+        humans.where((entry) => entry['isParticipant'] == true).length;
+    final assistants =
+        humans.where((entry) => entry['isAssistant'] == true).length;
+    final name = '$title -- $workdays-$participants-$assistants.json';
+    return TemplateFile(
+        file: File(p.join(_directory.path, name)),
+        title: title,
+        workdays: workdays,
+        participants: participants,
+        assistants: assistants);
+  }
+
+  static List<Map<String, Object?>> _active(
+          List<Map<String, Object?>> values) =>
+      values.where((entry) => entry['deleted'] != true).toList(growable: false);
+
+  static _ParsedTemplate? _parse(String name) {
+    final match = _nameExpression.firstMatch(name);
+    if (match == null) return null;
+    return _ParsedTemplate(match.group(1)!, int.parse(match.group(2)!),
+        int.parse(match.group(3)!), int.parse(match.group(4)!));
+  }
+}
+
+final class _ParsedTemplate {
+  const _ParsedTemplate(
+      this.title, this.workdays, this.participants, this.assistants);
+  final String title;
+  final int workdays;
+  final int participants;
+  final int assistants;
+  TemplateFile withFile(File file) => TemplateFile(
+      file: file,
+      title: title,
+      workdays: workdays,
+      participants: participants,
+      assistants: assistants);
+}

--- a/packages/bochki_schedule_infra/test/template_file_store_test.dart
+++ b/packages/bochki_schedule_infra/test/template_file_store_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory directory;
+  late TemplateFileStore store;
+
+  setUp(() async {
+    directory = await Directory.systemTemp.createTemp('bochki_templates_test');
+    store = TemplateFileStore(
+      appDataDirectory: directory,
+      safeFileWriter: const AtomicFileWriter(),
+    );
+  });
+
+  tearDown(() => directory.delete(recursive: true));
+
+  test('saves a full document with active entity counts in its filename',
+      () async {
+    final template = await store.save(
+      title: 'Бочки июль 26',
+      document: const ProjectDocument(
+        humans: [
+          {
+            'id': 1,
+            'name': 'Ученик',
+            'isParticipant': true,
+            'isAssistant': false,
+            'deleted': false
+          },
+          {
+            'id': 2,
+            'name': 'Ассистент',
+            'isParticipant': false,
+            'isAssistant': true,
+            'deleted': false
+          },
+          {
+            'id': 3,
+            'name': 'Удалён',
+            'isParticipant': true,
+            'isAssistant': true,
+            'deleted': true
+          },
+        ],
+        workdays: [
+          {'id': 1, 'name': 'День 1', 'deleted': false},
+          {'id': 2, 'name': 'День 2', 'deleted': true},
+        ],
+      ),
+    );
+
+    expect(template.displayName, 'Бочки июль 26 -- 1-1-1');
+    expect(await store.list(), hasLength(1));
+  });
+
+  test('lists only files with a template filename and rejects future schemas',
+      () async {
+    final templatesDirectory = Directory('${directory.path}/saved-patterns');
+    await templatesDirectory.create(recursive: true);
+    await File('${templatesDirectory.path}/other.json').writeAsString('{}');
+    final future = File('${templatesDirectory.path}/Новый -- 1-2-3.json');
+    await future.writeAsString('{"schemaVersion": 2}');
+
+    final templates = await store.list();
+    expect(templates, hasLength(1));
+    expect(() => store.read(templates.single), throwsFormatException);
+  });
+
+  test('rejects unsafe and empty titles', () {
+    expect(store.validateTitle(''), isNotEmpty);
+    expect(store.validateTitle('foo -- bar'), isNotEmpty);
+    expect(store.validateTitle('foo/name'), isNotEmpty);
+    expect(store.validateTitle('Хорошее имя'), isEmpty);
+  });
+}


### PR DESCRIPTION
Closes #92

Adds saved project templates with validated file naming, create/load/delete dialogs, full-project replacement with session reload, compatibility validation, and storage tests.