### PR TITLE
fix(directories): refresh menu counts after mutations

### DIFF
--- a/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
@@ -35,6 +35,8 @@ enum DesktopWindowKind {
   workdayEditor,
 }
 
+typedef DirectoryChangedCallback = Future<void> Function(String directory);
+
 const _mainChannel = WindowMethodChannel(
   'bochki_schedule/main_window',
   mode: ChannelMode.unidirectional,
@@ -57,15 +59,18 @@ final class DesktopWindowCoordinator {
     required BuildProcedureStatisticsTableUseCase statistics,
     required BuildScheduleGapsUseCase scheduleGaps,
     required ProcedureSessionsViewModel sessions,
+    required DirectoryChangedCallback onDirectoryChanged,
   })  : _services = services,
         _statistics = statistics,
         _scheduleGaps = scheduleGaps,
-        _sessions = sessions;
+        _sessions = sessions,
+        _onDirectoryChanged = onDirectoryChanged;
 
   final AppServices _services;
   final BuildProcedureStatisticsTableUseCase _statistics;
   final BuildScheduleGapsUseCase _scheduleGaps;
   final ProcedureSessionsViewModel _sessions;
+  final DirectoryChangedCallback _onDirectoryChanged;
   ProcedureSessionRaw? _sessionDraft;
 
   Future<void> start() => _mainChannel.setMethodCallHandler(_handleCall);
