### PR TITLE
feat(schedule): add schedule clearing

### DIFF
--- a/packages/bochki_schedule_app/integration_test/app_shell_test.dart
+++ b/packages/bochki_schedule_app/integration_test/app_shell_test.dart
@@ -393,6 +393,15 @@ final class _InMemoryProcedureSessionsRepository
   final List<ProcedureSessionRaw> _sessions = <ProcedureSessionRaw>[];
 
   @override
+  Future<int> clearAll() async {
+    final sessions = await list();
+    for (final session in sessions) {
+      await delete(session.id);
+    }
+    return sessions.length;
+  }
+
+  @override
   Future<ProcedureSessionRaw> create(
     ProcedureSessionRaw procedureSession,
   ) async {

--- a/packages/bochki_schedule_app/integration_test/app_shell_test.dart
+++ b/packages/bochki_schedule_app/integration_test/app_shell_test.dart
@@ -109,6 +109,8 @@ void main() {
       ),
       deleteProcedureSessionUseCase:
           DeleteProcedureSessionUseCase(procedureSessionsRepository),
+      clearProcedureSessionsUseCase:
+          ClearProcedureSessionsUseCase(procedureSessionsRepository),
       flushPending: _noopAsync,
       shutdown: _noopAsync,
     );

--- a/packages/bochki_schedule_app/lib/bochki_schedule_app.dart
+++ b/packages/bochki_schedule_app/lib/bochki_schedule_app.dart
@@ -37,6 +37,7 @@ export 'src/domain/program_settings/program_settings_repository.dart';
 export 'src/domain/program_settings/program_settings_validation_exception.dart';
 export 'src/domain/program_settings/update_program_settings_use_case.dart';
 export 'src/domain/procedure_sessions/create_procedure_session_use_case.dart';
+export 'src/domain/procedure_sessions/clear_procedure_sessions_use_case.dart';
 export 'src/domain/procedure_sessions/delete_procedure_session_use_case.dart';
 export 'src/domain/procedure_sessions/conflict_resource_type.dart';
 export 'src/domain/procedure_sessions/list_procedure_sessions_with_conflicts_use_case.dart';

--- a/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
+++ b/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
@@ -25,6 +25,7 @@ import 'domain/participants/delete_participant_use_case.dart';
 import 'domain/participants/list_participants_use_case.dart';
 import 'domain/participants/update_participant_use_case.dart';
 import 'domain/procedure_sessions/create_procedure_session_use_case.dart';
+import 'domain/procedure_sessions/clear_procedure_sessions_use_case.dart';
 import 'domain/procedure_sessions/delete_procedure_session_use_case.dart';
 import 'domain/procedure_sessions/list_procedure_sessions_use_case.dart';
 import 'domain/procedure_sessions/list_rich_procedure_sessions_use_case.dart';
