### PR TITLE
fix(templates): rebuild runtime after loading

### DIFF
--- a/packages/bochki_schedule_app/lib/src/presentation/startup_launcher.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/startup_launcher.dart
@@ -84,6 +84,7 @@ class _StartupLauncherState extends State<StartupLauncher> {
     final services = _services;
     if (_status == StartupStatus.continued && services != null) {
       return BochkiScheduleApp(
+        key: ValueKey(services),
         services: services,
         onProjectLoaded: _reloadProject,
       );

--- a/packages/bochki_schedule_app/test/app_bootstrap_test.dart
+++ b/packages/bochki_schedule_app/test/app_bootstrap_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:bochki_schedule_app/bochki_schedule_app.dart';
 import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 
@@ -84,5 +85,159 @@ void main() {
     final projectContents = await projectFile.readAsString();
     expect(projectContents, contains('"resourceBusyTime": 20'));
     expect(projectContents, contains('"shortName": "Бег"'));
+  });
+
+  test('loading a template replaces every project data source after restart',
+      () async {
+    final tempRoot = await Directory.systemTemp.createTemp(
+      'bochki_bootstrap_template_load_test',
+    );
+    final services = await AppBootstrap.initialize(appDataDirectory: tempRoot);
+    addTearDown(() => tempRoot.delete(recursive: true));
+
+    const templateDocument = ProjectDocument(
+      nextId: 50,
+      humans: [
+        <String, Object?>{
+          'id': 10,
+          'name': 'Новый участник',
+          'shortName': 'Новый',
+          'isParticipant': true,
+          'isAssistant': false,
+          'deleted': false,
+        },
+        <String, Object?>{
+          'id': 11,
+          'name': 'Новый ассистент',
+          'shortName': 'Ассистент',
+          'isParticipant': false,
+          'isAssistant': true,
+          'deleted': false,
+        },
+      ],
+      procedureKinds: [
+        <String, Object?>{
+          'id': 12,
+          'patternId': 'single',
+          'name': 'Новая процедура',
+          'shortName': 'Новая',
+          'capacity': 1,
+          'participantBusyTime': 30,
+          'resourceBusyTime': 30,
+          'deleted': false,
+        },
+      ],
+      workdays: [
+        <String, Object?>{
+          'id': 13,
+          'name': 'Новый день',
+          'calendarDate': '2026-08-20',
+          'deleted': false,
+        },
+      ],
+      procedureSessions: [
+        <String, Object?>{
+          'id': 14,
+          'dayId': 13,
+          'participantId': 10,
+          'startTime': '10:00',
+          'procedureKindId': 12,
+          'assistantId': 11,
+          'deleted': false,
+        },
+      ],
+      programSettings: ProgramSettings(
+        lunchStart: ProgramSettingsTime(hour: 12, minute: 0),
+        lunchEnd: ProgramSettingsTime(hour: 13, minute: 0),
+        minimumHour: 7,
+        maximumHour: 22,
+      ),
+      printPresetParams: PrintPresetParams(
+        workdayId: '13',
+        textBefore: 'Начало шаблона',
+        textAfter: 'Конец шаблона',
+      ),
+    );
+    final store = TemplateFileStore(
+      appDataDirectory: tempRoot,
+      safeFileWriter: const AtomicFileWriter(),
+    );
+    final template = await store.save(
+      title: 'Полная замена',
+      document: templateDocument,
+    );
+
+    await services.createParticipantUseCase.execute('Старый участник');
+    await services.flushPending();
+    await services.templateService!.load(template);
+    await services.shutdown();
+
+    final reloaded = await AppBootstrap.initialize(appDataDirectory: tempRoot);
+    addTearDown(reloaded.shutdown);
+
+    expect(
+      (await reloaded.listParticipantsUseCase.execute()).single.name,
+      'Новый участник',
+    );
+    expect(
+      (await reloaded.listAssistantsUseCase.execute()).single.name,
+      'Новый ассистент',
+    );
+    expect((await reloaded.listWorkdaysUseCase.execute()).single.name,
+        'Новый день');
+    expect((await reloaded.listProcedureKindsUseCase.execute()).single.name,
+        'Новая процедура');
+    expect(
+      (await reloaded.listProcedureSessionsUseCase.execute()).single.id,
+      '14',
+    );
+    expect(
+      await reloaded.getProgramSettingsUseCase.execute(),
+      templateDocument.programSettings,
+    );
+    expect(
+      await reloaded.getPrintPresetParamsUseCase.execute(),
+      templateDocument.printPresetParams,
+    );
+    expect(
+      (await reloaded.createParticipantUseCase.execute('Следующий')).id,
+      '50',
+    );
+  });
+
+  test('an unreadable template leaves the current project unchanged', () async {
+    final tempRoot = await Directory.systemTemp.createTemp(
+      'bochki_bootstrap_bad_template_test',
+    );
+    final services = await AppBootstrap.initialize(appDataDirectory: tempRoot);
+    addTearDown(() async {
+      await services.shutdown();
+      await tempRoot.delete(recursive: true);
+    });
+    await services.createParticipantUseCase.execute('Текущий участник');
+    await services.flushPending();
+    final projectFile = File(p.join(tempRoot.path, 'project.json'));
+    final beforeLoad = await projectFile.readAsString();
+    final invalidTemplate = TemplateFile(
+      file: File(
+          p.join(tempRoot.path, 'saved-patterns', 'Повреждён -- 0-0-0.json')),
+      title: 'Повреждён',
+      workdays: 0,
+      participants: 0,
+      assistants: 0,
+    );
+    await invalidTemplate.file.parent.create(recursive: true);
+    await invalidTemplate.file.writeAsString('{"schemaVersion": 999}');
+
+    await expectLater(
+      services.templateService!.load(invalidTemplate),
+      throwsFormatException,
+    );
+
+    expect(await projectFile.readAsString(), beforeLoad);
+    expect(
+      (await services.listParticipantsUseCase.execute()).single.name,
+      'Текущий участник',
+    );
   });
 }

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -29,6 +29,81 @@ void main() {
     expect(find.text('Список назначенных процедур пуст.'), findsOneWidget);
   });
 