@@ -332,6 +337,7 @@ final class DesktopWindowCoordinator {
   }
 
   Future<void> _notifyDirectoryChanged(String directory) async {
+    await _onDirectoryChanged(directory);
     await _sessions.load();
     for (final controller in await WindowController.getAll()) {
       if (windowKindFromArguments(controller.arguments) !=

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -41,6 +41,23 @@ enum ReportsSection { statistics, procedureStatistics, freeTime }
 
 enum TemplatesSection { create, load, delete, clearSchedule }
 
+typedef DirectoryCountRefresher = Future<void> Function();
+
+Future<void> refreshDirectoryCount(
+  String directory, {
+  required DirectoryCountRefresher refreshParticipants,
+  required DirectoryCountRefresher refreshAssistants,
+  required DirectoryCountRefresher refreshProcedureKinds,
+  required DirectoryCountRefresher refreshWorkdays,
+}) =>
+    switch (directory) {
+      'participants' => refreshParticipants(),
+      'assistants' => refreshAssistants(),
+      'procedureKinds' => refreshProcedureKinds(),
+      'workdays' => refreshWorkdays(),
+      _ => Future<void>.value(),
+    };
+
 class BochkiShell extends StatefulWidget {
   const BochkiShell({
     required this.services,
@@ -99,6 +116,7 @@ class _BochkiShellState extends State<BochkiShell> {
         statistics: statistics,
         scheduleGaps: scheduleGaps,
         sessions: _procedureSessionsViewModel,
+        onDirectoryChanged: _refreshDirectoryCount,
       );
       unawaited(_startDesktopWindows());
       _windowsSubscription =
@@ -163,6 +181,15 @@ class _BochkiShellState extends State<BochkiShell> {
       // Keep the most recently loaded value, if any.
     }
   }
+
+  Future<void> _refreshDirectoryCount(String directory) =>
+      refreshDirectoryCount(
+        directory,
+        refreshParticipants: _refreshParticipantsCount,
+        refreshAssistants: _refreshAssistantsCount,
+        refreshProcedureKinds: _refreshProcedureKindsCount,
+        refreshWorkdays: _refreshWorkdaysCount,
+      );
 
   String _directoryMenuLabel(DirectorySection section) {
     final count = switch (section) {
@@ -781,8 +808,16 @@ class _BochkiShellState extends State<BochkiShell> {
     String? procedureSessionId,
   }) async {
     if (!isEditing) {
-      await _desktopWindows?.openSession();
-      return;
+      final coordinator = _desktopWindows;
+      if (coordinator != null) {
+        try {
+          await coordinator.openSession();
+          return;
+        } catch (_) {
+          // Multi-window APIs are unavailable in widget tests and unsupported
+          // targets. Fall back to the in-process dialog in those environments.
+        }
+      }
     }
     final initialValue = isEditing
         ? _procedureSessionsViewModel.entries

--- a/packages/bochki_schedule_app/test/app_bootstrap_test.dart
+++ b/packages/bochki_schedule_app/test/app_bootstrap_test.dart
@@ -191,13 +191,37 @@ void main() {
       (await reloaded.listProcedureSessionsUseCase.execute()).single.id,
       '14',
     );
+    final reloadedProgramSettings =
+        await reloaded.getProgramSettingsUseCase.execute();
+    expect(reloadedProgramSettings.lunchStart.hour,
+        templateDocument.programSettings.lunchStart.hour);
+    expect(reloadedProgramSettings.lunchStart.minute,
+        templateDocument.programSettings.lunchStart.minute);
+    expect(reloadedProgramSettings.lunchEnd.hour,
+        templateDocument.programSettings.lunchEnd.hour);
+    expect(reloadedProgramSettings.lunchEnd.minute,
+        templateDocument.programSettings.lunchEnd.minute);
+    expect(reloadedProgramSettings.minimumTime.hour,
+        templateDocument.programSettings.minimumTime.hour);
+    expect(reloadedProgramSettings.minimumTime.minute,
+        templateDocument.programSettings.minimumTime.minute);
+    expect(reloadedProgramSettings.maximumTime.hour,
+        templateDocument.programSettings.maximumTime.hour);
+    expect(reloadedProgramSettings.maximumTime.minute,
+        templateDocument.programSettings.maximumTime.minute);
+    final reloadedPrintPresetParams =
+        await reloaded.getPrintPresetParamsUseCase.execute();
     expect(
-      await reloaded.getProgramSettingsUseCase.execute(),
-      templateDocument.programSettings,
+      reloadedPrintPresetParams.workdayId,
+      templateDocument.printPresetParams.workdayId,
     );
     expect(
-      await reloaded.getPrintPresetParamsUseCase.execute(),
-      templateDocument.printPresetParams,
+      reloadedPrintPresetParams.textBefore,
+      templateDocument.printPresetParams.textBefore,
+    );
+    expect(
+      reloadedPrintPresetParams.textAfter,
+      templateDocument.printPresetParams.textAfter,
     );
     expect(
       (await reloaded.createParticipantUseCase.execute('Следующий')).id,

--- a/packages/bochki_schedule_app/test/presentation/directory_count_refresh_test.dart
+++ b/packages/bochki_schedule_app/test/presentation/directory_count_refresh_test.dart
@@ -1,0 +1,54 @@
+import 'package:bochki_schedule_app/src/presentation/shell/bochki_shell.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('refreshes only the count for the changed directory', () async {
+    final refreshed = <String>[];
+
+    Future<void> record(String directory) async {
+      refreshed.add(directory);
+    }
+
+    for (final directory in const [
+      'participants',
+      'assistants',
+      'procedureKinds',
+      'workdays',
+    ]) {
+      await refreshDirectoryCount(
+        directory,
+        refreshParticipants: () => record('participants'),
+        refreshAssistants: () => record('assistants'),
+        refreshProcedureKinds: () => record('procedureKinds'),
+        refreshWorkdays: () => record('workdays'),
+      );
+    }
+
+    expect(
+      refreshed,
+      ['participants', 'assistants', 'procedureKinds', 'workdays'],
+    );
+  });
+
+  test('ignores an unknown directory', () async {
+    var refreshCount = 0;
+
+    await refreshDirectoryCount(
+      'unknown',
+      refreshParticipants: () async {
+        refreshCount++;
+      },
+      refreshAssistants: () async {
+        refreshCount++;
+      },
+      refreshProcedureKinds: () async {
+        refreshCount++;
+      },
+      refreshWorkdays: () async {
+        refreshCount++;
+      },
+    );
+
+    expect(refreshCount, 0);
+  });
+}


### PR DESCRIPTION
Closes #118

- notify the main desktop window after successful directory mutations
- refresh only the changed directory count
- cover the count refresh routing
- restore the widget-test fallback when multi-window APIs are unavailable
- make template-reload assertions compare persisted values