@@ -302,6 +303,9 @@ final class AppBootstrap {
     final deleteProcedureSessionUseCase = DeleteProcedureSessionUseCase(
       procedureSessionsRepository,
     );
+    final clearProcedureSessionsUseCase = ClearProcedureSessionsUseCase(
+      procedureSessionsRepository,
+    );
     final quickReassignmentsUseCase = QuickReassignmentsUseCase(
       repository: procedureSessionsRepository,
       workdaysRepository: workdaysRepository,
@@ -353,6 +357,7 @@ final class AppBootstrap {
       createProcedureSessionUseCase: createProcedureSessionUseCase,
       updateProcedureSessionUseCase: updateProcedureSessionUseCase,
       deleteProcedureSessionUseCase: deleteProcedureSessionUseCase,
+      clearProcedureSessionsUseCase: clearProcedureSessionsUseCase,
       quickReassignmentsUseCase: quickReassignmentsUseCase,
       flushPending: syncCoordinator.flushPending,
       shutdown: syncCoordinator.shutdown,

--- a/packages/bochki_schedule_app/lib/src/app_services.dart
+++ b/packages/bochki_schedule_app/lib/src/app_services.dart
@@ -8,6 +8,7 @@ import 'domain/participants/delete_participant_use_case.dart';
 import 'domain/participants/list_participants_use_case.dart';
 import 'domain/participants/update_participant_use_case.dart';
 import 'domain/procedure_sessions/create_procedure_session_use_case.dart';
+import 'domain/procedure_sessions/clear_procedure_sessions_use_case.dart';
 import 'domain/procedure_sessions/delete_procedure_session_use_case.dart';
 import 'domain/procedure_sessions/list_procedure_sessions_use_case.dart';
 import 'domain/procedure_sessions/list_rich_procedure_sessions_use_case.dart';
@@ -73,6 +74,7 @@ final class AppServices {
     required this.createProcedureSessionUseCase,
     required this.updateProcedureSessionUseCase,
     required this.deleteProcedureSessionUseCase,
+    required this.clearProcedureSessionsUseCase,
     this.quickReassignmentsUseCase,
     required this.flushPending,
     required this.shutdown,
@@ -115,6 +117,7 @@ final class AppServices {
   final CreateProcedureSessionUseCase createProcedureSessionUseCase;
   final UpdateProcedureSessionUseCase updateProcedureSessionUseCase;
   final DeleteProcedureSessionUseCase deleteProcedureSessionUseCase;
+  final ClearProcedureSessionsUseCase clearProcedureSessionsUseCase;
   final QuickReassignmentsUseCase? quickReassignmentsUseCase;
   final Future<void> Function() flushPending;
   final Future<void> Function() shutdown;

--- a/packages/bochki_schedule_app/lib/src/data/procedure_sessions/project_document_procedure_sessions_repository.dart
+++ b/packages/bochki_schedule_app/lib/src/data/procedure_sessions/project_document_procedure_sessions_repository.dart
@@ -111,6 +111,23 @@ final class ProjectDocumentProcedureSessionsRepository
   }
 
   @override
+  Future<int> clearAll() async {
+    var removedCount = 0;
+    for (var index = 0; index < _entries.length; index += 1) {
+      final entry = _entries[index];
+      if (entry.deleted) {
+        continue;
+      }
+      _entries[index] = entry.copyWith(deleted: true);
+      removedCount += 1;
+    }
+    if (removedCount > 0) {
+      _markRepositoryChanged();
+    }
+    return removedCount;
+  }
+
+  @override
   ProjectDocument applyToDocument(ProjectDocument document) {
     final sortedEntries = [
       for (final entry in _entries)

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/clear_procedure_sessions_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/clear_procedure_sessions_use_case.dart
@@ -1,0 +1,9 @@
+import 'procedure_sessions_repository.dart';
+
+final class ClearProcedureSessionsUseCase {
+  const ClearProcedureSessionsUseCase(this._repository);
+
+  final ProcedureSessionsRepository _repository;
+
+  Future<int> execute() => _repository.clearAll();
+}

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_sessions_repository.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_sessions_repository.dart
@@ -16,4 +16,15 @@ abstract interface class ProcedureSessionsRepository {
   }
 
   Future<void> delete(String procedureSessionId);
+
+  /// Removes all active procedure sessions as one logical operation.
+  ///
+  /// Returns the number of removed sessions.
+  Future<int> clearAll() async {
+    final procedureSessions = await list();
+    for (final procedureSession in procedureSessions) {
+      await delete(procedureSession.id);
+    }
+    return procedureSessions.length;
+  }
 }

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -511,7 +511,7 @@ class _BochkiShellState extends State<BochkiShell> {
       return;
     }
 
-    final controller = TextEditingController();
+    var confirmationText = '';
     try {
       final confirmed = await showDialog<bool>(
             context: context,
@@ -519,7 +519,7 @@ class _BochkiShellState extends State<BochkiShell> {
             builder: (dialogContext) => StatefulBuilder(
               builder: (context, setDialogState) {
                 final isConfirmationValid =
-                    controller.text.trim().toLowerCase() == 'очистить';
+                    confirmationText.trim().toLowerCase() == 'очистить';
                 return AlertDialog(
                   key: const Key('clear_schedule_confirmation_dialog'),
                   title: const Text('Очистить расписание?'),
@@ -534,12 +534,13 @@ class _BochkiShellState extends State<BochkiShell> {
                       const SizedBox(height: 16),
                       TextField(
                         key: const Key('clear_schedule_confirmation_field'),
-                        controller: controller,
                         autofocus: true,
                         decoration: const InputDecoration(
                           labelText: 'Введите «очистить» для подтверждения',
                         ),
-                        onChanged: (_) => setDialogState(() {}),
+                        onChanged: (value) => setDialogState(() {
+                          confirmationText = value;
+                        }),
                       ),
                     ],
                   ),
@@ -584,8 +585,6 @@ class _BochkiShellState extends State<BochkiShell> {
       }
     } catch (error) {
       _showError('Не удалось очистить расписание: $error');
-    } finally {
-      controller.dispose();
     }
   }
 

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -550,7 +550,8 @@ class _BochkiShellState extends State<BochkiShell> {
                     ),
                     FilledButton(
                       key: const Key('clear_schedule_confirm_button'),
-                      style: FilledButton.styleFrom(backgroundColor: Colors.red),
+                      style:
+                          FilledButton.styleFrom(backgroundColor: Colors.red),
                       onPressed: isConfirmationValid
                           ? () => Navigator.pop(dialogContext, true)
                           : null,

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -39,7 +39,7 @@ enum DirectorySection {
 
 enum ReportsSection { statistics, procedureStatistics, freeTime }
 
-enum TemplatesSection { create, load, delete }
+enum TemplatesSection { create, load, delete, clearSchedule }
 
 class BochkiShell extends StatefulWidget {
   const BochkiShell({
@@ -478,7 +478,6 @@ class _BochkiShellState extends State<BochkiShell> {
   }
 
   Future<void> _selectTemplateSection(TemplatesSection section) async {
-    if (widget.services.templateService == null) return;
     if (_templatesDialogOpen) return;
     setState(() => _templatesDialogOpen = true);
     try {
@@ -492,9 +491,100 @@ class _BochkiShellState extends State<BochkiShell> {
         case TemplatesSection.delete:
           await _chooseTemplate(isDelete: true);
           return;
+        case TemplatesSection.clearSchedule:
+          await _clearSchedule();
+          return;
       }
     } finally {
       if (mounted) setState(() => _templatesDialogOpen = false);
+    }
+  }
+
+  Future<void> _clearSchedule() async {
+    final procedureSessions =
+        await widget.services.listProcedureSessionsUseCase.execute();
+    if (!mounted) return;
+    if (procedureSessions.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Назначенных процедур нет.')),
+      );
+      return;
+    }
+
+    final controller = TextEditingController();
+    try {
+      final confirmed = await showDialog<bool>(
+            context: context,
+            barrierDismissible: false,
+            builder: (dialogContext) => StatefulBuilder(
+              builder: (context, setDialogState) {
+                final isConfirmationValid =
+                    controller.text.trim().toLowerCase() == 'очистить';
+                return AlertDialog(
+                  key: const Key('clear_schedule_confirmation_dialog'),
+                  title: const Text('Очистить расписание?'),
+                  content: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        'Будут удалены все назначенные процедуры на все дни. '
+                        'Дни, справочники и виды процедур сохранятся.',
+                      ),
+                      const SizedBox(height: 16),
+                      TextField(
+                        key: const Key('clear_schedule_confirmation_field'),
+                        controller: controller,
+                        autofocus: true,
+                        decoration: const InputDecoration(
+                          labelText: 'Введите «очистить» для подтверждения',
+                        ),
+                        onChanged: (_) => setDialogState(() {}),
+                      ),
+                    ],
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(dialogContext, false),
+                      child: const Text('Отмена'),
+                    ),
+                    FilledButton(
+                      key: const Key('clear_schedule_confirm_button'),
+                      style: FilledButton.styleFrom(backgroundColor: Colors.red),
+                      onPressed: isConfirmationValid
+                          ? () => Navigator.pop(dialogContext, true)
+                          : null,
+                      child: const Text('Ok'),
+                    ),
+                  ],
+                );
+              },
+            ),
+          ) ??
+          false;
+      if (!confirmed) return;
+
+      final removedCount =
+          await widget.services.clearProcedureSessionsUseCase.execute();
+      if (removedCount == 0) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Назначенных процедур нет.')),
+          );
+        }
+        return;
+      }
+      await widget.services.flushPending();
+      await _procedureSessionsViewModel.load();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Удалено процедур: $removedCount')),
+        );
+      }
+    } catch (error) {
+      _showError('Не удалось очистить расписание: $error');
+    } finally {
+      controller.dispose();
     }
   }
 
@@ -923,6 +1013,15 @@ class _BochkiShellState extends State<BochkiShell> {
                         PopupMenuItem(
                             value: TemplatesSection.delete,
                             child: Text('Удалить шаблон')),
+                        PopupMenuDivider(),
+                        PopupMenuItem(
+                          key: Key('clear_schedule_menu_item'),
+                          value: TemplatesSection.clearSchedule,
+                          child: Text(
+                            'Очистить расписание',
+                            style: TextStyle(color: Colors.red),
+                          ),
+                        ),
                       ],
                       child: Container(
                         padding: const EdgeInsets.symmetric(

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -59,7 +59,9 @@ void main() {
 
     await tester.pumpWidget(BochkiScheduleApp(services: context.services));
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('templates_menu_button')));
+    final templatesMenu = find.byKey(const Key('templates_menu_button'));
+    await tester.ensureVisible(templatesMenu);
+    await tester.tap(templatesMenu);
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('clear_schedule_menu_item')));
     await tester.pumpAndSettle();
@@ -93,7 +95,9 @@ void main() {
 
     await tester.pumpWidget(BochkiScheduleApp(services: context.services));
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('templates_menu_button')));
+    final templatesMenu = find.byKey(const Key('templates_menu_button'));
+    await tester.ensureVisible(templatesMenu);
+    await tester.tap(templatesMenu);
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('clear_schedule_menu_item')));
     await tester.pumpAndSettle();

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -2462,6 +2462,15 @@ final class _InMemoryProcedureSessionsRepository
   final List<ProcedureSessionRaw> _sessions;
 
   @override
