### PR TITLE
fix(workdays): select calendar dates

### DIFF
--- a/packages/bochki_schedule_app/lib/src/app.dart
+++ b/packages/bochki_schedule_app/lib/src/app.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'app_services.dart';
 import 'presentation/shell/bochki_shell.dart';
@@ -57,6 +58,9 @@ class _BochkiScheduleAppState extends State<BochkiScheduleApp> {
     return MaterialApp(
       title: 'ПО Расписание Бочки',
       debugShowCheckedModeBanner: false,
+      locale: const Locale('ru', 'RU'),
+      supportedLocales: const [Locale('ru', 'RU')],
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
       theme: ThemeData(
         useMaterial3: true,
         colorScheme: ColorScheme.fromSeed(

--- a/packages/bochki_schedule_app/lib/src/data/workdays/workday_dto.dart
+++ b/packages/bochki_schedule_app/lib/src/data/workdays/workday_dto.dart
@@ -9,10 +9,11 @@ final class WorkdayDto {
   });
 
   factory WorkdayDto.fromJson(Map<String, Object?> json) {
+    final rawCalendarDate = (json['calendarDate'] as String? ?? '').trim();
     return WorkdayDto(
       id: (json['id'] as num?)?.toInt() ?? 0,
       name: (json['name'] as String? ?? '').trim(),
-      calendarDateIso: (json['calendarDate'] as String? ?? '').trim(),
+      calendarDateIso: _formatIsoDate(_parseIsoDate(rawCalendarDate)),
       deleted: json['deleted'] as bool? ?? false,
     );
   }
@@ -66,14 +67,23 @@ final class WorkdayDto {
   }
 
   static DateTime _parseIsoDate(String value) {
-    final parts = value.split('-');
+    final dateOnly = value.length >= 10 ? value.substring(0, 10) : value;
+    final parts = dateOnly.split('-');
     if (parts.length != 3) {
       return DateTime(1970, 1, 1);
     }
-    final year = int.tryParse(parts[0]) ?? 1970;
-    final month = int.tryParse(parts[1]) ?? 1;
-    final day = int.tryParse(parts[2]) ?? 1;
-    return DateTime(year, month, day);
+    final year = int.tryParse(parts[0]);
+    final month = int.tryParse(parts[1]);
+    final day = int.tryParse(parts[2]);
+    if (year == null || month == null || day == null) {
+      return DateTime(1970, 1, 1);
+    }
+    final parsedDate = DateTime(year, month, day);
+    return parsedDate.year == year &&
+            parsedDate.month == month &&
+            parsedDate.day == day
+        ? parsedDate
+        : DateTime(1970, 1, 1);
   }
 
   static String _formatIsoDate(DateTime value) {

--- a/packages/bochki_schedule_app/lib/src/features/workdays/workday_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/workdays/workday_dialog.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import '../../domain/workdays/workday.dart';
 import 'workday_date_format.dart';
@@ -27,13 +26,15 @@ class _WorkdayDialogState extends State<WorkdayDialog> {
 
   late final TextEditingController _nameController;
   late final TextEditingController _dateController;
+  late DateTime _selectedDate;
 
   @override
   void initState() {
     super.initState();
     _nameController = TextEditingController(text: widget.initialWorkday.name);
+    _selectedDate = widget.initialWorkday.calendarDate;
     _dateController = TextEditingController(
-      text: formatWorkdayDate(widget.initialWorkday.calendarDate),
+      text: formatWorkdayDate(_selectedDate),
     );
   }
 
@@ -49,17 +50,37 @@ class _WorkdayDialogState extends State<WorkdayDialog> {
         ? await widget.viewModel.updateWorkday(
             workdayId: widget.initialWorkday.id,
             rawName: _nameController.text,
-            rawCalendarDate: _dateController.text,
+            rawCalendarDate: formatWorkdayDate(_selectedDate),
           )
         : await widget.viewModel.createWorkday(
             rawName: _nameController.text,
-            rawCalendarDate: _dateController.text,
+            rawCalendarDate: formatWorkdayDate(_selectedDate),
           );
     if (!mounted || savedWorkday == null) {
       return;
     }
 
     Navigator.of(context).pop(savedWorkday);
+  }
+
+  Future<void> _selectDate() async {
+    if (widget.viewModel.isSaving) {
+      return;
+    }
+    final selectedDate = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate,
+      firstDate: DateTime(1900),
+      lastDate: DateTime(2100, 12, 31),
+    );
+    if (!mounted || selectedDate == null) {
+      return;
+    }
+    setState(() {
+      _selectedDate = selectedDate;
+      _dateController.text = formatWorkdayDate(selectedDate);
+    });
+    widget.viewModel.clearFormError();
   }
 
   @override
@@ -97,10 +118,12 @@ class _WorkdayDialogState extends State<WorkdayDialog> {
                     key: const Key('workday_date_field'),
                     controller: _dateController,
                     enabled: !widget.viewModel.isSaving,
-                    inputFormatters: [
-                      FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
-                    ],
-                    onChanged: (_) => widget.viewModel.clearFormError(),
+                    readOnly: true,
+                    showCursor: false,
+                    onTap: _selectDate,
+                    decoration: const InputDecoration(
+                      suffixIcon: Icon(Icons.calendar_month),
+                    ),
                   ),
                 ),
                 if (widget.viewModel.formErrorMessage case final message?) ...[

--- a/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
@@ -910,11 +910,19 @@ Assistant _assistantFromMap(Map<String, dynamic> m) => Assistant(
     name: m['name'] as String,
     shortName: m['shortName'] as String);
 Map<String, dynamic> _workdayMap(Workday d) =>
-    {'id': d.id, 'name': d.name, 'date': d.calendarDate.toIso8601String()};
+    {'id': d.id, 'name': d.name, 'date': _formatCalendarDate(d.calendarDate)};
 Workday _workdayFromMap(Map<String, dynamic> m) => Workday(
     id: m['id'] as String,
     name: m['name'] as String,
     calendarDate: DateTime.parse(m['date'] as String));
+
+String _formatCalendarDate(DateTime value) {
+  final year = value.year.toString().padLeft(4, '0');
+  final month = value.month.toString().padLeft(2, '0');
+  final day = value.day.toString().padLeft(2, '0');
+  return '$year-$month-$day';
+}
+
 Map<String, dynamic> _kindMap(ProcedureKind k) => {
       'id': k.id,
       'patternId': k.patternId,

--- a/packages/bochki_schedule_app/pubspec.lock
+++ b/packages/bochki_schedule_app/pubspec.lock
@@ -113,6 +113,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -128,6 +133,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   json_annotation:
     dependency: transitive
     description:

--- a/packages/bochki_schedule_app/pubspec.yaml
+++ b/packages/bochki_schedule_app/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
   desktop_multi_window: ^0.3.0
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   path: ^1.9.0
   path_provider: ^2.1.5
   window_manager: ^0.4.3

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -1738,10 +1738,30 @@ void main() {
       find.byKey(const Key('workday_name_field')),
       '  День   22 ',
     );
-    await tester.enterText(
-      find.byKey(const Key('workday_date_field')),
-      '15.07.2026',
+    final dateField = find.byKey(const Key('workday_date_field'));
+    expect(tester.widget<TextField>(dateField).readOnly, isTrue);
+    await tester.tap(dateField);
+    await tester.pumpAndSettle();
+    expect(find.byType(CalendarDatePicker), findsOneWidget);
+    await tester.tap(
+      find
+          .descendant(
+            of: find.byType(DatePickerDialog),
+            matching: find.byType(TextButton),
+          )
+          .first,
     );
+    await tester.pumpAndSettle();
+    expect(
+      find.descendant(of: dateField, matching: find.text('12.07.2026')),
+      findsOneWidget,
+    );
+
+    await tester.tap(dateField);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('15').last);
+    await tester.tap(find.text('ОК'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('Создать').last);
     await tester.pumpAndSettle();
 
@@ -1755,10 +1775,11 @@ void main() {
       find.byKey(const Key('workday_name_field')),
       'День 3',
     );
-    await tester.enterText(
-      find.byKey(const Key('workday_date_field')),
-      '16.07.2026',
-    );
+    await tester.tap(find.byKey(const Key('workday_date_field')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('16').last);
+    await tester.tap(find.text('ОК'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('Сохранить'));
     await tester.pumpAndSettle();
 

--- a/packages/bochki_schedule_app/test/data/workdays/project_document_workdays_repository_test.dart
+++ b/packages/bochki_schedule_app/test/data/workdays/project_document_workdays_repository_test.dart
@@ -20,7 +20,7 @@ void main() {
           <String, Object?>{
             'id': 1,
             'name': 'День 1',
-            'calendarDate': '2026-07-11',
+            'calendarDate': '2026-07-11T14:30:00',
             'deleted': false,
           },
         ],
@@ -29,6 +29,11 @@ void main() {
       onChanged: () {
         changeNotifications += 1;
       },
+    );
+
+    expect(
+      (await repository.list()).single.calendarDate,
+      DateTime(2026, 7, 11),
     );
 
     final createdWorkday = await repository.create(


### PR DESCRIPTION
Closes #123

- replace manual date input with a Russian Material calendar picker
- persist and exchange workday dates as `YYYY-MM-DD`
- migrate legacy timestamps by retaining their calendar day
- cover legacy persistence plus create, edit, and cancel picker flows