### PR TITLE
fix(directories): restore people table CRUD

### DIFF
--- a/packages/bochki_schedule_app/lib/src/domain/assistants/create_assistant_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/assistants/create_assistant_use_case.dart
@@ -6,17 +6,29 @@ import 'assistants_validation_exception.dart';
 
 final class CreateAssistantUseCase {
   CreateAssistantUseCase(AssistantsRepository repository)
-      : _delegate = CreateNamedDirectoryEntryUseCase<Assistant>(
+      : _repository = repository,
+        _delegate = CreateNamedDirectoryEntryUseCase<Assistant>(
           repository,
           emptyNameMessage: 'Введите имя ассистента.',
           duplicateNameMessage: 'Ассистент с таким именем уже есть.',
           exceptionFactory: _validationException,
         );
 
+  final AssistantsRepository _repository;
   final CreateNamedDirectoryEntryUseCase<Assistant> _delegate;
 
-  Future<Assistant> execute(String rawName) {
-    return _delegate.execute(rawName);
+  Future<Assistant> execute(
+    String rawName, {
+    String? rawShortName,
+  }) async {
+    final assistant = await _delegate.execute(rawName);
+    if (rawShortName == null) {
+      return assistant;
+    }
+
+    return _repository.update(
+      assistant.copyWith(shortName: rawShortName),
+    );
   }
 
   static AssistantsValidationException _validationException(String message) {

--- a/packages/bochki_schedule_app/lib/src/features/directory/people_directory_table.dart
+++ b/packages/bochki_schedule_app/lib/src/features/directory/people_directory_table.dart
@@ -1,0 +1,292 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+enum PeopleDirectoryType { participants, assistants }
+
+class PeopleDirectoryEntry {
+  const PeopleDirectoryEntry({
+    required this.id,
+    required this.name,
+    this.shortName,
+  });
+
+  final String id;
+  final String name;
+  final String? shortName;
+}
+
+typedef PeopleDirectoryMutation = Future<String?> Function(
+  String action, {
+  String? id,
+  String? name,
+  String? shortName,
+});
+
+class PeopleDirectoryTable extends StatefulWidget {
+  const PeopleDirectoryTable({
+    required this.type,
+    required this.entries,
+    required this.onMutate,
+    required this.onChanged,
+    super.key,
+  });
+
+  final PeopleDirectoryType type;
+  final List<PeopleDirectoryEntry> entries;
+  final PeopleDirectoryMutation onMutate;
+  final Future<void> Function() onChanged;
+
+  @override
+  State<PeopleDirectoryTable> createState() => _PeopleDirectoryTableState();
+}
+
+class _PeopleDirectoryTableState extends State<PeopleDirectoryTable> {
+  final _name = TextEditingController();
+  final _shortName = TextEditingController();
+  final _rowFocus = FocusNode();
+  final _nameFocus = FocusNode();
+  String? _editingId;
+  bool _creating = false;
+  bool _saving = false;
+  String? _error;
+
+  bool get _hasShortName => widget.type == PeopleDirectoryType.assistants;
+  bool get _isEditing => _creating || _editingId != null;
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _shortName.dispose();
+    _rowFocus.dispose();
+    _nameFocus.dispose();
+    super.dispose();
+  }
+
+  void _beginEdit(PeopleDirectoryEntry entry) {
+    if (_saving) return;
+    setState(() {
+      _creating = false;
+      _editingId = entry.id;
+      _name.text = entry.name;
+      _shortName.text = entry.shortName ?? '';
+      _error = null;
+    });
+    _focusName();
+  }
+
+  void _beginCreate() {
+    if (_saving) return;
+    setState(() {
+      _creating = true;
+      _editingId = null;
+      _name.clear();
+      _shortName.clear();
+      _error = null;
+    });
+    _focusName();
+  }
+
+  void _focusName() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _nameFocus.requestFocus();
+    });
+  }
+
+  void _cancel() {
+    if (!_isEditing || _saving) return;
+    setState(() {
+      _editingId = null;
+      _creating = false;
+      _error = null;
+    });
+  }
+
+  Future<void> _submit() async {
+    if (!_isEditing || _saving) return;
+    setState(() => _saving = true);
+    final error = await widget.onMutate(
+      _creating ? 'create' : 'update',
+      id: _editingId,
+      name: _name.text,
+      shortName: _hasShortName ? _shortName.text : null,
+    );
+    if (!mounted) return;
+    if (error != null) {
+      setState(() {
+        _saving = false;
+        _error = error;
+      });
+      return;
+    }
+    setState(() {
+      _saving = false;
+      _editingId = null;
+      _creating = false;
+      _error = null;
+    });
+    await widget.onChanged();
+  }
+
+  Future<void> _delete(PeopleDirectoryEntry entry) async {
+    if (_saving) return;
+    final typeName = widget.type == PeopleDirectoryType.participants
+        ? 'участника'
+        : 'ассистента';
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Удалить $typeName?'),
+        content: Text('Запись «${entry.name}» будет скрыта из списка.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Отмена'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Удалить'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    setState(() => _saving = true);
+    final error = await widget.onMutate('delete', id: entry.id);
+    if (!mounted) return;
+    setState(() {
+      _saving = false;
+      _error = error;
+    });
+    if (error == null) await widget.onChanged();
+  }
+
+  bool _onKey(FocusNode _, KeyEvent event) {
+    if (event is! KeyDownEvent) return false;
+    if (event.logicalKey == LogicalKeyboardKey.escape) {
+      _cancel();
+      return true;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.enter ||
+        event.logicalKey == LogicalKeyboardKey.numpadEnter) {
+      unawaited(_submit());
+      return true;
+    }
+    return false;
+  }
+
+  Widget _field(TextEditingController controller, String label) => Expanded(
+        child: Padding(
+          padding: const EdgeInsets.all(6),
+          child: TextField(
+            controller: controller,
+            focusNode: controller == _name ? _nameFocus : null,
+            enabled: !_saving,
+            decoration: InputDecoration(isDense: true, labelText: label),
+          ),
+        ),
+      );
+
+  Widget _row(PeopleDirectoryEntry entry) {
+    final editing = _editingId == entry.id;
+    final content = editing
+        ? Focus(
+            focusNode: _rowFocus,
+            onKeyEvent: (node, event) => _onKey(node, event)
+                ? KeyEventResult.handled
+                : KeyEventResult.ignored,
+            child: TapRegion(
+              onTapOutside: (_) => unawaited(_submit()),
+              child: Row(children: [
+                _field(_name, 'Имя'),
+                if (_hasShortName) _field(_shortName, 'Краткое имя'),
+                const SizedBox(width: 180),
+              ]),
+            ),
+          )
+        : Row(children: [
+            Expanded(
+                child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Text(entry.name))),
+            if (_hasShortName)
+              Expanded(
+                  child: Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: Text(entry.shortName ?? ''))),
+            SizedBox(
+              width: 180,
+              child: Row(mainAxisAlignment: MainAxisAlignment.end, children: [
+                TextButton(
+                    onPressed: () => _beginEdit(entry),
+                    child: const Text('изм.')),
+                TextButton(
+                    onPressed: () => _delete(entry), child: const Text('удл.')),
+              ]),
+            ),
+          ]);
+    return InkWell(
+      key: Key('people_directory_row_${entry.id}'),
+      onTap: editing ? null : () => _beginEdit(entry),
+      child: Container(
+        decoration: const BoxDecoration(
+            border: Border(bottom: BorderSide(color: Color(0xFFD8E1EA)))),
+        child: content,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Container(
+            color: const Color(0xFFF0F4F8),
+            child: Row(children: [
+              const Expanded(
+                  child:
+                      Padding(padding: EdgeInsets.all(12), child: Text('Имя'))),
+              if (_hasShortName)
+                const Expanded(
+                    child: Padding(
+                        padding: EdgeInsets.all(12),
+                        child: Text('Краткое имя'))),
+              const SizedBox(width: 180),
+            ]),
+          ),
+          Expanded(
+              child: ListView(
+                  children: [for (final entry in widget.entries) _row(entry)])),
+          if (_creating)
+            Focus(
+              focusNode: _rowFocus,
+              onKeyEvent: (node, event) => _onKey(node, event)
+                  ? KeyEventResult.handled
+                  : KeyEventResult.ignored,
+              child: TapRegion(
+                onTapOutside: (_) => unawaited(_submit()),
+                child: Row(children: [
+                  _field(_name, 'Имя'),
+                  if (_hasShortName) _field(_shortName, 'Краткое имя'),
+                  const SizedBox(width: 180),
+                ]),
+              ),
+            )
+          else
+            InkWell(
+              key: const Key('people_directory_add_row'),
+              onTap: _beginCreate,
+              child: const Padding(
+                padding: EdgeInsets.all(14),
+                child: Text('Создать новую запись'),
+              ),
+            ),
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(_error!, style: const TextStyle(color: Colors.red)),
+            ),
+        ],
+      );
+}

