### PR TITLE
fix(directories): clear procedure references on person deletion

### DIFF
--- a/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
+++ b/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
@@ -175,6 +175,8 @@ final class AppBootstrap {
     );
     final deleteParticipantUseCase = DeleteParticipantUseCase(
       participantsRepository,
+      humansRepository: humansRepository,
+      procedureSessionsRepository: procedureSessionsRepository,
     );
     final listAssistantsUseCase = ListAssistantsUseCase(
       assistantsRepository,
@@ -187,6 +189,8 @@ final class AppBootstrap {
     );
     final deleteAssistantUseCase = DeleteAssistantUseCase(
       assistantsRepository,
+      humansRepository: humansRepository,
+      procedureSessionsRepository: procedureSessionsRepository,
     );
     final listProcedureKindsUseCase = ListProcedureKindsUseCase(
       procedureKindsRepository,

--- a/packages/bochki_schedule_app/lib/src/data/procedure_sessions/procedure_session_dto.dart
+++ b/packages/bochki_schedule_app/lib/src/data/procedure_sessions/procedure_session_dto.dart
@@ -15,7 +15,7 @@ final class ProcedureSessionDto {
     return ProcedureSessionDto(
       id: (json['id'] as num?)?.toInt() ?? 0,
       dayId: (json['dayId'] as num?)?.toInt() ?? 0,
-      participantId: (json['participantId'] as num?)?.toInt() ?? 0,
+      participantId: (json['participantId'] as num?)?.toInt(),
       startTime: (json['startTime'] as String? ?? '').trim(),
       procedureKindId: (json['procedureKindId'] as num?)?.toInt() ?? 0,
       assistantId: (json['assistantId'] as num?)?.toInt(),
@@ -30,7 +30,9 @@ final class ProcedureSessionDto {
     return ProcedureSessionDto(
       id: int.parse(procedureSession.id),
       dayId: int.parse(procedureSession.dayId),
-      participantId: int.parse(procedureSession.participantId),
+      participantId: procedureSession.participantId == null
+          ? null
+          : int.parse(procedureSession.participantId!),
       startTime: procedureSession.startTime,
       procedureKindId: int.parse(procedureSession.procedureKindId),
       assistantId: procedureSession.assistantId == null
@@ -42,7 +44,7 @@ final class ProcedureSessionDto {
 
   final int id;
   final int dayId;
-  final int participantId;
+  final int? participantId;
   final String startTime;
   final int procedureKindId;
   final int? assistantId;
@@ -52,7 +54,7 @@ final class ProcedureSessionDto {
     return ProcedureSessionRaw(
       id: '$id',
       dayId: '$dayId',
-      participantId: '$participantId',
+      participantId: participantId?.toString(),
       startTime: startTime,
       procedureKindId: '$procedureKindId',
       assistantId: assistantId?.toString(),
@@ -63,6 +65,7 @@ final class ProcedureSessionDto {
     int? id,
     int? dayId,
     int? participantId,
+    bool clearParticipantId = false,
     String? startTime,
     int? procedureKindId,
     int? assistantId,
@@ -72,7 +75,8 @@ final class ProcedureSessionDto {
     return ProcedureSessionDto(
       id: id ?? this.id,
       dayId: dayId ?? this.dayId,
-      participantId: participantId ?? this.participantId,
+      participantId:
+          clearParticipantId ? null : participantId ?? this.participantId,
       startTime: startTime ?? this.startTime,
       procedureKindId: procedureKindId ?? this.procedureKindId,
       assistantId: clearAssistantId ? null : assistantId ?? this.assistantId,
@@ -87,7 +91,7 @@ final class ProcedureSessionDto {
       'participantId': participantId,
       'startTime': startTime,
       'procedureKindId': procedureKindId,
-      if (assistantId != null) 'assistantId': assistantId,
+      'assistantId': assistantId,
       'deleted': deleted,
     };
   }

--- a/packages/bochki_schedule_app/lib/src/domain/assistants/delete_assistant_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/assistants/delete_assistant_use_case.dart
@@ -1,22 +1,72 @@
 import '../named_directory/delete_named_directory_entry_use_case.dart';
+import '../humans/humans_repository.dart';
+import '../procedure_sessions/procedure_session_raw.dart';
+import '../procedure_sessions/procedure_sessions_repository.dart';
 
 import 'assistant.dart';
 import 'assistants_repository.dart';
 import 'assistants_validation_exception.dart';
 
 final class DeleteAssistantUseCase {
-  DeleteAssistantUseCase(AssistantsRepository repository)
-      : _delegate = DeleteNamedDirectoryEntryUseCase<Assistant>(
+  DeleteAssistantUseCase(
+    AssistantsRepository repository, {
+    HumansRepository? humansRepository,
+    ProcedureSessionsRepository? procedureSessionsRepository,
+  })  : _humansRepository = humansRepository,
+        _procedureSessionsRepository = procedureSessionsRepository,
+        _delegate = DeleteNamedDirectoryEntryUseCase<Assistant>(
           repository,
           emptyIdMessage: 'Идентификатор ассистента не должен быть пустым.',
           exceptionFactory: _validationException,
         );
 
   final DeleteNamedDirectoryEntryUseCase<Assistant> _delegate;
+  final HumansRepository? _humansRepository;
+  final ProcedureSessionsRepository? _procedureSessionsRepository;
 
-  Future<void> execute(String assistantId) {
-    return _delegate.execute(assistantId);
+  Future<int> countReferences(String assistantId) async {
+    final repository = _procedureSessionsRepository;
+    if (repository == null) return 0;
+    return _affectedSessions(await repository.list(), assistantId).length;
   }
+
+  Future<void> execute(String assistantId) async {
+    final sessionsRepository = _procedureSessionsRepository;
+    final humansRepository = _humansRepository;
+    if (sessionsRepository == null || humansRepository == null) {
+      return _delegate.execute(assistantId);
+    }
+    final current =
+        _affectedSessions(await sessionsRepository.list(), assistantId);
+    final replacements = [
+      for (final session in current)
+        session.copyWith(
+          clearParticipantId: session.participantId == assistantId,
+          clearAssistantId: session.assistantId == assistantId,
+        ),
+    ];
+    try {
+      if (replacements.isNotEmpty) {
+        await sessionsRepository.updateMany(replacements);
+      }
+      await humansRepository.delete(assistantId);
+    } catch (_) {
+      if (replacements.isNotEmpty) {
+        await sessionsRepository.updateMany(current);
+      }
+      rethrow;
+    }
+  }
+
+  static List<ProcedureSessionRaw> _affectedSessions(
+    List<ProcedureSessionRaw> sessions,
+    String humanId,
+  ) =>
+      sessions
+          .where((session) =>
+              session.participantId == humanId ||
+              session.assistantId == humanId)
+          .toList(growable: false);
 
   static AssistantsValidationException _validationException(String message) {
     return AssistantsValidationException(message);

--- a/packages/bochki_schedule_app/lib/src/domain/participants/delete_participant_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/participants/delete_participant_use_case.dart
@@ -1,21 +1,82 @@
 import '../named_directory/delete_named_directory_entry_use_case.dart';
+import '../humans/humans_repository.dart';
+import '../procedure_sessions/procedure_session_raw.dart';
+import '../procedure_sessions/procedure_sessions_repository.dart';
 
 import 'participant.dart';
 import 'participants_repository.dart';
 import 'participants_validation_exception.dart';
 
 final class DeleteParticipantUseCase {
-  DeleteParticipantUseCase(ParticipantsRepository repository)
-      : _delegate = DeleteNamedDirectoryEntryUseCase<Participant>(
+  DeleteParticipantUseCase(
+    ParticipantsRepository repository, {
+    HumansRepository? humansRepository,
+    ProcedureSessionsRepository? procedureSessionsRepository,
+  })  : _humansRepository = humansRepository,
+        _procedureSessionsRepository = procedureSessionsRepository,
+        _delegate = DeleteNamedDirectoryEntryUseCase<Participant>(
           repository,
           emptyIdMessage: 'Идентификатор участника не должен быть пустым.',
           exceptionFactory: _validationException,
         );
 
   final DeleteNamedDirectoryEntryUseCase<Participant> _delegate;
+  final HumansRepository? _humansRepository;
+  final ProcedureSessionsRepository? _procedureSessionsRepository;
 
-  Future<void> execute(String participantId) {
-    return _delegate.execute(participantId);
+  Future<int> countReferences(String participantId) async {
+    final repository = _procedureSessionsRepository;
+    if (repository == null) return 0;
+    return _affectedSessions(await repository.list(), participantId).length;
+  }
+
+  Future<void> execute(String participantId) async {
+    final sessionsRepository = _procedureSessionsRepository;
+    final humansRepository = _humansRepository;
+    if (sessionsRepository == null || humansRepository == null) {
+      return _delegate.execute(participantId);
+    }
+    await _deleteHumanAndClearReferences(
+      participantId,
+      sessionsRepository: sessionsRepository,
+      humansRepository: humansRepository,
+    );
+  }
+
+  static List<ProcedureSessionRaw> _affectedSessions(
+    List<ProcedureSessionRaw> sessions,
+    String humanId,
+  ) =>
+      sessions
+          .where((session) =>
+              session.participantId == humanId ||
+              session.assistantId == humanId)
+          .toList(growable: false);
+
+  static Future<void> _deleteHumanAndClearReferences(
+    String humanId, {
+    required ProcedureSessionsRepository sessionsRepository,
+    required HumansRepository humansRepository,
+  }) async {
+    final current = _affectedSessions(await sessionsRepository.list(), humanId);
+    final replacements = [
+      for (final session in current)
+        session.copyWith(
+          clearParticipantId: session.participantId == humanId,
+          clearAssistantId: session.assistantId == humanId,
+        ),
+    ];
+    try {
+      if (replacements.isNotEmpty) {
+        await sessionsRepository.updateMany(replacements);
+      }
+      await humansRepository.delete(humanId);
+    } catch (_) {
+      if (replacements.isNotEmpty) {
+        await sessionsRepository.updateMany(current);
+      }
+      rethrow;
+    }
   }
 
   static ParticipantsValidationException _validationException(String message) {

--- a/packages/bochki_schedule_app/lib/src/domain/print_schedule/build_print_schedule_document_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/print_schedule/build_print_schedule_document_use_case.dart
@@ -57,10 +57,14 @@ final class BuildPrintScheduleDocumentUseCase {
             participantSortKey: _sortKey(session.participant?.name),
             procedureSortKey: _sortKey(session.procedureKind?.name),
             row: PrintScheduleRow(
-              participantName: session.participant?.name ?? 'Не найден',
+              participantName: session.participant?.name ??
+                  (session.participantId == null ? 'Не назначен' : 'Не найден'),
               startTime: session.startTime,
               procedureName: session.procedureKind?.name ?? 'Не найдено',
-              assistantName: session.assistant?.name ?? '',
+              assistantName: session.assistant?.name ??
+                  (session.requiresAssistant && session.assistantId == null
+                      ? 'Не назначен'
+                      : ''),
             ),
           ),
     ];

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_conflict_calculator.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_conflict_calculator.dart
@@ -27,6 +27,9 @@ final class ProcedureSessionConflictCalculator {
     }
 
     final conflicts = <ScheduleConflict>[];
+    for (final session in sessions) {
+      conflicts.addAll(_calculateAssignmentConflicts(session));
+    }
     for (final group in grouped.values) {
       conflicts.addAll(_calculateGroup(group));
     }
@@ -35,6 +38,34 @@ final class ProcedureSessionConflictCalculator {
           .addAll(_calculateTimeBoundaryConflicts(session, programSettings));
     }
     return _mergeAdjacentConflicts(conflicts);
+  }
+
+  List<ScheduleConflict> _calculateAssignmentConflicts(
+    ProcedureSessionRich session,
+  ) {
+    final conflicts = <ScheduleConflict>[];
+    void add(String message) => conflicts.add(ScheduleConflict(
+          type: ScheduleConflictType.missingAssignment,
+          workdayId: session.dayId,
+          timeStart: session.startTime,
+          timeFinish: session.startTime,
+          procedureSessionId: session.id,
+          message: message,
+        ));
+
+    if (session.participantId == null) {
+      add('Не назначен участник.');
+    } else if (session.participant == null) {
+      add('Участник не найден.');
+    }
+    if (session.requiresAssistant) {
+      if (session.assistantId == null) {
+        add('Не назначен ассистент.');
+      } else if (session.assistant == null) {
+        add('Ассистент не найден.');
+      }
+    }
+    return conflicts;
   }
 
   List<ScheduleConflict> _calculateTimeBoundaryConflicts(
@@ -71,8 +102,9 @@ final class ProcedureSessionConflictCalculator {
     }
 
     addEnd('участник', kind.participantBusyTime);
-    if (session.assistantId != null)
+    if (session.assistantId != null) {
       addEnd('ассистент', kind.assistantBusyTime);
+    }
     addEnd('ресурс', kind.resourceBusyTime);
     if (ends.isNotEmpty) {
       conflicts.add(ScheduleConflict(
@@ -104,15 +136,16 @@ final class ProcedureSessionConflictCalculator {
     }
 
     final records = <ProcedureSessionOccupancyRecord>[
-      ProcedureSessionOccupancyRecord(
-        resourceType: ConflictResourceType.human,
-        resourceId: session.participantId,
-        workdayId: session.dayId,
-        timeStart: session.startTime,
-        timeFinish: session.finishTime ?? session.startTime,
-        procedureSessionId: session.id,
-        capacityAllowed: 1,
-      ),
+      if (session.participantId != null && session.participant != null)
+        ProcedureSessionOccupancyRecord(
+          resourceType: ConflictResourceType.human,
+          resourceId: session.participantId!,
+          workdayId: session.dayId,
+          timeStart: session.startTime,
+          timeFinish: session.finishTime ?? session.startTime,
+          procedureSessionId: session.id,
+          capacityAllowed: 1,
+        ),
       ProcedureSessionOccupancyRecord(
         resourceType: ConflictResourceType.item,
         resourceId: session.procedureKindId,

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_conflict_message_formatter.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_conflict_message_formatter.dart
@@ -13,7 +13,7 @@ final class ProcedureSessionConflictMessageFormatter {
     required Iterable<Human> humans,
     required Iterable<ProcedureKind> procedureKinds,
   }) {
-    if (conflict.type == ScheduleConflictType.timeBoundary) {
+    if (conflict.type != ScheduleConflictType.resourceOverload) {
       return conflict.message ?? 'Нарушены границы времени программы.';
     }
     switch (conflict.resourceType!) {

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_raw.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_raw.dart
@@ -5,13 +5,15 @@ final class ProcedureSessionRaw {
   ProcedureSessionRaw({
     required String id,
     required String dayId,
-    required String participantId,
+    String? participantId,
     required String startTime,
     required String procedureKindId,
     String? assistantId,
   })  : id = id.trim(),
         dayId = dayId.trim(),
-        participantId = participantId.trim(),
+        participantId = participantId?.trim().isEmpty ?? true
+            ? null
+            : participantId!.trim(),
         startTime = startTime.trim(),
         procedureKindId = procedureKindId.trim(),
         assistantId =
@@ -24,11 +26,6 @@ final class ProcedureSessionRaw {
     if (this.dayId.isEmpty) {
       throw const ProcedureSessionsValidationException(
         'Выберите день.',
-      );
-    }
-    if (this.participantId.isEmpty) {
-      throw const ProcedureSessionsValidationException(
-        'Выберите участника.',
       );
     }
     if (!ProcedureSessionTime.isValid(this.startTime)) {
@@ -45,7 +42,7 @@ final class ProcedureSessionRaw {
 
   final String id;
   final String dayId;
-  final String participantId;
+  final String? participantId;
   final String startTime;
   final String procedureKindId;
   final String? assistantId;
@@ -57,12 +54,14 @@ final class ProcedureSessionRaw {
     String? startTime,
     String? procedureKindId,
     String? assistantId,
+    bool clearParticipantId = false,
     bool clearAssistantId = false,
   }) {
     return ProcedureSessionRaw(
       id: id ?? this.id,
       dayId: dayId ?? this.dayId,
-      participantId: participantId ?? this.participantId,
+      participantId:
+          clearParticipantId ? null : participantId ?? this.participantId,
       startTime: startTime ?? this.startTime,
       procedureKindId: procedureKindId ?? this.procedureKindId,
       assistantId: clearAssistantId ? null : assistantId ?? this.assistantId,

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_rich.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_rich.dart
@@ -23,7 +23,7 @@ final class ProcedureSessionRich {
 
   String get id => raw.id;
   String get dayId => raw.dayId;
-  String get participantId => raw.participantId;
+  String? get participantId => raw.participantId;
   String get startTime => raw.startTime;
   String get procedureKindId => raw.procedureKindId;
   String? get assistantId => raw.assistantId;

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_validator.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_validator.dart
@@ -21,10 +21,10 @@ abstract final class ProcedureSessionValidator {
       throw const ProcedureSessionsValidationException('Выберите день.');
     }
 
-    final participant = _findHuman(
-      existingHumans,
-      procedureSession.participantId,
-    );
+    final participantId = procedureSession.participantId;
+    final participant = participantId == null
+        ? null
+        : _findHuman(existingHumans, participantId);
     if (participant == null) {
       throw const ProcedureSessionsValidationException('Выберите участника.');
     }

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_with_conflicts.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_with_conflicts.dart
@@ -13,7 +13,7 @@ final class ProcedureSessionWithConflicts {
 
   String get id => rich.id;
   String get dayId => rich.dayId;
-  String get participantId => rich.participantId;
+  String? get participantId => rich.participantId;
   String get startTime => rich.startTime;
   String? get finishTime => rich.finishTime;
   String get procedureKindId => rich.procedureKindId;

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/schedule_conflict_type.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/schedule_conflict_type.dart
@@ -1,4 +1,5 @@
 enum ScheduleConflictType {
   resourceOverload,
   timeBoundary,
+  missingAssignment,
 }

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_statistics/build_procedure_statistics_document_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_statistics/build_procedure_statistics_document_use_case.dart
@@ -34,13 +34,13 @@ final class BuildProcedureStatisticsDocumentUseCase {
       final procedureName = kind?.shortName ?? 'Не найден';
       final assistantName = session.assistant?.shortName ?? 'Не найден';
       final pattern = kind?.patternId;
-      if (pattern == 'single') {
+      if (participantId != null && pattern == 'single') {
         final countKey = '$participantId/${session.procedureKindId}';
         final next = (participantCounts[countKey] ?? 0) + 1;
         participantCounts[countKey] = next;
         _add(cells, key, ProcedureStatisticsTextLine('$next $procedureName'),
             section: _Section.participantSingle);
-      } else if (pattern == 'curated') {
+      } else if (participantId != null && pattern == 'curated') {
         _add(cells, key,
             ProcedureStatisticsTextLine('$procedureName - $assistantName'),
             section: _Section.participantCurated);
@@ -51,7 +51,7 @@ final class BuildProcedureStatisticsDocumentUseCase {
             ProcedureStatisticsTextLine(procedureName),
             section: _Section.assistedCurated);
       }
-      if (pattern == 'grouped') {
+      if (participantId != null && pattern == 'grouped') {
         final countKey = '$participantId/${session.procedureKindId}';
         final next = (groupedCounts[countKey] ?? 0) + 1;
         groupedCounts[countKey] = next;

--- a/packages/bochki_schedule_app/lib/src/features/assistants/assistants_view_model.dart
+++ b/packages/bochki_schedule_app/lib/src/features/assistants/assistants_view_model.dart
@@ -26,6 +26,7 @@ final class AssistantsViewModel extends NamedDirectoryViewModel<Assistant> {
             );
           },
           deleteEntry: deleteAssistantUseCase.execute,
+          countReferences: deleteAssistantUseCase.countReferences,
           loadErrorMessageText: 'Не удалось загрузить ассистентов.',
           saveErrorMessageText: 'Не удалось сохранить изменения.',
           deleteErrorMessageText: 'Не удалось удалить ассистента.',

--- a/packages/bochki_schedule_app/lib/src/features/directory/named_directory_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/directory/named_directory_dialog.dart
@@ -356,6 +356,37 @@ class _NamedDirectoryDialogState<T extends NamedDirectoryEntry>
       return;
     }
 
+    final referencesCount = await widget.viewModel.countReferences(entry.id);
+    if (!mounted) {
+      return;
+    }
+    if (referencesCount > 0) {
+      final referencesConfirmed = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Удалить связанные назначения?'),
+          content: Text(
+            'Запись используется в $referencesCount '
+            '${_procedureWord(referencesCount)}. После удаления ссылки '
+            'будут очищены, а назначения помечены конфликтными.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Отмена'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('ОК'),
+            ),
+          ],
+        ),
+      );
+      if (referencesConfirmed != true || !mounted) {
+        return;
+      }
+    }
+
     final isSuccess = await widget.viewModel.deleteEntry(entry.id);
     if (!mounted) {
       return;
@@ -378,6 +409,19 @@ class _NamedDirectoryDialogState<T extends NamedDirectoryEntry>
         entryId: nextEntries[nextSelectionIndex].id,
       ),
     );
+  }
+
+  String _procedureWord(int count) {
+    final remainder100 = count % 100;
+    final remainder10 = count % 10;
+    if (remainder100 >= 11 && remainder100 <= 14) {
+      return 'назначенных процедурах';
+    }
+    if (remainder10 == 1) return 'назначенной процедуре';
+    if (remainder10 >= 2 && remainder10 <= 4) {
+      return 'назначенных процедурах';
+    }
+    return 'назначенных процедурах';
   }
 
   bool _handleTableKeyEvent(KeyEvent event) {

--- a/packages/bochki_schedule_app/lib/src/features/directory/named_directory_view_model.dart
+++ b/packages/bochki_schedule_app/lib/src/features/directory/named_directory_view_model.dart
@@ -14,6 +14,7 @@ typedef NamedDirectoryUpdater<T extends NamedDirectoryEntry> = Future<T>
   required String fieldId,
 });
 typedef NamedDirectoryDeleter = Future<void> Function(String entryId);
+typedef NamedDirectoryReferenceCounter = Future<int> Function(String entryId);
 
 class NamedDirectoryViewModel<T extends NamedDirectoryEntry>
     extends ChangeNotifier {
@@ -22,18 +23,21 @@ class NamedDirectoryViewModel<T extends NamedDirectoryEntry>
     required NamedDirectoryCreator<T> createEntry,
     required NamedDirectoryUpdater<T> updateEntry,
     required NamedDirectoryDeleter deleteEntry,
+    NamedDirectoryReferenceCounter? countReferences,
     required this.loadErrorMessageText,
     required this.saveErrorMessageText,
     required this.deleteErrorMessageText,
   })  : _loadEntries = loadEntries,
         _createEntry = createEntry,
         _updateEntry = updateEntry,
-        _deleteEntry = deleteEntry;
+        _deleteEntry = deleteEntry,
+        _countReferences = countReferences;
 
   final NamedDirectoryLoader<T> _loadEntries;
   final NamedDirectoryCreator<T> _createEntry;
   final NamedDirectoryUpdater<T> _updateEntry;
   final NamedDirectoryDeleter _deleteEntry;
+  final NamedDirectoryReferenceCounter? _countReferences;
   final String loadErrorMessageText;
   final String saveErrorMessageText;
   final String deleteErrorMessageText;
@@ -51,6 +55,10 @@ class NamedDirectoryViewModel<T extends NamedDirectoryEntry>
   String? get loadErrorMessage => _loadErrorMessage;
   String? get formErrorMessage => _formErrorMessage;
   String? get actionErrorMessage => _actionErrorMessage;
+
+  Future<int> countReferences(String entryId) async {
+    return _countReferences?.call(entryId) ?? 0;
+  }
 
   Future<void> loadEntries() async {
     _isLoading = true;

--- a/packages/bochki_schedule_app/lib/src/features/participants/participants_view_model.dart
+++ b/packages/bochki_schedule_app/lib/src/features/participants/participants_view_model.dart
@@ -25,6 +25,7 @@ final class ParticipantsViewModel extends NamedDirectoryViewModel<Participant> {
             );
           },
           deleteEntry: deleteParticipantUseCase.execute,
+          countReferences: deleteParticipantUseCase.countReferences,
           loadErrorMessageText: 'Не удалось загрузить участников.',
           saveErrorMessageText: 'Не удалось сохранить изменения.',
           deleteErrorMessageText: 'Не удалось удалить участника.',

--- a/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_session_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_session_dialog.dart
@@ -44,7 +44,7 @@ class ProcedureSessionDialog extends StatefulWidget {
 
 class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
   late String _dayId;
-  late String _participantId;
+  late String? _participantId;
   late String _procedureKindId;
   late String? _assistantId;
   late String _hour;
@@ -154,10 +154,11 @@ class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
           child: Text(participant.name),
         ),
     ];
-    if (!items.any((item) => item.value == _participantId)) {
+    if (_participantId != null &&
+        !items.any((item) => item.value == _participantId)) {
       items.add(
         DropdownMenuItem<String>(
-          value: _participantId,
+          value: _participantId!,
           child: Text('Ошибка: участник не найден ($_participantId)'),
         ),
       );
@@ -375,6 +376,7 @@ class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
                       child: DropdownButtonFormField<String>(
                         key: const Key('procedure_session_participant_field'),
                         value: _participantId,
+                        hint: const Text('Выберите участника'),
                         isExpanded: true,
                         items: _buildParticipantItems(),
                         onChanged: _isBusy

--- a/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
@@ -946,7 +946,7 @@ ProcedureSessionRaw _sessionFromMap(Map<String, dynamic> m) =>
     ProcedureSessionRaw(
         id: m['id'] as String,
         dayId: m['dayId'] as String,
-        participantId: m['participantId'] as String,
+        participantId: m['participantId'] as String?,
         startTime: m['startTime'] as String,
         procedureKindId: m['procedureKindId'] as String,
         assistantId: m['assistantId'] as String?);

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -1586,7 +1586,10 @@ class _ProcedureSessionsTableState extends State<_ProcedureSessionsTable> {
   }
 
   String _participantText(dynamic entry) {
-    return entry.participant?.name ?? 'Ошибка: участник не найден';
+    if (entry.participant != null) return entry.participant!.name;
+    return entry.participantId == null
+        ? 'Не назначен'
+        : 'Ошибка: участник не найден';
   }
 
   String _procedureText(dynamic entry) {
@@ -1597,7 +1600,10 @@ class _ProcedureSessionsTableState extends State<_ProcedureSessionsTable> {
     if (!entry.requiresAssistant) {
       return '';
     }
-    return entry.assistant?.name ?? 'Ошибка: ассистент не найден';
+    if (entry.assistant != null) return entry.assistant!.name;
+    return entry.assistantId == null
+        ? 'Не назначен'
+        : 'Ошибка: ассистент не найден';
   }
 
   Widget _buildPersonSummaryCell({

--- a/packages/bochki_schedule_app/test/data/procedure_sessions/project_document_procedure_sessions_repository_test.dart
+++ b/packages/bochki_schedule_app/test/data/procedure_sessions/project_document_procedure_sessions_repository_test.dart
@@ -1,4 +1,6 @@
 import 'package:bochki_schedule_app/src/data/procedure_sessions/project_document_procedure_sessions_repository.dart';
+import 'package:bochki_schedule_app/src/data/humans/project_document_humans_repository.dart';
+import 'package:bochki_schedule_app/src/data/participants/project_document_participants_repository.dart';
 import 'package:bochki_schedule_app/src/data/project_document/project_document_id_allocator.dart';
 import 'package:bochki_schedule_app/bochki_schedule_app.dart';
 import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
@@ -119,9 +121,107 @@ void main() {
         'participantId': 11,
         'startTime': '11:00',
         'procedureKindId': 101,
+        'assistantId': null,
         'deleted': false,
       },
     ]);
     expect(changeNotifications, 4);
+  });
+
+  test('repository persists explicitly cleared participant and assistant ids',
+      () async {
+    final repository = ProjectDocumentProcedureSessionsRepository(
+      initialDocument: const ProjectDocument(
+        nextId: 2,
+        procedureSessions: <Map<String, Object?>>[
+          <String, Object?>{
+            'id': 1,
+            'dayId': 1,
+            'participantId': 10,
+            'assistantId': 20,
+            'startTime': '09:00',
+            'procedureKindId': 100,
+            'deleted': false,
+          },
+        ],
+      ),
+      idAllocator: ProjectDocumentIdAllocator(nextId: 2, onChanged: () {}),
+      onChanged: () {},
+    );
+
+    final session = (await repository.list()).single;
+    await repository.update(session.copyWith(
+      clearParticipantId: true,
+      clearAssistantId: true,
+    ));
+
+    final stored = repository
+        .applyToDocument(const ProjectDocument(nextId: 2))
+        .procedureSessions
+        .single;
+    expect(stored['participantId'], isNull);
+    expect(stored['assistantId'], isNull);
+    expect((await repository.list()).single.participantId, isNull);
+  });
+
+  test('deleting a person clears every active procedure reference', () async {
+    const document = ProjectDocument(
+      nextId: 30,
+      humans: <Map<String, Object?>>[
+        <String, Object?>{
+          'id': 10,
+          'name': 'Анна',
+          'shortName': 'Анна',
+          'isParticipant': true,
+          'isAssistant': true,
+          'deleted': false,
+        },
+      ],
+      procedureSessions: <Map<String, Object?>>[
+        <String, Object?>{
+          'id': 1,
+          'dayId': 1,
+          'participantId': 10,
+          'assistantId': 10,
+          'startTime': '09:00',
+          'procedureKindId': 100,
+          'deleted': false,
+        },
+        <String, Object?>{
+          'id': 2,
+          'dayId': 1,
+          'participantId': 10,
+          'startTime': '10:00',
+          'procedureKindId': 100,
+          'deleted': true,
+        },
+      ],
+    );
+    final allocator = ProjectDocumentIdAllocator(nextId: 30, onChanged: () {});
+    final humans = ProjectDocumentHumansRepository(
+      initialDocument: document,
+      idAllocator: allocator,
+      onChanged: () {},
+    );
+    final sessions = ProjectDocumentProcedureSessionsRepository(
+      initialDocument: document,
+      idAllocator: allocator,
+      onChanged: () {},
+    );
+    final useCase = DeleteParticipantUseCase(
+      ProjectDocumentParticipantsRepository(humansRepository: humans),
+      humansRepository: humans,
+      procedureSessionsRepository: sessions,
+    );
+
+    expect(await useCase.countReferences('10'), 1);
+    await useCase.execute('10');
+
+    expect(await humans.list(), isEmpty);
+    final active = (await sessions.list()).single;
+    expect(active.participantId, isNull);
+    expect(active.assistantId, isNull);
+    final persisted = sessions.applyToDocument(document).procedureSessions;
+    expect(persisted.last['participantId'], 10);
   });
 }

--- a/packages/bochki_schedule_app/test/domain/procedure_sessions/procedure_sessions_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/procedure_sessions/procedure_sessions_use_cases_test.dart
@@ -331,6 +331,49 @@ void main() {
       expect(noConflicts, isEmpty);
     });
 
+    test('conflict calculator reports missing required assignments', () {
+      const calculator = ProcedureSessionConflictCalculator();
+      final kind = ProcedureKind(
+        id: '100',
+        patternId: ProcedureKindPatterns.curated.patternId,
+        name: 'Бочка',
+        capacity: 1,
+        participantBusyTime: 30,
+        assistantBusyTime: 30,
+      );
+      final session = ProcedureSessionRich(
+        raw: ProcedureSessionRaw(
+          id: '1',
+          dayId: '1',
+          startTime: '10:00',
+          procedureKindId: kind.id,
+        ),
+        day: Workday(
+          id: '1',
+          name: 'День 1',
+          calendarDate: DateTime(2026, 7, 11),
+        ),
+        participant: null,
+        procedureKind: kind,
+        assistant: null,
+      );
+
+      final conflicts = calculator.calculate(
+        [session],
+        programSettings: ProgramSettings.defaults,
+      );
+
+      expect(
+        conflicts
+            .where(
+              (conflict) =>
+                  conflict.type == ScheduleConflictType.missingAssignment,
+            )
+            .map((conflict) => conflict.message),
+        containsAll(['Не назначен участник.', 'Не назначен ассистент.']),
+      );
+    });
+
     test('conflict calculator reports exact time-boundary violations', () {
       const calculator = ProcedureSessionConflictCalculator();
       const settings = ProgramSettings(


### PR DESCRIPTION
Closes #120

- warns with the exact number of affected active procedures before deleting a person
- clears participant and assistant references atomically with rollback on failure
- exposes missing and dangling assignments as schedule conflicts
- persists nullable references and updates print/statistics behavior
- adds persistence, deletion, and conflict coverage