+  testWidgets('a new app services instance recreates the shell state', (
+    tester,
+  ) async {
+    final oldContext = _buildTestContext(
+      participants: [Participant(id: '1', name: 'Старый участник')],
+      procedureKinds: [
+        ProcedureKind(
+          id: '2',
+          patternId: ProcedureKindPatterns.single.patternId,
+          name: 'Старая процедура',
+          capacity: 1,
+          participantBusyTime: 30,
+          resourceBusyTime: 30,
+        ),
+      ],
+      workdays: [
+        Workday(id: '3', name: 'Старый день', calendarDate: DateTime(2026)),
+      ],
+      procedureSessions: [
+        ProcedureSessionRaw(
+          id: '4',
+          dayId: '3',
+          participantId: '1',
+          startTime: '10:00',
+          procedureKindId: '2',
+        ),
+      ],
+    );
+    final newContext = _buildTestContext(
+      participants: [Participant(id: '11', name: 'Новый участник')],
+      procedureKinds: [
+        ProcedureKind(
+          id: '12',
+          patternId: ProcedureKindPatterns.single.patternId,
+          name: 'Новая процедура',
+          capacity: 1,
+          participantBusyTime: 30,
+          resourceBusyTime: 30,
+        ),
+      ],
+      workdays: [
+        Workday(id: '13', name: 'Новый день', calendarDate: DateTime(2026)),
+      ],
+      procedureSessions: [
+        ProcedureSessionRaw(
+          id: '14',
+          dayId: '13',
+          participantId: '11',
+          startTime: '11:00',
+          procedureKindId: '12',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      BochkiScheduleApp(
+        key: ValueKey(oldContext.services),
+        services: oldContext.services,
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Старая процедура'), findsOneWidget);
+
+    await tester.pumpWidget(
+      BochkiScheduleApp(
+        key: ValueKey(newContext.services),
+        services: newContext.services,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Старая процедура'), findsNothing);
+    expect(find.text('Новая процедура'), findsOneWidget);
+  });
+
   testWidgets('procedure session filters use a two-row scrollable form', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary
- recreate the app shell when template loading produces a new service graph
- cover replacement of every persisted project section after restart
- keep the current project intact when a template cannot be read

Closes #103

## Checks
- dart format --output=none --set-exit-if-changed .
- dart analyze .
- flutter test -r expanded