--- a/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
@@ -20,6 +20,7 @@ import '../app_services.dart';
 import '../features/procedure_sessions/procedure_session_dialog.dart';
 import '../features/procedure_sessions/procedure_session_submit_result.dart';
 import '../features/procedure_sessions/procedure_sessions_view_model.dart';
+import '../features/directory/people_directory_table.dart';
 
 enum DesktopWindowKind {
   main,
@@ -288,8 +289,10 @@ final class DesktopWindowCoordinator {
             await _services.deleteAssistantUseCase
                 .execute(values['id'] as String);
           if (action == 'create')
-            await _services.createAssistantUseCase
-                .execute(entry['name'] as String);
+            await _services.createAssistantUseCase.execute(
+              entry['name'] as String,
+              rawShortName: entry['shortName'] as String?,
+            );
           if (action == 'update')
             await _services.updateAssistantUseCase.execute(
                 assistantId: values['id'] as String,
@@ -971,6 +974,9 @@ class _DirectoryChildWindowState extends State<DirectoryChildWindow> {
   bool get _isEditor =>
       _kind == DesktopWindowKind.procedureKindEditor ||
       _kind == DesktopWindowKind.workdayEditor;
+  bool get _isPeopleDirectory =>
+      _kind == DesktopWindowKind.participants ||
+      _kind == DesktopWindowKind.assistants;
   String get _directory => switch (_kind) {
         DesktopWindowKind.participants => 'participants',
         DesktopWindowKind.assistants => 'assistants',
@@ -1112,6 +1118,7 @@ class _DirectoryChildWindowState extends State<DirectoryChildWindow> {
       return const MaterialApp(
           home: Scaffold(body: Center(child: CircularProgressIndicator())));
     return MaterialApp(
+      debugShowCheckedModeBanner: false,
       theme: ThemeData(useMaterial3: true),
       home: Scaffold(
         appBar: AppBar(title: Text(_title)),
@@ -1138,7 +1145,55 @@ class _DirectoryChildWindowState extends State<DirectoryChildWindow> {
         _ => '',
       };
 
-  Widget _directoryList() => Column(children: [
+  Widget _directoryList() {
+    if (_isPeopleDirectory) {
+      return PeopleDirectoryTable(
+        type: _kind == DesktopWindowKind.participants
+            ? PeopleDirectoryType.participants
+            : PeopleDirectoryType.assistants,
+        entries: _entries
+            .map(
+              (entry) => PeopleDirectoryEntry(
+                id: entry['id'] as String,
+                name: entry['name'] as String,
+                shortName: entry['shortName'] as String?,
+              ),
+            )
+            .toList(growable: false),
+        onMutate: _mutatePeople,
+        onChanged: _load,
+      );
+    }
+    return _legacyDirectoryList();
+  }
+
+  Future<String?> _mutatePeople(
+    String action, {
+    String? id,
+    String? name,
+    String? shortName,
+  }) async {
+    try {
+      final result = Map<String, dynamic>.from(
+        await _mainChannel.invokeMethod('directoryMutate', {
+          'directory': _directory,
+          'action': action,
+          if (id != null) 'id': id,
+          'entry': {
+            if (name != null) 'name': name,
+            if (shortName != null) 'shortName': shortName,
+          },
+        }) as Map,
+      );
+      return result['ok'] == true
+          ? null
+          : result['error'] as String? ?? 'Не удалось сохранить изменения.';
+    } catch (_) {
+      return 'Не удалось сохранить изменения.';
+    }
+  }
+
+  Widget _legacyDirectoryList() => Column(children: [
         Row(children: [
           FilledButton.tonal(
               onPressed: _saving

--- a/packages/bochki_schedule_app/test/domain/assistants/assistants_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/assistants/assistants_use_cases_test.dart
@@ -49,6 +49,19 @@ void main() {
       expect(repository.assistants.single.name, 'Иван Иванов');
     });
 
+    test('create preserves a supplied short name', () async {
+      final repository = _InMemoryAssistantsRepository();
+      final useCase = CreateAssistantUseCase(repository);
+
+      final assistant = await useCase.execute(
+        'Иван Иванов',
+        rawShortName: 'Иван',
+      );
+
+      expect(assistant.shortName, 'Иван');
+      expect(repository.assistants.single.shortName, 'Иван');
+    });
+
     test('empty name does not pass validation', () async {
       final repository = _InMemoryAssistantsRepository();
       final useCase = CreateAssistantUseCase(repository);

--- a/packages/bochki_schedule_app/test/features/directory/people_directory_table_test.dart
+++ b/packages/bochki_schedule_app/test/features/directory/people_directory_table_test.dart
@@ -1,0 +1,77 @@
+import 'package:bochki_schedule_app/src/features/directory/people_directory_table.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('assistant table edits and creates rows inline', (tester) async {
+    final mutations = <String>[];
+    await tester.pumpWidget(_table(
+      type: PeopleDirectoryType.assistants,
+      onMutate: (action, {id, name, shortName}) async {
+        mutations.add('$action:$id:$name:$shortName');
+        return null;
+      },
+    ));
+
+    expect(find.text('Имя'), findsOneWidget);
+    expect(find.text('Краткое имя'), findsOneWidget);
+    expect(find.text('изм.'), findsOneWidget);
+    expect(find.text('удл.'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('people_directory_row_1')));
+    await tester.pump();
+    expect(find.byType(TextField), findsNWidgets(2));
+    await tester.enterText(find.byType(TextField).first, 'Анна Петрова');
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+    expect(mutations, ['update:1:Анна Петрова:Анна']);
+
+    await tester.tap(find.byKey(const Key('people_directory_add_row')));
+    await tester.pump();
+    await tester.enterText(find.byType(TextField).first, 'Борис');
+    await tester.enterText(find.byType(TextField).last, 'Б');
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+    expect(mutations.last, 'create:null:Борис:Б');
+  });
+
+  testWidgets('escape cancels an inline edit and errors preserve it',
+      (tester) async {
+    await tester.pumpWidget(_table(
+      type: PeopleDirectoryType.participants,
+      onMutate: (action, {id, name, shortName}) async =>
+          'Введите имя участника.',
+    ));
+
+    await tester.tap(find.byKey(const Key('people_directory_row_1')));
+    await tester.pump();
+    await tester.enterText(find.byType(TextField), '');
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+    expect(find.text('Введите имя участника.'), findsOneWidget);
+    expect(find.byType(TextField), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+    expect(find.byType(TextField), findsNothing);
+    expect(find.text('Анна'), findsOneWidget);
+  });
+}
+
+Widget _table({
+  required PeopleDirectoryType type,
+  required PeopleDirectoryMutation onMutate,
+}) =>
+    MaterialApp(
+      home: Scaffold(
+        body: PeopleDirectoryTable(
+          type: type,
+          entries: const [
+            PeopleDirectoryEntry(id: '1', name: 'Анна', shortName: 'Анна'),
+          ],
+          onMutate: onMutate,
+          onChanged: () async {},
+        ),
+      ),
+    );


### PR DESCRIPTION
Closes #116

- restores inline table CRUD for participants and assistants
- restores bottom creation row and row actions
- preserves assistant short names on creation
- removes the child-window debug banner
- adds domain and widget coverage