### PR TITLE
feat(shell): reorder data menu

### DIFF
--- a/packages/bochki_schedule_app/integration_test/app_shell_test.dart
+++ b/packages/bochki_schedule_app/integration_test/app_shell_test.dart
@@ -117,7 +117,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('ПО Расписание Бочки'), findsOneWidget);
-    expect(find.text('Справочники'), findsOneWidget);
+    expect(find.text('Данные'), findsOneWidget);
 
     _openDirectoriesMenu(tester);
     await tester.pumpAndSettle();

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -758,10 +758,22 @@ class _BochkiShellState extends State<BochkiShell> {
                   const SizedBox(width: 12),
                   PopupMenuButton<DirectorySection>(
                     key: const Key('directories_menu_button'),
-                    tooltip: 'Справочники',
+                    tooltip: 'Данные',
                     popUpAnimationStyle: AnimationStyle.noAnimation,
                     onSelected: _selectDirectorySection,
                     itemBuilder: (context) => [
+                      PopupMenuItem<DirectorySection>(
+                        value: DirectorySection.participants,
+                        child: Text(
+                          _directoryMenuLabel(DirectorySection.participants),
+                        ),
+                      ),
+                      PopupMenuItem<DirectorySection>(
+                        value: DirectorySection.assistants,
+                        child: Text(
+                          _directoryMenuLabel(DirectorySection.assistants),
+                        ),
+                      ),
                       PopupMenuItem<DirectorySection>(
                         value: DirectorySection.procedureKinds,
                         child: Text(
@@ -772,18 +784,6 @@ class _BochkiShellState extends State<BochkiShell> {
                         value: DirectorySection.workdays,
                         child: Text(
                           _directoryMenuLabel(DirectorySection.workdays),
-                        ),
-                      ),
-                      PopupMenuItem<DirectorySection>(
-                        value: DirectorySection.assistants,
-                        child: Text(
-                          _directoryMenuLabel(DirectorySection.assistants),
-                        ),
-                      ),
-                      PopupMenuItem<DirectorySection>(
-                        value: DirectorySection.participants,
-                        child: Text(
-                          _directoryMenuLabel(DirectorySection.participants),
                         ),
                       ),
                       const PopupMenuItem<DirectorySection>(
@@ -804,45 +804,11 @@ class _BochkiShellState extends State<BochkiShell> {
                       child: const Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          Text('Справочники'),
+                          Text('Данные'),
                           SizedBox(width: 6),
                           Icon(Icons.arrow_drop_down, size: 18),
                         ],
                       ),
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  PopupMenuButton<TemplatesSection>(
-                    key: const Key('templates_menu_button'),
-                    tooltip: 'Шаблоны',
-                    popUpAnimationStyle: AnimationStyle.noAnimation,
-                    onSelected: (section) =>
-                        unawaited(_selectTemplateSection(section)),
-                    itemBuilder: (context) => const [
-                      PopupMenuItem(
-                          value: TemplatesSection.create,
-                          child: Text('Создать шаблон')),
-                      PopupMenuItem(
-                          value: TemplatesSection.load,
-                          child: Text('Загрузить данные из шаблона')),
-                      PopupMenuItem(
-                          value: TemplatesSection.delete,
-                          child: Text('Удалить шаблон')),
-                    ],
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 10, vertical: 6),
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(6),
-                        color: Colors.white.withOpacity(0.72),
-                        border: Border.all(color: const Color(0xFFD0D7DE)),
-                      ),
-                      child:
-                          const Row(mainAxisSize: MainAxisSize.min, children: [
-                        Text('Шаблоны'),
-                        SizedBox(width: 6),
-                        Icon(Icons.arrow_drop_down, size: 18),
-                      ]),
                     ),
                   ),
                   const SizedBox(width: 12),
@@ -896,6 +862,40 @@ class _BochkiShellState extends State<BochkiShell> {
                     key: const Key('quick_reassignments_button'),
                     onPressed: _openQuickReassignments,
                     child: const Text('Быстрые перестановки'),
+                  ),
+                  const SizedBox(width: 12),
+                  PopupMenuButton<TemplatesSection>(
+                    key: const Key('templates_menu_button'),
+                    tooltip: 'Шаблоны',
+                    popUpAnimationStyle: AnimationStyle.noAnimation,
+                    onSelected: (section) =>
+                        unawaited(_selectTemplateSection(section)),
+                    itemBuilder: (context) => const [
+                      PopupMenuItem(
+                          value: TemplatesSection.create,
+                          child: Text('Создать шаблон')),
+                      PopupMenuItem(
+                          value: TemplatesSection.load,
+                          child: Text('Загрузить данные из шаблона')),
+                      PopupMenuItem(
+                          value: TemplatesSection.delete,
+                          child: Text('Удалить шаблон')),
+                    ],
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 10, vertical: 6),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(6),
+                        color: Colors.white.withOpacity(0.72),
+                        border: Border.all(color: const Color(0xFFD0D7DE)),
+                      ),
+                      child:
+                          const Row(mainAxisSize: MainAxisSize.min, children: [
+                        Text('Шаблоны'),
+                        SizedBox(width: 6),
+                        Icon(Icons.arrow_drop_down, size: 18),
+                      ]),
+                    ),
                   ),
                 ],
               ),

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -22,11 +22,33 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('ПО Расписание Бочки'), findsOneWidget);
-    expect(find.text('Справочники'), findsOneWidget);
+    expect(find.text('Данные'), findsOneWidget);
     expect(find.text('Отчёты'), findsOneWidget);
     expect(find.text('Распечатки'), findsOneWidget);
     expect(find.text('Добавить запись...'), findsOneWidget);
     expect(find.text('Список назначенных процедур пуст.'), findsOneWidget);
+  });
+
+  testWidgets('shell orders header actions from left to right', (tester) async {
+    final context = _buildTestContext();
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+
+    final labels = [
+      'Добавить запись...',
+      'Данные',
+      'Отчёты',
+      'Распечатки',
+      'Быстрые перестановки',
+      'Шаблоны',
+    ];
+    final positions =
+        labels.map((label) => tester.getCenter(find.text(label)).dx).toList();
+
+    for (var index = 1; index < positions.length; index++) {
+      expect(positions[index], greaterThan(positions[index - 1]));
+    }
   });
 
   testWidgets('a new app services instance recreates the shell state', (
@@ -445,6 +467,7 @@ void main() {
       find.byKey(const Key('directories_menu_button')),
     );
     expect(menu.popUpAnimationStyle, AnimationStyle.noAnimation);
+    expect(menu.tooltip, 'Данные');
 
     await tester.tap(find.byKey(const Key('directories_menu_button')));
     await tester.pump();
@@ -505,6 +528,19 @@ void main() {
     expect(find.text('Участники (2)'), findsOneWidget);
     expect(find.text('Настройки'), findsOneWidget);
     expect(find.text('Настройки (0)'), findsNothing);
+
+    final labels = [
+      'Участники (2)',
+      'Ассистенты (1)',
+      'Процедуры (1)',
+      'Дни (3)',
+      'Настройки',
+    ];
+    final positions =
+        labels.map((label) => tester.getCenter(find.text(label)).dy).toList();
+    for (var index = 1; index < positions.length; index++) {
+      expect(positions[index], greaterThan(positions[index - 1]));
+    }
   });
 
   testWidgets('directories menu refreshes a count after closing its dialog', (


### PR DESCRIPTION
Closes #106

- rename the user-facing directories menu to «Данные»
- order header actions and data-menu items as specified
- add widget tests for both visual orders
- update the Linux shell integration expectation