+  Future<int> clearAll() async {
+    final sessions = await list();
+    for (final session in sessions) {
+      await delete(session.id);
+    }
+    return sessions.length;
+  }
+
+  @override
   Future<void> updateMany(List<ProcedureSessionRaw> sessions) async {
     for (final session in sessions) {
       await update(session);

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -29,6 +29,78 @@ void main() {
     expect(find.text('Список назначенных процедур пуст.'), findsOneWidget);
   });
 
+  testWidgets('clear schedule requires typed confirmation and removes sessions',
+      (tester) async {
+    final context = _buildTestContext(
+      participants: [Participant(id: '1', name: 'Участник')],
+      procedureKinds: [
+        ProcedureKind(
+          id: '1',
+          patternId: ProcedureKindPatterns.single.patternId,
+          name: 'Процедура',
+          capacity: 1,
+          participantBusyTime: 30,
+          resourceBusyTime: 30,
+        ),
+      ],
+      workdays: [
+        Workday(id: '1', name: 'День', calendarDate: DateTime(2026, 1, 1)),
+      ],
+      procedureSessions: [
+        ProcedureSessionRaw(
+          id: '1',
+          dayId: '1',
+          participantId: '1',
+          startTime: '09:00',
+          procedureKindId: '1',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('templates_menu_button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('clear_schedule_menu_item')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('clear_schedule_confirmation_dialog')),
+        findsOneWidget);
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.byKey(const Key('clear_schedule_confirm_button')),
+          )
+          .onPressed,
+      isNull,
+    );
+
+    await tester.enterText(
+      find.byKey(const Key('clear_schedule_confirmation_field')),
+      ' Очистить ',
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('clear_schedule_confirm_button')));
+    await tester.pumpAndSettle();
+
+    expect(context.procedureSessionsRepository.sessions, isEmpty);
+    expect(find.text('Удалено процедур: 1'), findsOneWidget);
+  });
+
+  testWidgets('clear schedule reports when there are no sessions', (tester) async {
+    final context = _buildTestContext();
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('templates_menu_button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('clear_schedule_menu_item')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('clear_schedule_confirmation_dialog')), findsNothing);
+    expect(find.text('Назначенных процедур нет.'), findsOneWidget);
+  });
+
   testWidgets('shell orders header actions from left to right', (tester) async {
     final context = _buildTestContext();
 
@@ -2199,6 +2271,8 @@ _TestContext _buildTestContext({
       ),
       deleteProcedureSessionUseCase:
           DeleteProcedureSessionUseCase(procedureSessionsRepository),
+      clearProcedureSessionsUseCase:
+          ClearProcedureSessionsUseCase(procedureSessionsRepository),
       flushPending: _noopAsync,
       shutdown: _noopAsync,
     ),

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -87,7 +87,8 @@ void main() {
     expect(find.text('Удалено процедур: 1'), findsOneWidget);
   });
 
-  testWidgets('clear schedule reports when there are no sessions', (tester) async {
+  testWidgets('clear schedule reports when there are no sessions',
+      (tester) async {
     final context = _buildTestContext();
 
     await tester.pumpWidget(BochkiScheduleApp(services: context.services));
@@ -97,7 +98,8 @@ void main() {
     await tester.tap(find.byKey(const Key('clear_schedule_menu_item')));
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('clear_schedule_confirmation_dialog')), findsNothing);
+    expect(find.byKey(const Key('clear_schedule_confirmation_dialog')),
+        findsNothing);
     expect(find.text('Назначенных процедур нет.'), findsOneWidget);
   });
 

--- a/packages/bochki_schedule_app/test/data/procedure_sessions/project_document_procedure_sessions_repository_test.dart
+++ b/packages/bochki_schedule_app/test/data/procedure_sessions/project_document_procedure_sessions_repository_test.dart
@@ -5,6 +5,54 @@ import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('repository clears active procedure sessions in one change', () async {
+    var changeNotifications = 0;
+    final repository = ProjectDocumentProcedureSessionsRepository(
+      initialDocument: const ProjectDocument(
+        nextId: 4,
+        procedureSessions: <Map<String, Object?>>[
+          <String, Object?>{
+            'id': 1,
+            'dayId': 1,
+            'participantId': 10,
+            'startTime': '09:00',
+            'procedureKindId': 100,
+            'deleted': false,
+          },
+          <String, Object?>{
+            'id': 2,
+            'dayId': 1,
+            'participantId': 11,
+            'startTime': '10:00',
+            'procedureKindId': 101,
+            'deleted': true,
+          },
+          <String, Object?>{
+            'id': 3,
+            'dayId': 2,
+            'participantId': 12,
+            'startTime': '11:00',
+            'procedureKindId': 102,
+            'deleted': false,
+          },
+        ],
+      ),
+      idAllocator: ProjectDocumentIdAllocator(nextId: 4, onChanged: () {}),
+      onChanged: () => changeNotifications += 1,
+    );
+
+    expect(await repository.clearAll(), 2);
+    expect(await repository.list(), isEmpty);
+    expect(changeNotifications, 1);
+    expect(
+      repository
+          .applyToDocument(const ProjectDocument(nextId: 4))
+          .procedureSessions
+          .every((entry) => entry['deleted'] == true),
+      isTrue,
+    );
+  });
+
   test('repository create update and delete persist procedure sessions',
       () async {
     var changeNotifications = 0;

--- a/packages/bochki_schedule_app/test/domain/print_schedule/print_schedule_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/print_schedule/print_schedule_use_cases_test.dart
@@ -295,6 +295,13 @@ final class _InMemoryProcedureSessionsRepository
   final List<ProcedureSessionRaw> _sessions;
 
   @override
+  Future<int> clearAll() async {
+    final count = _sessions.length;
+    _sessions.clear();
+    return count;
+  }
+
+  @override
   Future<void> updateMany(List<ProcedureSessionRaw> sessions) async {}
 
   @override

--- a/packages/bochki_schedule_app/test/domain/procedure_sessions/procedure_sessions_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/procedure_sessions/procedure_sessions_use_cases_test.dart
@@ -4,6 +4,33 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('procedure sessions use cases', () {
+    test('clear removes all procedure sessions and returns their count',
+        () async {
+      final repository = _InMemoryProcedureSessionsRepository(
+        sessions: [
+          ProcedureSessionRaw(
+            id: '1',
+            dayId: '1',
+            participantId: '1',
+            startTime: '09:00',
+            procedureKindId: '1',
+          ),
+          ProcedureSessionRaw(
+            id: '2',
+            dayId: '2',
+            participantId: '2',
+            startTime: '10:00',
+            procedureKindId: '2',
+          ),
+        ],
+      );
+
+      final cleared = await ClearProcedureSessionsUseCase(repository).execute();
+
+      expect(cleared, 2);
+      expect(await repository.list(), isEmpty);
+    });
+
     test('create clears assistant for single procedure kind', () async {
       final repository = _InMemoryProcedureSessionsRepository();
       final workdaysRepository = _InMemoryWorkdaysRepository();

--- a/packages/bochki_schedule_app/test/domain/procedure_sessions/procedure_sessions_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/procedure_sessions/procedure_sessions_use_cases_test.dart
@@ -449,6 +449,15 @@ final class _InMemoryProcedureSessionsRepository
   final List<ProcedureSessionRaw> _sessions;
 
   @override
+  Future<int> clearAll() async {
+    final sessions = await list();
+    for (final session in sessions) {
+      await delete(session.id);
+    }
+    return sessions.length;
+  }
+
+  @override
   Future<void> updateMany(List<ProcedureSessionRaw> sessions) async {}
   int _nextId = 1;
 

--- a/packages/bochki_schedule_app/test/features/print_presets/print_preset_params_view_model_test.dart
+++ b/packages/bochki_schedule_app/test/features/print_presets/print_preset_params_view_model_test.dart
@@ -230,6 +230,13 @@ final class _ProcedureSessionsRepository
   final List<ProcedureSessionRaw> _sessions;
 
   @override
+  Future<int> clearAll() async {
+    final count = _sessions.length;
+    _sessions.clear();
+    return count;
+  }
+
+  @override
   Future<void> updateMany(List<ProcedureSessionRaw> sessions) async {}
 
   @override


### PR DESCRIPTION
Closes #104

## Что сделано
- Добавлена bulk-очистка всех назначенных процедур с мягким удалением.
- В меню «Шаблоны» добавлено подтверждаемое действие «Очистить расписание».
- Кнопка `Ok` доступна после ввода `очистить` без учёта регистра и внешних пробелов.
- Добавлены domain/data/widget тесты.