### PR TITLE
feat(directories): show active record counts in menu

### DIFF
--- a/packages/bochki_schedule_app/integration_test/app_shell_test.dart
+++ b/packages/bochki_schedule_app/integration_test/app_shell_test.dart
@@ -121,7 +121,7 @@ void main() {
 
     _openDirectoriesMenu(tester);
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Ассистенты').last);
+    await tester.tap(find.text('Ассистенты (0)').last);
     await tester.pumpAndSettle();
 
     expect(
@@ -133,7 +133,7 @@ void main() {
 
     _openDirectoriesMenu(tester);
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Участники').last);
+    await tester.tap(find.text('Участники (0)').last);
     await tester.pumpAndSettle();
 
     final participantsDialog = find.byKey(

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -62,6 +62,10 @@ class _BochkiShellState extends State<BochkiShell> {
   bool _printPresetParamsDialogOpen = false;
   bool _quickReassignmentsDialogOpen = false;
   bool _templatesDialogOpen = false;
+  int? _procedureKindsCount;
+  int? _workdaysCount;
+  int? _assistantsCount;
+  int? _participantsCount;
   late final ProcedureSessionsViewModel _procedureSessionsViewModel;
   DesktopWindowCoordinator? _desktopWindows;
 
@@ -94,6 +98,73 @@ class _BochkiShellState extends State<BochkiShell> {
       unawaited(_startDesktopWindows());
     }
     unawaited(_procedureSessionsViewModel.load());
+    unawaited(_loadDirectoryCounts());
+  }
+
+  Future<void> _loadDirectoryCounts() async {
+    await _refreshProcedureKindsCount();
+    await _refreshWorkdaysCount();
+    await _refreshAssistantsCount();
+    await _refreshParticipantsCount();
+  }
+
+  Future<void> _refreshProcedureKindsCount() async {
+    try {
+      final count =
+          (await widget.services.listProcedureKindsUseCase.execute()).length;
+      if (mounted) {
+        setState(() => _procedureKindsCount = count);
+      }
+    } catch (_) {
+      // Keep the most recently loaded value, if any.
+    }
+  }
+
+  Future<void> _refreshWorkdaysCount() async {
+    try {
+      final count =
+          (await widget.services.listWorkdaysUseCase.execute()).length;
+      if (mounted) {
+        setState(() => _workdaysCount = count);
+      }
+    } catch (_) {
+      // Keep the most recently loaded value, if any.
+    }
+  }
+
+  Future<void> _refreshAssistantsCount() async {
+    try {
+      final count =
+          (await widget.services.listAssistantsUseCase.execute()).length;
+      if (mounted) {
+        setState(() => _assistantsCount = count);
+      }
+    } catch (_) {
+      // Keep the most recently loaded value, if any.
+    }
+  }
+
+  Future<void> _refreshParticipantsCount() async {
+    try {
+      final count =
+          (await widget.services.listParticipantsUseCase.execute()).length;
+      if (mounted) {
+        setState(() => _participantsCount = count);
+      }
+    } catch (_) {
+      // Keep the most recently loaded value, if any.
+    }
+  }
+
+  String _directoryMenuLabel(DirectorySection section) {
+    final count = switch (section) {
+      DirectorySection.procedureKinds => _procedureKindsCount,
+      DirectorySection.workdays => _workdaysCount,
+      DirectorySection.assistants => _assistantsCount,
+      DirectorySection.participants => _participantsCount,
+      DirectorySection.settings => null,
+    };
+    return count == null ? section.title : '${section.title} ($count)';
   }
 
   Future<void> _startDesktopWindows() async {
@@ -139,6 +210,7 @@ class _BochkiShellState extends State<BochkiShell> {
       );
     } finally {
       viewModel.dispose();
+      await _refreshProcedureKindsCount();
       if (mounted) {
         setState(() {
           _procedureKindsDialogOpen = false;
@@ -174,6 +246,7 @@ class _BochkiShellState extends State<BochkiShell> {
       );
     } finally {
       viewModel.dispose();
+      await _refreshParticipantsCount();
       if (mounted) {
         setState(() {
           _participantsDialogOpen = false;
@@ -209,6 +282,7 @@ class _BochkiShellState extends State<BochkiShell> {
       );
     } finally {
       viewModel.dispose();
+      await _refreshWorkdaysCount();
       if (mounted) {
         setState(() {
           _workdaysDialogOpen = false;
@@ -244,6 +318,7 @@ class _BochkiShellState extends State<BochkiShell> {
       );
     } finally {
       viewModel.dispose();
+      await _refreshAssistantsCount();
       if (mounted) {
         setState(() {
           _assistantsDialogOpen = false;
@@ -686,24 +761,32 @@ class _BochkiShellState extends State<BochkiShell> {
                     tooltip: 'Справочники',
                     popUpAnimationStyle: AnimationStyle.noAnimation,
                     onSelected: _selectDirectorySection,
-                    itemBuilder: (context) => const [
+                    itemBuilder: (context) => [
                       PopupMenuItem<DirectorySection>(
                         value: DirectorySection.procedureKinds,
-                        child: Text('Процедуры'),
+                        child: Text(
+                          _directoryMenuLabel(DirectorySection.procedureKinds),
+                        ),
                       ),
                       PopupMenuItem<DirectorySection>(
                         value: DirectorySection.workdays,
-                        child: Text('Дни'),
+                        child: Text(
+                          _directoryMenuLabel(DirectorySection.workdays),
+                        ),
                       ),
                       PopupMenuItem<DirectorySection>(
                         value: DirectorySection.assistants,
-                        child: Text('Ассистенты'),
+                        child: Text(
+                          _directoryMenuLabel(DirectorySection.assistants),
+                        ),
                       ),
                       PopupMenuItem<DirectorySection>(
                         value: DirectorySection.participants,
-                        child: Text('Участники'),
+                        child: Text(
+                          _directoryMenuLabel(DirectorySection.participants),
+                        ),
                       ),
-                      PopupMenuItem<DirectorySection>(
+                      const PopupMenuItem<DirectorySection>(
                         value: DirectorySection.settings,
                         child: Text('Настройки'),
                       ),

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -450,13 +450,86 @@ void main() {
     await tester.pump();
     expect(find.byType(PopupMenuItem<DirectorySection>), findsNWidgets(5));
 
-    await tester.tap(find.text('Участники').last);
+    await tester.tap(find.text('Участники (0)').last);
     await tester.pump();
     expect(find.byType(PopupMenuItem<DirectorySection>), findsNothing);
     expect(
       find.byKey(const Key('participants_directory_dialog')),
       findsOneWidget,
     );
+  });
+
+  testWidgets('directories menu shows active directory counts', (tester) async {
+    final context = _buildTestContext(
+      participants: [
+        Participant(id: '1', name: 'Иван'),
+        Participant(id: '2', name: 'Мария'),
+      ],
+      assistants: [Assistant(id: '3', name: 'Анна')],
+      procedureKinds: [
+        ProcedureKind(
+          id: '4',
+          patternId: ProcedureKindPatterns.single.patternId,
+          name: 'Бочка',
+          capacity: 1,
+          participantBusyTime: 30,
+        ),
+      ],
+      workdays: [
+        Workday(
+          id: '5',
+          name: 'Понедельник',
+          calendarDate: DateTime(2026, 8, 24),
+        ),
+        Workday(
+          id: '6',
+          name: 'Вторник',
+          calendarDate: DateTime(2026, 8, 25),
+        ),
+        Workday(
+          id: '7',
+          name: 'Среда',
+          calendarDate: DateTime(2026, 8, 26),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('directories_menu_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Процедуры (1)'), findsOneWidget);
+    expect(find.text('Дни (3)'), findsOneWidget);
+    expect(find.text('Ассистенты (1)'), findsOneWidget);
+    expect(find.text('Участники (2)'), findsOneWidget);
+    expect(find.text('Настройки'), findsOneWidget);
+    expect(find.text('Настройки (0)'), findsNothing);
+  });
+
+  testWidgets('directories menu refreshes a count after closing its dialog', (
+    tester,
+  ) async {
+    final context = _buildTestContext();
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await _openParticipantsDialog(tester);
+    await tester.tap(find.byKey(const Key('participant_add_row')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('participant_name_field')),
+      'Иван',
+    );
+    await tester.tap(find.text('Участники (0)'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byTooltip('Закрыть'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('directories_menu_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Участники (1)'), findsOneWidget);
   });
 
   testWidgets('shell opens assistants dialog from menu', (tester) async {
@@ -1932,28 +2005,28 @@ Future<void> _doubleMouseClick(
 Future<void> _openParticipantsDialog(WidgetTester tester) async {
   await tester.tap(find.byKey(const Key('directories_menu_button')));
   await tester.pumpAndSettle();
-  await tester.tap(find.text('Участники').last);
+  await tester.tap(find.textContaining('Участники (').last);
   await tester.pumpAndSettle();
 }
 
 Future<void> _openAssistantsDialog(WidgetTester tester) async {
   await tester.tap(find.byKey(const Key('directories_menu_button')));
   await tester.pumpAndSettle();
-  await tester.tap(find.text('Ассистенты').last);
+  await tester.tap(find.textContaining('Ассистенты (').last);
   await tester.pumpAndSettle();
 }
 
 Future<void> _openProcedureKindsDialog(WidgetTester tester) async {
   await tester.tap(find.byKey(const Key('directories_menu_button')));
   await tester.pumpAndSettle();
-  await tester.tap(find.text('Процедуры').last);
+  await tester.tap(find.textContaining('Процедуры (').last);
   await tester.pumpAndSettle();
 }
 
 Future<void> _openWorkdaysDialog(WidgetTester tester) async {
   await tester.tap(find.byKey(const Key('directories_menu_button')));
   await tester.pumpAndSettle();
-  await tester.tap(find.text('Дни').last);
+  await tester.tap(find.textContaining('Дни (').last);
   await tester.pumpAndSettle();
 }
 


### PR DESCRIPTION
Closes #105

- shows active records counts for directory menu entries
- refreshes the affected count after closing a directory dialog
- recalculates values after template-driven shell recreation
- covers labels and refresh behavior with widget tests