### PR TITLE
feat: add minute precision to program time limits

### DIFF
--- a/packages/bochki_schedule_app/integration_test/app_shell_test.dart
+++ b/packages/bochki_schedule_app/integration_test/app_shell_test.dart
@@ -90,6 +90,8 @@ void main() {
       listProcedureSessionsWithConflictsUseCase:
           ListProcedureSessionsWithConflictsUseCase(
         listRichProcedureSessionsUseCase: listRichProcedureSessionsUseCase,
+        getProgramSettingsUseCase:
+            GetProgramSettingsUseCase(programSettingsRepository),
       ),
       createProcedureSessionUseCase: CreateProcedureSessionUseCase(
         procedureSessionsRepository,

--- a/packages/bochki_schedule_app/lib/bochki_schedule_app.dart
+++ b/packages/bochki_schedule_app/lib/bochki_schedule_app.dart
@@ -52,6 +52,7 @@ export 'src/domain/procedure_sessions/procedure_session_rich_factory.dart';
 export 'src/domain/procedure_sessions/procedure_session_time.dart';
 export 'src/domain/procedure_sessions/procedure_session_with_conflicts.dart';
 export 'src/domain/procedure_sessions/schedule_conflict.dart';
+export 'src/domain/procedure_sessions/schedule_conflict_type.dart';
 export 'src/domain/procedure_sessions/procedure_sessions_repository.dart';
 export 'src/domain/procedure_sessions/procedure_sessions_validation_exception.dart';
 export 'src/domain/procedure_sessions/update_procedure_session_use_case.dart';

--- a/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
+++ b/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
@@ -283,6 +283,7 @@ final class AppBootstrap {
     final listProcedureSessionsWithConflictsUseCase =
         ListProcedureSessionsWithConflictsUseCase(
       listRichProcedureSessionsUseCase: listRichProcedureSessionsUseCase,
+      getProgramSettingsUseCase: getProgramSettingsUseCase,
     );
     final createProcedureSessionUseCase = CreateProcedureSessionUseCase(
       procedureSessionsRepository,

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/list_procedure_sessions_with_conflicts_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/list_procedure_sessions_with_conflicts_use_case.dart
@@ -1,4 +1,5 @@
 import 'list_rich_procedure_sessions_use_case.dart';
+import '../program_settings/get_program_settings_use_case.dart';
 import 'procedure_session_conflict_calculator.dart';
 import 'procedure_session_with_conflicts.dart';
 import 'schedule_conflict.dart';
@@ -6,16 +7,23 @@ import 'schedule_conflict.dart';
 final class ListProcedureSessionsWithConflictsUseCase {
   ListProcedureSessionsWithConflictsUseCase({
     required ListRichProcedureSessionsUseCase listRichProcedureSessionsUseCase,
+    required GetProgramSettingsUseCase getProgramSettingsUseCase,
     ProcedureSessionConflictCalculator? calculator,
   })  : _listRichProcedureSessionsUseCase = listRichProcedureSessionsUseCase,
+        _getProgramSettingsUseCase = getProgramSettingsUseCase,
         _calculator = calculator ?? const ProcedureSessionConflictCalculator();
 
   final ListRichProcedureSessionsUseCase _listRichProcedureSessionsUseCase;
+  final GetProgramSettingsUseCase _getProgramSettingsUseCase;
   final ProcedureSessionConflictCalculator _calculator;
 
   Future<List<ProcedureSessionWithConflicts>> execute() async {
     final sessions = await _listRichProcedureSessionsUseCase.execute();
-    final conflicts = _calculator.calculate(sessions);
+    final settings = await _getProgramSettingsUseCase.execute();
+    final conflicts = _calculator.calculate(
+      sessions,
+      programSettings: settings,
+    );
     final conflictsBySessionId = <String, List<ScheduleConflict>>{};
     for (final conflict in conflicts) {
       conflictsBySessionId

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_conflict_calculator.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_conflict_calculator.dart
@@ -1,13 +1,19 @@
+import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+
 import 'conflict_resource_type.dart';
 import 'procedure_session_occupancy_record.dart';
 import 'procedure_session_rich.dart';
 import 'procedure_session_time.dart';
 import 'schedule_conflict.dart';
+import 'schedule_conflict_type.dart';
 
 final class ProcedureSessionConflictCalculator {
   const ProcedureSessionConflictCalculator();
 
-  List<ScheduleConflict> calculate(Iterable<ProcedureSessionRich> sessions) {
+  List<ScheduleConflict> calculate(
+    Iterable<ProcedureSessionRich> sessions, {
+    required ProgramSettings programSettings,
+  }) {
     final records = <ProcedureSessionOccupancyRecord>[
       for (final session in sessions) ..._buildRecords(session),
     ];
@@ -24,7 +30,69 @@ final class ProcedureSessionConflictCalculator {
     for (final group in grouped.values) {
       conflicts.addAll(_calculateGroup(group));
     }
+    for (final session in sessions) {
+      conflicts
+          .addAll(_calculateTimeBoundaryConflicts(session, programSettings));
+    }
     return _mergeAdjacentConflicts(conflicts);
+  }
+
+  List<ScheduleConflict> _calculateTimeBoundaryConflicts(
+    ProcedureSessionRich session,
+    ProgramSettings settings,
+  ) {
+    final start = ProcedureSessionTime.toMinutes(session.startTime);
+    final minimum =
+        settings.minimumTime.hour * 60 + settings.minimumTime.minute;
+    final maximum =
+        settings.maximumTime.hour * 60 + settings.maximumTime.minute;
+    final conflicts = <ScheduleConflict>[];
+    if (start < minimum) {
+      conflicts.add(ScheduleConflict(
+        type: ScheduleConflictType.timeBoundary,
+        workdayId: session.dayId,
+        timeStart: session.startTime,
+        timeFinish: _formatAbsoluteTime(minimum),
+        procedureSessionId: session.id,
+        message:
+            'Процедура начинается раньше минимального времени ${_formatAbsoluteTime(minimum)}.',
+      ));
+    }
+
+    final kind = session.procedureKind;
+    if (kind == null) return conflicts;
+    final ends = <String>[];
+    final endMinutes = <int>[];
+    void addEnd(String label, int? duration) {
+      if (duration == null) return;
+      final end = start + duration;
+      endMinutes.add(end);
+      if (end > maximum) ends.add('$label до ${_formatAbsoluteTime(end)}');
+    }
+
+    addEnd('участник', kind.participantBusyTime);
+    if (session.assistantId != null)
+      addEnd('ассистент', kind.assistantBusyTime);
+    addEnd('ресурс', kind.resourceBusyTime);
+    if (ends.isNotEmpty) {
+      conflicts.add(ScheduleConflict(
+        type: ScheduleConflictType.timeBoundary,
+        workdayId: session.dayId,
+        timeStart: session.startTime,
+        timeFinish:
+            _formatAbsoluteTime(endMinutes.reduce((a, b) => a > b ? a : b)),
+        procedureSessionId: session.id,
+        message:
+            'Процедура выходит за максимальное время ${_formatAbsoluteTime(maximum)}: ${ends.join(', ')}.',
+      ));
+    }
+    return conflicts;
+  }
+
+  String _formatAbsoluteTime(int minutes) {
+    final dayOffset = minutes ~/ (24 * 60);
+    final time = ProcedureSessionTime.fromMinutes(minutes);
+    return dayOffset > 0 ? '$time следующего дня' : time;
   }
 
   List<ProcedureSessionOccupancyRecord> _buildRecords(
@@ -141,8 +209,8 @@ final class ProcedureSessionConflictCalculator {
         if (bySession != 0) {
           return bySession;
         }
-        final byResourceType =
-            left.resourceType.name.compareTo(right.resourceType.name);
+        final byResourceType = (left.resourceType?.name ?? '')
+            .compareTo(right.resourceType?.name ?? '');
         if (byResourceType != 0) {
           return byResourceType;
         }
@@ -169,14 +237,15 @@ final class ProcedureSessionConflictCalculator {
       }
 
       final previous = merged.last;
-      final canMerge =
+      final canMerge = previous.type == ScheduleConflictType.resourceOverload &&
+          conflict.type == ScheduleConflictType.resourceOverload &&
           previous.procedureSessionId == conflict.procedureSessionId &&
-              previous.resourceType == conflict.resourceType &&
-              previous.resourceId == conflict.resourceId &&
-              previous.workdayId == conflict.workdayId &&
-              previous.capacityAllowed == conflict.capacityAllowed &&
-              previous.capacityRegistered == conflict.capacityRegistered &&
-              previous.timeFinish == conflict.timeStart;
+          previous.resourceType == conflict.resourceType &&
+          previous.resourceId == conflict.resourceId &&
+          previous.workdayId == conflict.workdayId &&
+          previous.capacityAllowed == conflict.capacityAllowed &&
+          previous.capacityRegistered == conflict.capacityRegistered &&
+          previous.timeFinish == conflict.timeStart;
       if (!canMerge) {
         merged.add(conflict);
         continue;

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_conflict_message_formatter.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_conflict_message_formatter.dart
@@ -3,6 +3,7 @@ import '../procedure_kinds/procedure_kind.dart';
 
 import 'conflict_resource_type.dart';
 import 'schedule_conflict.dart';
+import 'schedule_conflict_type.dart';
 
 final class ProcedureSessionConflictMessageFormatter {
   const ProcedureSessionConflictMessageFormatter();
@@ -12,7 +13,10 @@ final class ProcedureSessionConflictMessageFormatter {
     required Iterable<Human> humans,
     required Iterable<ProcedureKind> procedureKinds,
   }) {
-    switch (conflict.resourceType) {
+    if (conflict.type == ScheduleConflictType.timeBoundary) {
+      return conflict.message ?? 'Нарушены границы времени программы.';
+    }
+    switch (conflict.resourceType!) {
       case ConflictResourceType.human:
         final humanName = _findHumanName(humans, conflict.humanId);
         return 'Участник/ассистент $humanName занят с '

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_validator.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_validator.dart
@@ -6,7 +6,6 @@ import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 
 import 'procedure_session_raw.dart';
 import 'procedure_sessions_validation_exception.dart';
-import 'procedure_session_time.dart';
 
 abstract final class ProcedureSessionValidator {
   static ProcedureSessionRaw validateForSave(
@@ -38,11 +37,6 @@ abstract final class ProcedureSessionValidator {
       throw const ProcedureSessionsValidationException('Выберите процедуру.');
     }
 
-    _validateStartTime(
-      procedureSession.startTime,
-      programSettings: programSettings,
-    );
-
     if (procedureKind.isCurated) {
       if (procedureSession.assistantId == null) {
         throw const ProcedureSessionsValidationException(
@@ -63,22 +57,6 @@ abstract final class ProcedureSessionValidator {
     }
 
     return procedureSession.copyWith(clearAssistantId: true);
-  }
-
-  static void _validateStartTime(
-    String startTime, {
-    required ProgramSettings programSettings,
-  }) {
-    final startMinutes = ProcedureSessionTime.toMinutes(startTime);
-    final minimumStartMinutes = programSettings.minimumHour * 60;
-    final maximumStartMinutes = programSettings.maximumHour * 60 + 55;
-    if (startMinutes < minimumStartMinutes ||
-        startMinutes > maximumStartMinutes) {
-      throw ProcedureSessionsValidationException(
-        'Время начала должно быть в диапазоне '
-        '${_formatTime(minimumStartMinutes)}-${_formatTime(maximumStartMinutes)}.',
-      );
-    }
   }
 
   static void validateId(String procedureSessionId) {

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/schedule_conflict.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/schedule_conflict.dart
@@ -1,27 +1,32 @@
 import 'conflict_resource_type.dart';
+import 'schedule_conflict_type.dart';
 
 final class ScheduleConflict {
   const ScheduleConflict({
-    required this.resourceType,
+    this.type = ScheduleConflictType.resourceOverload,
+    this.resourceType,
     required this.workdayId,
     required this.timeStart,
     required this.timeFinish,
     required this.procedureSessionId,
-    required this.capacityAllowed,
-    required this.capacityRegistered,
+    this.capacityAllowed,
+    this.capacityRegistered,
+    this.message,
     this.humanId,
     this.itemId,
   });
 
-  final ConflictResourceType resourceType;
+  final ScheduleConflictType type;
+  final ConflictResourceType? resourceType;
   final String workdayId;
   final String timeStart;
   final String timeFinish;
   final String procedureSessionId;
   final String? humanId;
   final String? itemId;
-  final int capacityAllowed;
-  final int capacityRegistered;
+  final int? capacityAllowed;
+  final int? capacityRegistered;
+  final String? message;
 
   String get resourceId => humanId ?? itemId ?? '';
 
@@ -30,8 +35,10 @@ final class ScheduleConflict {
     String? timeFinish,
     int? capacityAllowed,
     int? capacityRegistered,
+    String? message,
   }) {
     return ScheduleConflict(
+      type: type,
       resourceType: resourceType,
       workdayId: workdayId,
       timeStart: timeStart ?? this.timeStart,
@@ -41,6 +48,7 @@ final class ScheduleConflict {
       itemId: itemId,
       capacityAllowed: capacityAllowed ?? this.capacityAllowed,
       capacityRegistered: capacityRegistered ?? this.capacityRegistered,
+      message: message ?? this.message,
     );
   }
 }

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/schedule_conflict_type.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/schedule_conflict_type.dart
@@ -1,0 +1,4 @@
+enum ScheduleConflictType {
+  resourceOverload,
+  timeBoundary,
+}

--- a/packages/bochki_schedule_app/lib/src/domain/program_settings/program_settings_validator.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/program_settings/program_settings_validator.dart
@@ -9,29 +9,20 @@ abstract final class ProgramSettingsValidator {
         'Конец обеда должен быть позже начала обеда.',
       );
     }
-    if (settings.maximumHour <= settings.minimumHour) {
+    if (settings.maximumTime.compareTo(settings.minimumTime) <= 0) {
       throw const ProgramSettingsValidationException(
         'Максимальное время должно быть больше минимального.',
       );
     }
 
-    final minimumTime = ProgramSettingsTime(
-      hour: settings.minimumHour,
-      minute: 0,
-    );
-    final maximumTime = ProgramSettingsTime(
-      hour: settings.maximumHour,
-      minute: 0,
-    );
-
-    if (settings.lunchStart.compareTo(minimumTime) < 0 ||
-        settings.lunchStart.compareTo(maximumTime) > 0) {
+    if (settings.lunchStart.compareTo(settings.minimumTime) < 0 ||
+        settings.lunchStart.compareTo(settings.maximumTime) > 0) {
       throw const ProgramSettingsValidationException(
         'Начало обеда должно быть внутри диапазона времени.',
       );
     }
-    if (settings.lunchEnd.compareTo(minimumTime) < 0 ||
-        settings.lunchEnd.compareTo(maximumTime) > 0) {
+    if (settings.lunchEnd.compareTo(settings.minimumTime) < 0 ||
+        settings.lunchEnd.compareTo(settings.maximumTime) > 0) {
       throw const ProgramSettingsValidationException(
         'Конец обеда должен быть внутри диапазона времени.',
       );

--- a/packages/bochki_schedule_app/lib/src/domain/schedule_gaps/build_schedule_gaps_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/schedule_gaps/build_schedule_gaps_use_case.dart
@@ -52,8 +52,9 @@ final class BuildScheduleGapsUseCase {
     final kinds = await _listProcedureKindsUseCase.execute();
     final sessions = await _listProcedureSessionsUseCase.execute();
     final kindsById = {for (final kind in kinds) kind.id: kind};
-    final dayStart = settings.minimumHour * 60;
-    final dayEnd = settings.maximumHour * 60;
+    final dayStart =
+        settings.minimumTime.hour * 60 + settings.minimumTime.minute;
+    final dayEnd = settings.maximumTime.hour * 60 + settings.maximumTime.minute;
     final result = <ScheduleGap>[];
 
     for (final day in workdays) {

--- a/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_session_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_session_dialog.dart
@@ -86,8 +86,8 @@ class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
 
   List<String> get _hours {
     final hours = [
-      for (int hour = widget.programSettings.minimumHour;
-          hour <= widget.programSettings.maximumHour;
+      for (int hour = widget.programSettings.minimumTime.hour;
+          hour <= widget.programSettings.maximumTime.hour;
           hour++)
         hour.toString().padLeft(2, '0'),
     ];
@@ -119,10 +119,10 @@ class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
 
   String get _scheduleHint {
     final minimumHour =
-        widget.programSettings.minimumHour.toString().padLeft(2, '0');
+        widget.programSettings.minimumTime.hour.toString().padLeft(2, '0');
     final maximumHour =
-        widget.programSettings.maximumHour.toString().padLeft(2, '0');
-    return 'Допустимое время начала: $minimumHour:00-$maximumHour:55. '
+        widget.programSettings.maximumTime.hour.toString().padLeft(2, '0');
+    return 'Доступные часы начала: $minimumHour-$maximumHour. '
         'Обед: с ${_formatSettingsTime(widget.programSettings.lunchStart)} '
         'до ${_formatSettingsTime(widget.programSettings.lunchEnd)}.';
   }

--- a/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_sessions_view_model.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_sessions_view_model.dart
@@ -250,7 +250,7 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
       dayId: _workdays.isEmpty ? 'missing-day' : _workdays.first.id,
       participantId: _humans.isEmpty ? 'missing-participant' : _humans.first.id,
       startTime:
-          '${_programSettings.minimumHour.toString().padLeft(2, '0')}:00',
+          '${_programSettings.minimumTime.hour.toString().padLeft(2, '0')}:00',
       procedureKindId: firstProcedureKind == null
           ? 'missing-procedure'
           : firstProcedureKind.id,
@@ -434,7 +434,10 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
         return left.id.compareTo(right.id);
       });
 
-    final conflicts = _conflictCalculator.calculate(richSessions);
+    final conflicts = _conflictCalculator.calculate(
+      richSessions,
+      programSettings: _programSettings,
+    );
     final conflictsBySessionId = <String, List<ScheduleConflict>>{};
     for (final conflict in conflicts) {
       conflictsBySessionId

--- a/packages/bochki_schedule_app/lib/src/features/program_settings/program_settings_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/program_settings/program_settings_dialog.dart
@@ -21,7 +21,9 @@ class _ProgramSettingsDialogState extends State<ProgramSettingsDialog> {
   late int _lunchEndHour;
   late int _lunchEndMinute;
   late int _minimumHour;
+  late int _minimumMinute;
   late int _maximumHour;
+  late int _maximumMinute;
 
   @override
   void initState() {
@@ -42,8 +44,10 @@ class _ProgramSettingsDialogState extends State<ProgramSettingsDialog> {
     _lunchStartMinute = settings.lunchStart.minute;
     _lunchEndHour = settings.lunchEnd.hour;
     _lunchEndMinute = settings.lunchEnd.minute;
-    _minimumHour = settings.minimumHour;
-    _maximumHour = settings.maximumHour;
+    _minimumHour = settings.minimumTime.hour;
+    _minimumMinute = settings.minimumTime.minute;
+    _maximumHour = settings.maximumTime.hour;
+    _maximumMinute = settings.maximumTime.minute;
   }
 
   void _showActionErrorIfNeeded() {
@@ -73,8 +77,14 @@ class _ProgramSettingsDialogState extends State<ProgramSettingsDialog> {
         hour: _lunchEndHour,
         minute: _lunchEndMinute,
       ),
-      minimumHour: _minimumHour,
-      maximumHour: _maximumHour,
+      minimumTime: ProgramSettingsTime(
+        hour: _minimumHour,
+        minute: _minimumMinute,
+      ),
+      maximumTime: ProgramSettingsTime(
+        hour: _maximumHour,
+        minute: _maximumMinute,
+      ),
     );
 
     final isSuccess = await widget.viewModel.saveProgramSettings(settings);
@@ -180,20 +190,32 @@ class _ProgramSettingsDialogState extends State<ProgramSettingsDialog> {
                       _updateField(() => _lunchEndMinute = value),
                 ),
                 const SizedBox(height: 16),
-                _buildHourField(
+                _buildTimeRow(
                   label: 'Минимальное время',
-                  fieldKey: const Key('program_settings_minimum_hour_field'),
+                  tooltip:
+                      'Процедура, начавшаяся раньше этого времени, будет отмечена как конфликт.',
+                  hourKey: const Key('program_settings_minimum_hour_field'),
+                  minuteKey: const Key('program_settings_minimum_minute_field'),
                   selectedHour: _minimumHour,
-                  onChanged: (value) =>
+                  selectedMinute: _minimumMinute,
+                  onHourChanged: (value) =>
                       _updateField(() => _minimumHour = value),
+                  onMinuteChanged: (value) =>
+                      _updateField(() => _minimumMinute = value),
                 ),
                 const SizedBox(height: 16),
-                _buildHourField(
+                _buildTimeRow(
                   label: 'Максимальное время',
-                  fieldKey: const Key('program_settings_maximum_hour_field'),
+                  tooltip:
+                      'Если участник, ассистент или ресурс занят позже этого времени, процедура будет отмечена как конфликт.',
+                  hourKey: const Key('program_settings_maximum_hour_field'),
+                  minuteKey: const Key('program_settings_maximum_minute_field'),
                   selectedHour: _maximumHour,
-                  onChanged: (value) =>
+                  selectedMinute: _maximumMinute,
+                  onHourChanged: (value) =>
                       _updateField(() => _maximumHour = value),
+                  onMinuteChanged: (value) =>
+                      _updateField(() => _maximumMinute = value),
                 ),
                 if (widget.viewModel.formErrorMessage case final message?) ...[
                   const SizedBox(height: 16),
@@ -213,6 +235,7 @@ class _ProgramSettingsDialogState extends State<ProgramSettingsDialog> {
 
   Widget _buildTimeRow({
     required String label,
+    String? tooltip,
     required Key hourKey,
     required Key minuteKey,
     required int selectedHour,
@@ -223,7 +246,20 @@ class _ProgramSettingsDialogState extends State<ProgramSettingsDialog> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(label),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(label),
+            if (tooltip != null)
+              Tooltip(
+                message: tooltip,
+                child: const Padding(
+                  padding: EdgeInsets.only(left: 4),
+                  child: Icon(Icons.info_outline, size: 18),
+                ),
+              ),
+          ],
+        ),
         const SizedBox(height: 8),
         Row(
           children: [
@@ -241,34 +277,12 @@ class _ProgramSettingsDialogState extends State<ProgramSettingsDialog> {
               child: _buildDropdown<int>(
                 fieldKey: minuteKey,
                 value: selectedMinute,
-                items: List<int>.generate(6, (index) => index * 10),
+                items: List<int>.generate(12, (index) => index * 5),
                 formatter: _formatHour,
                 onChanged: onMinuteChanged,
               ),
             ),
           ],
-        ),
-      ],
-    );
-  }
-
-  Widget _buildHourField({
-    required String label,
-    required Key fieldKey,
-    required int selectedHour,
-    required ValueChanged<int> onChanged,
-  }) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(label),
-        const SizedBox(height: 8),
-        _buildDropdown<int>(
-          fieldKey: fieldKey,
-          value: selectedHour,
-          items: List<int>.generate(24, (index) => index),
-          formatter: _formatHour,
-          onChanged: onChanged,
         ),
       ],
     );

--- a/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
@@ -225,8 +225,8 @@ final class DesktopWindowCoordinator {
         'procedureKinds': _sessions.procedureKinds.map(_kindMap).toList(),
         'assistants': _sessions.assistants.map(_assistantMap).toList(),
         'settings': {
-          'minimumHour': _sessions.programSettings.minimumHour,
-          'maximumHour': _sessions.programSettings.maximumHour,
+          'minimumTime': _sessions.programSettings.minimumTime.toJson(),
+          'maximumTime': _sessions.programSettings.maximumTime.toJson(),
           'lunchStart': _sessions.programSettings.lunchStart.toJson(),
           'lunchEnd': _sessions.programSettings.lunchEnd.toJson(),
         },
@@ -846,8 +846,10 @@ class _ProcedureSessionWindowState extends State<ProcedureSessionWindow> {
           assistants:
               _maps(snapshot['assistants']).map(_assistantFromMap).toList(),
           programSettings: ProgramSettings(
-              minimumHour: settings['minimumHour'] as int,
-              maximumHour: settings['maximumHour'] as int,
+              minimumTime:
+                  ProgramSettingsTime.fromJson(settings['minimumTime']),
+              maximumTime:
+                  ProgramSettingsTime.fromJson(settings['maximumTime']),
               lunchStart: ProgramSettingsTime.fromJson(settings['lunchStart']),
               lunchEnd: ProgramSettingsTime.fromJson(settings['lunchEnd'])),
           onSubmit: (session, allowConflicts) async {

--- a/packages/bochki_schedule_app/test/app_bootstrap_test.dart
+++ b/packages/bochki_schedule_app/test/app_bootstrap_test.dart
@@ -149,8 +149,8 @@ void main() {
       programSettings: ProgramSettings(
         lunchStart: ProgramSettingsTime(hour: 12, minute: 0),
         lunchEnd: ProgramSettingsTime(hour: 13, minute: 0),
-        minimumHour: 7,
-        maximumHour: 22,
+        minimumTime: ProgramSettingsTime(hour: 7, minute: 0),
+        maximumTime: ProgramSettingsTime(hour: 22, minute: 0),
       ),
       printPresetParams: PrintPresetParams(
         workdayId: '13',

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -1041,8 +1041,8 @@ void main() {
       programSettings: const ProgramSettings(
         lunchStart: ProgramSettingsTime(hour: 13, minute: 0),
         lunchEnd: ProgramSettingsTime(hour: 14, minute: 0),
-        minimumHour: 8,
-        maximumHour: 20,
+        minimumTime: ProgramSettingsTime(hour: 8, minute: 0),
+        maximumTime: ProgramSettingsTime(hour: 20, minute: 0),
       ),
     );
 
@@ -1112,8 +1112,8 @@ void main() {
       programSettings: const ProgramSettings(
         lunchStart: ProgramSettingsTime(hour: 14, minute: 0),
         lunchEnd: ProgramSettingsTime(hour: 15, minute: 0),
-        minimumHour: 8,
-        maximumHour: 20,
+        minimumTime: ProgramSettingsTime(hour: 8, minute: 0),
+        maximumTime: ProgramSettingsTime(hour: 20, minute: 0),
       ),
     );
 
@@ -1250,8 +1250,8 @@ void main() {
       programSettings: const ProgramSettings(
         lunchStart: ProgramSettingsTime(hour: 14, minute: 0),
         lunchEnd: ProgramSettingsTime(hour: 15, minute: 0),
-        minimumHour: 10,
-        maximumHour: 18,
+        minimumTime: ProgramSettingsTime(hour: 10, minute: 0),
+        maximumTime: ProgramSettingsTime(hour: 18, minute: 0),
       ),
     );
 
@@ -1270,7 +1270,7 @@ void main() {
     );
     expect(
       find.text(
-        'Допустимое время начала: 10:00-18:55. Обед: с 14:00 до 15:00.',
+        'Доступные часы начала: 10-18. Обед: с 14:00 до 15:00.',
       ),
       findsOneWidget,
     );
@@ -1279,7 +1279,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.text('Время начала должно быть в диапазоне 10:00-18:55.'),
+      find.text('Процедура начинается раньше минимального времени 10:00.'),
       findsOneWidget,
     );
     expect(
@@ -2258,6 +2258,8 @@ _TestContext _buildTestContext({
       listProcedureSessionsWithConflictsUseCase:
           ListProcedureSessionsWithConflictsUseCase(
         listRichProcedureSessionsUseCase: listRichProcedureSessionsUseCase,
+        getProgramSettingsUseCase:
+            GetProgramSettingsUseCase(programSettingsRepository),
       ),
       createProcedureSessionUseCase: CreateProcedureSessionUseCase(
         procedureSessionsRepository,

--- a/packages/bochki_schedule_app/test/data/program_settings/project_document_program_settings_repository_test.dart
+++ b/packages/bochki_schedule_app/test/data/program_settings/project_document_program_settings_repository_test.dart
@@ -26,8 +26,8 @@ void main() {
     const updated = ProgramSettings(
       lunchStart: ProgramSettingsTime(hour: 13, minute: 0),
       lunchEnd: ProgramSettingsTime(hour: 14, minute: 0),
-      minimumHour: 7,
-      maximumHour: 19,
+      minimumTime: ProgramSettingsTime(hour: 7, minute: 0),
+      maximumTime: ProgramSettingsTime(hour: 19, minute: 0),
     );
 
     await repository.update(updated);

--- a/packages/bochki_schedule_app/test/domain/procedure_sessions/procedure_sessions_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/procedure_sessions/procedure_sessions_use_cases_test.dart
@@ -153,34 +153,27 @@ void main() {
       expect(sorted.map((entry) => entry.id), ['1', '2', '3']);
     });
 
-    test('create rejects start time before minimum hour', () async {
+    test('create allows start time before minimum hour', () async {
       final repository = _InMemoryProcedureSessionsRepository();
 
-      expect(
-        () => CreateProcedureSessionUseCase(
-          repository,
-          workdaysRepository: _InMemoryWorkdaysRepository(),
-          humansRepository: _InMemoryHumansRepository(),
-          procedureKindsRepository: _InMemoryProcedureKindsRepository(),
-          assistantsRepository: _InMemoryAssistantsRepository(),
-          programSettingsRepository: _InMemoryProgramSettingsRepository(),
-        ).execute(
-          ProcedureSessionRaw(
-            id: 'draft',
-            dayId: '1',
-            participantId: '1',
-            startTime: '07:55',
-            procedureKindId: '2',
-          ),
-        ),
-        throwsA(
-          isA<ProcedureSessionsValidationException>().having(
-            (error) => error.message,
-            'message',
-            'Время начала должно быть в диапазоне 08:00-20:55.',
-          ),
+      final created = await CreateProcedureSessionUseCase(
+        repository,
+        workdaysRepository: _InMemoryWorkdaysRepository(),
+        humansRepository: _InMemoryHumansRepository(),
+        procedureKindsRepository: _InMemoryProcedureKindsRepository(),
+        assistantsRepository: _InMemoryAssistantsRepository(),
+        programSettingsRepository: _InMemoryProgramSettingsRepository(),
+      ).execute(
+        ProcedureSessionRaw(
+          id: 'draft',
+          dayId: '1',
+          participantId: '1',
+          startTime: '07:55',
+          procedureKindId: '2',
         ),
       );
+
+      expect(created.startTime, '07:55');
     });
 
     test('create allows start time at maximum hour minute 55', () async {
@@ -273,7 +266,7 @@ void main() {
             resourceBusyTime: 30,
           ),
         ),
-      ]);
+      ], programSettings: ProgramSettings.defaults);
 
       expect(conflicts, hasLength(4));
       expect(
@@ -333,9 +326,53 @@ void main() {
             resourceBusyTime: 30,
           ),
         ),
-      ]);
+      ], programSettings: ProgramSettings.defaults);
 
       expect(noConflicts, isEmpty);
+    });
+
+    test('conflict calculator reports exact time-boundary violations', () {
+      const calculator = ProcedureSessionConflictCalculator();
+      const settings = ProgramSettings(
+        lunchStart: ProgramSettingsTime(hour: 12, minute: 0),
+        lunchEnd: ProgramSettingsTime(hour: 13, minute: 0),
+        minimumTime: ProgramSettingsTime(hour: 8, minute: 15),
+        maximumTime: ProgramSettingsTime(hour: 19, minute: 40),
+      );
+
+      final conflicts = calculator.calculate([
+        _buildRichSession(
+          id: '1',
+          participantId: '10',
+          startTime: '08:10',
+          assistantId: '20',
+          procedureKind: ProcedureKind(
+            id: '100',
+            patternId: ProcedureKindPatterns.curated.patternId,
+            name: 'Бочка',
+            capacity: 1,
+            participantBusyTime: 100,
+            assistantBusyTime: 700,
+            resourceBusyTime: 1000,
+          ),
+        ),
+      ], programSettings: settings);
+
+      expect(
+          conflicts
+              .where((item) => item.type == ScheduleConflictType.timeBoundary),
+          hasLength(2));
+      expect(
+        conflicts.map((item) => item.message),
+        contains(contains('раньше минимального времени 08:15')),
+      );
+      expect(
+        conflicts.map((item) => item.message),
+        contains(allOf(
+          contains('ассистент до 19:50'),
+          contains('ресурс до 00:50 следующего дня'),
+        )),
+      );
     });
 
     test('list rich sorts by workday name then time then procedure name',

--- a/packages/bochki_schedule_app/test/domain/program_settings/program_settings_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/program_settings/program_settings_use_cases_test.dart
@@ -8,8 +8,8 @@ void main() {
       const settings = ProgramSettings(
         lunchStart: ProgramSettingsTime(hour: 14, minute: 0),
         lunchEnd: ProgramSettingsTime(hour: 15, minute: 0),
-        minimumHour: 8,
-        maximumHour: 20,
+        minimumTime: ProgramSettingsTime(hour: 8, minute: 0),
+        maximumTime: ProgramSettingsTime(hour: 20, minute: 0),
       );
       final repository = _InMemoryProgramSettingsRepository(settings);
 
@@ -28,8 +28,8 @@ void main() {
           const ProgramSettings(
             lunchStart: ProgramSettingsTime(hour: 14, minute: 0),
             lunchEnd: ProgramSettingsTime(hour: 13, minute: 50),
-            minimumHour: 8,
-            maximumHour: 20,
+            minimumTime: ProgramSettingsTime(hour: 8, minute: 0),
+            maximumTime: ProgramSettingsTime(hour: 20, minute: 0),
           ),
         ),
         throwsA(
@@ -52,8 +52,8 @@ void main() {
           const ProgramSettings(
             lunchStart: ProgramSettingsTime(hour: 7, minute: 50),
             lunchEnd: ProgramSettingsTime(hour: 15, minute: 0),
-            minimumHour: 8,
-            maximumHour: 20,
+            minimumTime: ProgramSettingsTime(hour: 8, minute: 0),
+            maximumTime: ProgramSettingsTime(hour: 20, minute: 0),
           ),
         ),
         throwsA(

--- a/packages/bochki_schedule_app/test/features/procedure_sessions/procedure_session_dialog_test.dart
+++ b/packages/bochki_schedule_app/test/features/procedure_sessions/procedure_session_dialog_test.dart
@@ -56,8 +56,8 @@ void main() {
             programSettings: const ProgramSettings(
               lunchStart: ProgramSettingsTime(hour: 13, minute: 30),
               lunchEnd: ProgramSettingsTime(hour: 14, minute: 30),
-              minimumHour: 10,
-              maximumHour: 12,
+              minimumTime: ProgramSettingsTime(hour: 10, minute: 0),
+              maximumTime: ProgramSettingsTime(hour: 12, minute: 0),
             ),
             onSubmit: (_, __) async =>
                 const ProcedureSessionSubmitResult.saved(),
@@ -68,7 +68,7 @@ void main() {
 
     expect(
       find.text(
-        'Допустимое время начала: 10:00-12:55. Обед: с 13:30 до 14:30.',
+        'Доступные часы начала: 10-12. Обед: с 13:30 до 14:30.',
       ),
       findsOneWidget,
     );

--- a/packages/bochki_schedule_app/test/features/program_settings/program_settings_view_model_test.dart
+++ b/packages/bochki_schedule_app/test/features/program_settings/program_settings_view_model_test.dart
@@ -31,8 +31,8 @@ void main() {
         const ProgramSettings(
           lunchStart: ProgramSettingsTime(hour: 15, minute: 0),
           lunchEnd: ProgramSettingsTime(hour: 14, minute: 0),
-          minimumHour: 8,
-          maximumHour: 20,
+          minimumTime: ProgramSettingsTime(hour: 8, minute: 0),
+          maximumTime: ProgramSettingsTime(hour: 20, minute: 0),
         ),
       );
 

--- a/packages/bochki_schedule_domain/lib/src/program_settings.dart
+++ b/packages/bochki_schedule_domain/lib/src/program_settings.dart
@@ -4,28 +4,21 @@ final class ProgramSettings {
   const ProgramSettings({
     required this.lunchStart,
     required this.lunchEnd,
-    required this.minimumHour,
-    required this.maximumHour,
-  })  : assert(
-          minimumHour >= 0 && minimumHour <= 23,
-          'minimumHour must be between 0 and 23',
-        ),
-        assert(
-          maximumHour >= 0 && maximumHour <= 23,
-          'maximumHour must be between 0 and 23',
-        );
+    required this.minimumTime,
+    required this.maximumTime,
+  });
 
   static const ProgramSettings defaults = ProgramSettings(
     lunchStart: ProgramSettingsTime(hour: 14, minute: 0),
     lunchEnd: ProgramSettingsTime(hour: 15, minute: 0),
-    minimumHour: 8,
-    maximumHour: 20,
+    minimumTime: ProgramSettingsTime(hour: 8, minute: 0),
+    maximumTime: ProgramSettingsTime(hour: 20, minute: 0),
   );
 
   final ProgramSettingsTime lunchStart;
   final ProgramSettingsTime lunchEnd;
-  final int minimumHour;
-  final int maximumHour;
+  final ProgramSettingsTime minimumTime;
+  final ProgramSettingsTime maximumTime;
 
   factory ProgramSettings.fromJson(Object? json) {
     if (json is! Map) {
@@ -35,8 +28,18 @@ final class ProgramSettings {
     return ProgramSettings(
       lunchStart: ProgramSettingsTime.fromJson(json['lunchStart']),
       lunchEnd: ProgramSettingsTime.fromJson(json['lunchEnd']),
-      minimumHour: _readHour(json['minimumHour'], fieldName: 'minimumHour'),
-      maximumHour: _readHour(json['maximumHour'], fieldName: 'maximumHour'),
+      minimumTime: json.containsKey('minimumTime')
+          ? ProgramSettingsTime.fromJson(json['minimumTime'])
+          : ProgramSettingsTime(
+              hour: _readHour(json['minimumHour'], fieldName: 'minimumHour'),
+              minute: 0,
+            ),
+      maximumTime: json.containsKey('maximumTime')
+          ? ProgramSettingsTime.fromJson(json['maximumTime'])
+          : ProgramSettingsTime(
+              hour: _readHour(json['maximumHour'], fieldName: 'maximumHour'),
+              minute: 0,
+            ),
     );
   }
 
@@ -44,22 +47,22 @@ final class ProgramSettings {
     return <String, Object?>{
       'lunchStart': lunchStart.toJson(),
       'lunchEnd': lunchEnd.toJson(),
-      'minimumHour': minimumHour,
-      'maximumHour': maximumHour,
+      'minimumTime': minimumTime.toJson(),
+      'maximumTime': maximumTime.toJson(),
     };
   }
 
   ProgramSettings copyWith({
     ProgramSettingsTime? lunchStart,
     ProgramSettingsTime? lunchEnd,
-    int? minimumHour,
-    int? maximumHour,
+    ProgramSettingsTime? minimumTime,
+    ProgramSettingsTime? maximumTime,
   }) {
     return ProgramSettings(
       lunchStart: lunchStart ?? this.lunchStart,
       lunchEnd: lunchEnd ?? this.lunchEnd,
-      minimumHour: minimumHour ?? this.minimumHour,
-      maximumHour: maximumHour ?? this.maximumHour,
+      minimumTime: minimumTime ?? this.minimumTime,
+      maximumTime: maximumTime ?? this.maximumTime,
     );
   }
 

--- a/packages/bochki_schedule_domain/lib/src/program_settings_time.dart
+++ b/packages/bochki_schedule_domain/lib/src/program_settings_time.dart
@@ -4,8 +4,8 @@ final class ProgramSettingsTime {
     required this.minute,
   })  : assert(hour >= 0 && hour <= 23, 'hour must be between 0 and 23'),
         assert(
-          minute >= 0 && minute <= 50 && minute % 10 == 0,
-          'minute must be between 0 and 50 in 10-minute increments',
+          minute >= 0 && minute <= 55 && minute % 5 == 0,
+          'minute must be between 0 and 55 in 5-minute increments',
         );
 
   final int hour;
@@ -71,9 +71,9 @@ final class ProgramSettingsTime {
     }
 
     final minute = value.toInt();
-    if (minute < 0 || minute > 50 || minute % 10 != 0) {
+    if (minute < 0 || minute > 55 || minute % 5 != 0) {
       throw const FormatException(
-        'Program settings time minute must be between 0 and 50 in 10-minute increments.',
+        'Program settings time minute must be between 0 and 55 in 5-minute increments.',
       );
     }
     return minute;

--- a/packages/bochki_schedule_domain/test/project_document_test.dart
+++ b/packages/bochki_schedule_domain/test/project_document_test.dart
@@ -31,13 +31,35 @@ void main() {
     const settings = ProgramSettings(
       lunchStart: ProgramSettingsTime(hour: 12, minute: 0),
       lunchEnd: ProgramSettingsTime(hour: 13, minute: 0),
-      minimumHour: 8,
-      maximumHour: 18,
+      minimumTime: ProgramSettingsTime(hour: 8, minute: 0),
+      maximumTime: ProgramSettingsTime(hour: 18, minute: 0),
     );
 
     final json = const ProjectDocument(programSettings: settings).toJson();
 
     expect(json['programSettings'], settings.toJson());
+  });
+
+  test('migrates legacy program settings hours to times', () {
+    final document = ProjectDocument.fromJson(<String, Object?>{
+      'programSettings': <String, Object?>{
+        'lunchStart': <String, Object?>{'hour': 12, 'minute': 0},
+        'lunchEnd': <String, Object?>{'hour': 13, 'minute': 0},
+        'minimumHour': 8,
+        'maximumHour': 18,
+      },
+    });
+
+    expect(document.programSettings.minimumTime.hour, 8);
+    expect(document.programSettings.minimumTime.minute, 0);
+    expect(document.programSettings.maximumTime.hour, 18);
+    expect(document.programSettings.maximumTime.minute, 0);
+    expect(document.toJson()['programSettings'], <String, Object?>{
+      'lunchStart': <String, Object?>{'hour': 12, 'minute': 0},
+      'lunchEnd': <String, Object?>{'hour': 13, 'minute': 0},
+      'minimumTime': <String, Object?>{'hour': 8, 'minute': 0},
+      'maximumTime': <String, Object?>{'hour': 18, 'minute': 0},
+    });
   });
 
   test('throws when stored print preset params are incomplete', () {


### PR DESCRIPTION
## What Changed

- Replaced hour-only program time limits with minute-precise values and legacy JSON migration.
- Added boundary conflicts for early starts and late participant, assistant, or resource finishes.
- Updated settings UI, free-slot calculations, desktop bridge, and procedure-time selection.

## How It Was Verified

- Dart formatting check for changed packages.
- Dart tests in packages/bochki_schedule_domain.
- Full Flutter suite will run in GitHub CI; the local Flutter SDK is incomplete.

## Tests Added Or Updated

- Legacy settings migration and serialization.
- Time-boundary conflict aggregation, including a next-day finish.
- Existing settings and procedure tests updated for the new value objects.

## Docs Or ADR Updates

- Issue #108 contains the agreed implementation plan.

## Architecture Notes

- Time-boundary conflicts are modeled separately from resource-overload conflicts.