### PR TITLE
fix: free-time reports, templates, and reassignments

### DIFF
--- a/packages/bochki_schedule_app/integration_test/app_shell_test.dart
+++ b/packages/bochki_schedule_app/integration_test/app_shell_test.dart
@@ -66,8 +66,10 @@ void main() {
           CreateProcedureKindUseCase(procedureKindsRepository),
       updateProcedureKindUseCase:
           UpdateProcedureKindUseCase(procedureKindsRepository),
-      deleteProcedureKindUseCase:
-          DeleteProcedureKindUseCase(procedureKindsRepository),
+      deleteProcedureKindUseCase: DeleteProcedureKindUseCase(
+        procedureKindsRepository,
+        procedureSessionsRepository: procedureSessionsRepository,
+      ),
       listWorkdaysUseCase: ListWorkdaysUseCase(workdaysRepository),
       createWorkdayUseCase: CreateWorkdayUseCase(workdaysRepository),
       updateWorkdayUseCase: UpdateWorkdayUseCase(workdaysRepository),

--- a/packages/bochki_schedule_app/lib/bochki_schedule_app.dart
+++ b/packages/bochki_schedule_app/lib/bochki_schedule_app.dart
@@ -17,6 +17,7 @@ export 'src/domain/procedure_kinds/create_procedure_kind_use_case.dart';
 export 'src/domain/procedure_kinds/delete_procedure_kind_use_case.dart';
 export 'src/domain/procedure_kinds/list_procedure_kinds_use_case.dart';
 export 'src/domain/procedure_kinds/procedure_kind.dart';
+export 'src/domain/procedure_kinds/procedure_kind_in_use_exception.dart';
 export 'src/domain/procedure_kinds/procedure_kind_pattern.dart';
 export 'src/domain/procedure_kinds/procedure_kinds_repository.dart';
 export 'src/domain/procedure_kinds/procedure_kinds_validation_exception.dart';

--- a/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
+++ b/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
@@ -211,6 +211,7 @@ final class AppBootstrap {
     );
     final deleteProcedureKindUseCase = DeleteProcedureKindUseCase(
       procedureKindsRepository,
+      procedureSessionsRepository: procedureSessionsRepository,
     );
     final listWorkdaysUseCase = ListWorkdaysUseCase(
       workdaysRepository,

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_kinds/delete_procedure_kind_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_kinds/delete_procedure_kind_use_case.dart
@@ -1,13 +1,41 @@
 import 'procedure_kind_validator.dart';
+import 'procedure_kind_in_use_exception.dart';
 import 'procedure_kinds_repository.dart';
+import '../procedure_sessions/procedure_session_raw.dart';
+import '../procedure_sessions/procedure_sessions_repository.dart';
 
 final class DeleteProcedureKindUseCase {
-  const DeleteProcedureKindUseCase(this._repository);
+  const DeleteProcedureKindUseCase(
+    this._repository, {
+    required ProcedureSessionsRepository procedureSessionsRepository,
+  }) : _procedureSessionsRepository = procedureSessionsRepository;
 
   final ProcedureKindsRepository _repository;
+  final ProcedureSessionsRepository _procedureSessionsRepository;
+
+  Future<int> countReferences(String procedureKindId) async {
+    ProcedureKindValidator.validateId(procedureKindId);
+    return _affectedSessions(
+      await _procedureSessionsRepository.list(),
+      procedureKindId.trim(),
+    ).length;
+  }
 
   Future<void> execute(String procedureKindId) async {
     ProcedureKindValidator.validateId(procedureKindId);
-    await _repository.delete(procedureKindId.trim());
+    final normalizedId = procedureKindId.trim();
+    final referencesCount = await countReferences(normalizedId);
+    if (referencesCount > 0) {
+      throw ProcedureKindInUseException(referencesCount);
+    }
+    await _repository.delete(normalizedId);
   }
+
+  static List<ProcedureSessionRaw> _affectedSessions(
+    List<ProcedureSessionRaw> sessions,
+    String procedureKindId,
+  ) =>
+      sessions
+          .where((session) => session.procedureKindId == procedureKindId)
+          .toList(growable: false);
 }

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_kinds/procedure_kind_in_use_exception.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_kinds/procedure_kind_in_use_exception.dart
@@ -1,0 +1,9 @@
+final class ProcedureKindInUseException implements Exception {
+  const ProcedureKindInUseException(this.referencesCount);
+
+  final int referencesCount;
+
+  @override
+  String toString() =>
+      'Невозможно удалить процедуру: $referencesCount активных назначений.';
+}

--- a/packages/bochki_schedule_app/lib/src/features/procedure_kinds/procedure_kinds_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_kinds/procedure_kinds_dialog.dart
@@ -86,6 +86,16 @@ class _ProcedureKindsDialogState extends State<ProcedureKindsDialog> {
   }
 
   Future<void> _deleteProcedureKind(ProcedureKind procedureKind) async {
+    final referencesCount =
+        await widget.viewModel.countReferences(procedureKind.id);
+    if (!mounted) {
+      return;
+    }
+    if (referencesCount > 0) {
+      await _showDeletionBlockedDialog(procedureKind, referencesCount);
+      return;
+    }
+
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) {
@@ -111,17 +121,59 @@ class _ProcedureKindsDialogState extends State<ProcedureKindsDialog> {
       return;
     }
 
-    final isSuccess =
+    final result =
         await widget.viewModel.deleteProcedureKind(procedureKind.id);
-    if (!mounted || !isSuccess) {
+    if (!mounted) {
       return;
     }
+    if (result case ProcedureKindDeletionBlocked(:final referencesCount)) {
+      await _showDeletionBlockedDialog(procedureKind, referencesCount);
+      return;
+    }
+    if (result is ProcedureKindDeletionFailed) return;
 
     setState(() {
       if (_selectedProcedureKindId == procedureKind.id) {
         _selectedProcedureKindId = null;
       }
     });
+  }
+
+  Future<void> _showDeletionBlockedDialog(
+    ProcedureKind procedureKind,
+    int referencesCount,
+  ) {
+    return showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Невозможно удалить процедуру'),
+        content: Text(
+          'Найдено: $referencesCount '
+          '${ProcedureKindsDialog.assignedProcedureWord(referencesCount)} '
+          'для процедуры '
+          '"${procedureKind.name}". '
+          'Сначала удалите эти назначенные процедуры.',
+        ),
+        actions: [
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Понятно'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String assignedProcedureWord(int count) {
+    final remainder100 = count % 100;
+    if (remainder100 >= 11 && remainder100 <= 14) {
+      return 'назначенных процедур';
+    }
+    return switch (count % 10) {
+      1 => 'назначенная процедура',
+      2 || 3 || 4 => 'назначенные процедуры',
+      _ => 'назначенных процедур',
+    };
   }
 
   @override

--- a/packages/bochki_schedule_app/lib/src/features/procedure_kinds/procedure_kinds_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_kinds/procedure_kinds_dialog.dart
@@ -121,8 +121,7 @@ class _ProcedureKindsDialogState extends State<ProcedureKindsDialog> {
       return;
     }
 
-    final result =
-        await widget.viewModel.deleteProcedureKind(procedureKind.id);
+    final result = await widget.viewModel.deleteProcedureKind(procedureKind.id);
     if (!mounted) {
       return;
     }

--- a/packages/bochki_schedule_app/lib/src/features/procedure_kinds/procedure_kinds_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_kinds/procedure_kinds_dialog.dart
@@ -14,6 +14,18 @@ class ProcedureKindsDialog extends StatefulWidget {
 
   final ProcedureKindsViewModel viewModel;
 
+  static String assignedProcedureWord(int count) {
+    final remainder100 = count % 100;
+    if (remainder100 >= 11 && remainder100 <= 14) {
+      return 'назначенных процедур';
+    }
+    return switch (count % 10) {
+      1 => 'назначенная процедура',
+      2 || 3 || 4 => 'назначенные процедуры',
+      _ => 'назначенных процедур',
+    };
+  }
+
   @override
   State<ProcedureKindsDialog> createState() => _ProcedureKindsDialogState();
 }
@@ -161,18 +173,6 @@ class _ProcedureKindsDialogState extends State<ProcedureKindsDialog> {
         ],
       ),
     );
-  }
-
-  static String assignedProcedureWord(int count) {
-    final remainder100 = count % 100;
-    if (remainder100 >= 11 && remainder100 <= 14) {
-      return 'назначенных процедур';
-    }
-    return switch (count % 10) {
-      1 => 'назначенная процедура',
-      2 || 3 || 4 => 'назначенные процедуры',
-      _ => 'назначенных процедур',
-    };
   }
 
   @override

--- a/packages/bochki_schedule_app/lib/src/features/procedure_kinds/procedure_kinds_view_model.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_kinds/procedure_kinds_view_model.dart
@@ -4,6 +4,7 @@ import '../../domain/procedure_kinds/create_procedure_kind_use_case.dart';
 import '../../domain/procedure_kinds/delete_procedure_kind_use_case.dart';
 import '../../domain/procedure_kinds/list_procedure_kinds_use_case.dart';
 import '../../domain/procedure_kinds/procedure_kind.dart';
+import '../../domain/procedure_kinds/procedure_kind_in_use_exception.dart';
 import '../../domain/procedure_kinds/procedure_kinds_validation_exception.dart';
 import '../../domain/procedure_kinds/update_procedure_kind_use_case.dart';
 
@@ -130,7 +131,12 @@ final class ProcedureKindsViewModel extends ChangeNotifier {
     });
   }
 
-  Future<bool> deleteProcedureKind(String procedureKindId) async {
+  Future<int> countReferences(String procedureKindId) {
+    return _deleteProcedureKindUseCase.countReferences(procedureKindId);
+  }
+
+  Future<ProcedureKindDeleteResult> deleteProcedureKind(
+      String procedureKindId) async {
     _actionErrorMessage = null;
     _isSaving = true;
     notifyListeners();
@@ -140,13 +146,15 @@ final class ProcedureKindsViewModel extends ChangeNotifier {
       _procedureKinds = _procedureKinds
           .where((procedureKind) => procedureKind.id != procedureKindId)
           .toList(growable: false);
-      return true;
+      return const ProcedureKindDeleted();
+    } on ProcedureKindInUseException catch (error) {
+      return ProcedureKindDeletionBlocked(error.referencesCount);
     } on ProcedureKindsValidationException catch (error) {
       _actionErrorMessage = error.message;
-      return false;
+      return const ProcedureKindDeletionFailed();
     } catch (_) {
       _actionErrorMessage = 'Не удалось удалить процедуру.';
-      return false;
+      return const ProcedureKindDeletionFailed();
     } finally {
       _isSaving = false;
       notifyListeners();
@@ -234,4 +242,22 @@ final class ProcedureKindsViewModel extends ChangeNotifier {
     );
     return List<ProcedureKind>.unmodifiable(sortedProcedureKinds);
   }
+}
+
+sealed class ProcedureKindDeleteResult {
+  const ProcedureKindDeleteResult();
+}
+
+final class ProcedureKindDeleted extends ProcedureKindDeleteResult {
+  const ProcedureKindDeleted();
+}
+
+final class ProcedureKindDeletionBlocked extends ProcedureKindDeleteResult {
+  const ProcedureKindDeletionBlocked(this.referencesCount);
+
+  final int referencesCount;
+}
+
+final class ProcedureKindDeletionFailed extends ProcedureKindDeleteResult {
+  const ProcedureKindDeletionFailed();
 }

--- a/packages/bochki_schedule_app/lib/src/features/quick_reassignments/quick_reassignments_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/quick_reassignments/quick_reassignments_dialog.dart
@@ -107,11 +107,11 @@ class QuickReassignmentsDialog extends StatelessWidget {
       Row(children: [
         Expanded(
             child: _personDropdown(
-              value,
-              candidates,
-              change,
-              assistant: assistant,
-            )),
+          value,
+          candidates,
+          change,
+          assistant: assistant,
+        )),
         Tooltip(message: label, child: const Icon(Icons.info_outline, size: 18))
       ]);
 
@@ -123,9 +123,8 @@ class QuickReassignmentsDialog extends StatelessWidget {
   }) {
     final candidatesById = <String, dynamic>{};
     for (final candidate in candidates) {
-      final id = assistant
-          ? candidate.human.id as String
-          : candidate.id as String;
+      final id =
+          assistant ? candidate.human.id as String : candidate.id as String;
       candidatesById.putIfAbsent(id, () => candidate);
     }
     return DropdownButton<String>(

--- a/packages/bochki_schedule_app/lib/src/features/quick_reassignments/quick_reassignments_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/quick_reassignments/quick_reassignments_dialog.dart
@@ -79,7 +79,9 @@ class QuickReassignmentsDialog extends StatelessWidget {
                                   (id) => viewModel.changeParticipant(s, id))),
                               DataCell(_person(
                                   s.assistantId,
-                                  s.assistant?.name ?? 'Ассистент не назначен',
+                                  s.assistantId == null
+                                      ? 'Ассистент не назначен'
+                                      : s.assistant?.name ?? 'Не найден',
                                   viewModel.assistantCandidates(s),
                                   (id) => viewModel.chooseAssistant(s, id),
                                   assistant: true)),
@@ -104,31 +106,56 @@ class QuickReassignmentsDialog extends StatelessWidget {
           {bool assistant = false}) =>
       Row(children: [
         Expanded(
-            child: DropdownButton<String>(
-                isExpanded: true,
-                value: value,
-                items: [
-                  for (final h in candidates)
-                    DropdownMenuItem(
-                        value:
-                            assistant ? h.human.id as String : h.id as String,
-                        child: Text(assistant
-                            ? (h.human.id == value
-                                ? h.human.name as String
-                                : h.isSwap
-                                    ? '${h.human.name} (${h.swapSession.participant?.name ?? 'Не найден'})'
-                                    : '${h.human.name} (Свободен)')
-                            : (h.id == value
-                                ? h.name as String
-                                : '${h.name} (свободен)')))
-                ],
-                onChanged: (id) {
-                  if (id != null) {
-                    final item = candidates.firstWhere(
-                        (h) => assistant ? h.human.id == id : h.id == id);
-                    change(assistant ? item : id);
-                  }
-                })),
+            child: _personDropdown(
+              value,
+              candidates,
+              change,
+              assistant: assistant,
+            )),
         Tooltip(message: label, child: const Icon(Icons.info_outline, size: 18))
       ]);
+
+  Widget _personDropdown(
+    String? value,
+    List<dynamic> candidates,
+    Future<void> Function(dynamic) change, {
+    required bool assistant,
+  }) {
+    final candidatesById = <String, dynamic>{};
+    for (final candidate in candidates) {
+      final id = assistant
+          ? candidate.human.id as String
+          : candidate.id as String;
+      candidatesById.putIfAbsent(id, () => candidate);
+    }
+    return DropdownButton<String>(
+      isExpanded: true,
+      value: value,
+      items: [
+        if (value != null && !candidatesById.containsKey(value))
+          DropdownMenuItem(value: value, child: const Text('Не найден')),
+        for (final entry in candidatesById.entries)
+          DropdownMenuItem(
+            value: entry.key,
+            child: Text(_candidateLabel(entry.value, value, assistant)),
+          ),
+      ],
+      onChanged: (id) {
+        if (id == null) return;
+        final candidate = candidatesById[id];
+        if (candidate != null) change(assistant ? candidate : id);
+      },
+    );
+  }
+
+  String _candidateLabel(dynamic candidate, String? value, bool assistant) =>
+      assistant
+          ? candidate.human.id == value
+              ? candidate.human.name as String
+              : candidate.isSwap
+                  ? '${candidate.human.name} (${candidate.swapSession.participant?.name ?? 'Не найден'})'
+                  : '${candidate.human.name} (Свободен)'
+          : candidate.id == value
+              ? candidate.name as String
+              : '${candidate.name} (свободен)';
 }

--- a/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
@@ -377,14 +377,14 @@ Future<void> configureChildWindow(DesktopWindowKind kind) async {
   final options = WindowOptions(
     title: title,
     size: isStatistics || isFreeTime
-        ? const Size(1065, 514)
+        ? const Size(1080, 514)
         : isDirectory
             ? const Size(920, 640)
             : isEditor
                 ? const Size(650, 500)
                 : const Size(900, 680),
-    minimumSize: isStatistics
-        ? const Size(820, 420)
+    minimumSize: isStatistics || isFreeTime
+        ? const Size(1080, 420)
         : isEditor
             ? const Size(600, 420)
             : const Size(700, 500),
@@ -760,40 +760,85 @@ class _FreeTimeWindowState extends State<FreeTimeWindow> {
                 : _gaps.isEmpty
                     ? const Center(
                         child: Text('Нет данных по выбранным фильтрам'))
-                    : SingleChildScrollView(
-                        scrollDirection: Axis.horizontal,
-                        child: DataTable(
-                            columns: const [
-                              DataColumn(label: Text('День')),
-                              DataColumn(label: Text('Человек')),
-                              DataColumn(label: Text('Начало')),
-                              DataColumn(label: Text('Конец')),
-                              DataColumn(label: Text('Длительность')),
-                              DataColumn(label: Text('')),
-                            ],
-                            rows: _gaps.map((g) {
-                              final day = _workdayFromMap(
-                                  Map<String, dynamic>.from(g['day'] as Map));
-                              final human = _humanFromMap(
-                                  Map<String, dynamic>.from(g['human'] as Map));
-                              return DataRow(cells: [
-                                DataCell(Text(day.name)),
-                                DataCell(Text(human.name)),
-                                DataCell(Text(g['start'] as String)),
-                                DataCell(Text(g['end'] as String)),
-                                DataCell(Text(g['duration'] as String)),
-                                DataCell(FilledButton.tonal(
-                                    onPressed: () => _mainChannel
-                                            .invokeMethod<void>(
-                                                'openProcedureSession', {
-                                          'dayId': day.id,
-                                          'participantId': human.id,
-                                          'startTime': g['start'] as String
-                                        }),
-                                    child: const Text('Занять участника'))),
-                              ]);
-                            }).toList()))),
+                    : FreeTimeResultsTable(
+                        gaps: _gaps,
+                        onOccupy: (gap) {
+                          final day = _workdayFromMap(
+                              Map<String, dynamic>.from(gap['day'] as Map));
+                          final human = _humanFromMap(
+                              Map<String, dynamic>.from(gap['human'] as Map));
+                          return _mainChannel.invokeMethod<void>(
+                              'openProcedureSession', {
+                            'dayId': day.id,
+                            'participantId': human.id,
+                            'startTime': gap['start'] as String,
+                          });
+                        },
+                      ),
       ])));
+}
+
+class FreeTimeResultsTable extends StatefulWidget {
+  const FreeTimeResultsTable({
+    required this.gaps,
+    required this.onOccupy,
+    super.key,
+  });
+
+  final List<Map<String, dynamic>> gaps;
+  final Future<void> Function(Map<String, dynamic> gap) onOccupy;
+
+  @override
+  State<FreeTimeResultsTable> createState() => _FreeTimeResultsTableState();
+}
+
+class _FreeTimeResultsTableState extends State<FreeTimeResultsTable> {
+  final _verticalScrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _verticalScrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Scrollbar(
+        controller: _verticalScrollController,
+        thumbVisibility: true,
+        child: SingleChildScrollView(
+          controller: _verticalScrollController,
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: DataTable(
+              columns: const [
+                DataColumn(label: Text('День')),
+                DataColumn(label: Text('Человек')),
+                DataColumn(label: Text('Начало')),
+                DataColumn(label: Text('Конец')),
+                DataColumn(label: Text('Длительность')),
+                DataColumn(label: Text('')),
+              ],
+              rows: widget.gaps.map((gap) {
+                final day = _workdayFromMap(
+                    Map<String, dynamic>.from(gap['day'] as Map));
+                final human = _humanFromMap(
+                    Map<String, dynamic>.from(gap['human'] as Map));
+                return DataRow(cells: [
+                  DataCell(Text(day.name)),
+                  DataCell(Text(human.name)),
+                  DataCell(Text(gap['start'] as String)),
+                  DataCell(Text(gap['end'] as String)),
+                  DataCell(Text(gap['duration'] as String)),
+                  DataCell(FilledButton.tonal(
+                    onPressed: () => widget.onOccupy(gap),
+                    child: const Text('Занять участника'),
+                  )),
+                ]);
+              }).toList(),
+            ),
+          ),
+        ),
+      );
 }
 
 class ProcedureSessionWindow extends StatefulWidget {

--- a/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
@@ -767,14 +767,14 @@ class _FreeTimeWindowState extends State<FreeTimeWindow> {
                               Map<String, dynamic>.from(gap['day'] as Map));
                           final human = _humanFromMap(
                               Map<String, dynamic>.from(gap['human'] as Map));
-                          return _mainChannel.invokeMethod<void>(
-                              'openProcedureSession', {
+                          return _mainChannel
+                              .invokeMethod<void>('openProcedureSession', {
                             'dayId': day.id,
                             'participantId': human.id,
                             'startTime': gap['start'] as String,
                           });
                         },
-                      ),
+                      )),
       ])));
 }
 

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -703,10 +703,9 @@ class _BochkiShellState extends State<BochkiShell> {
               style: isDelete
                   ? FilledButton.styleFrom(backgroundColor: Colors.red)
                   : null,
-              onPressed:
-                  selected == null
-                      ? null
-                      : () => Navigator.pop(dialogContext, selected),
+              onPressed: selected == null
+                  ? null
+                  : () => Navigator.pop(dialogContext, selected),
               child: Text(isDelete ? 'Удалить' : 'Загрузить'),
             ),
           ],

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -669,7 +669,7 @@ class _BochkiShellState extends State<BochkiShell> {
     final templates = await templateService.list();
     if (!mounted) return;
     TemplateFile? selected;
-    await showDialog<void>(
+    final template = await showDialog<TemplateFile>(
       context: context,
       barrierDismissible: false,
       builder: (dialogContext) => StatefulBuilder(
@@ -704,14 +704,15 @@ class _BochkiShellState extends State<BochkiShell> {
                   ? FilledButton.styleFrom(backgroundColor: Colors.red)
                   : null,
               onPressed:
-                  selected == null ? null : () => Navigator.pop(dialogContext),
+                  selected == null
+                      ? null
+                      : () => Navigator.pop(dialogContext, selected),
               child: Text(isDelete ? 'Удалить' : 'Загрузить'),
             ),
           ],
         ),
       ),
     );
-    final template = selected;
     if (template == null || !mounted) return;
     if (isDelete) {
       if (!await _confirm('Удалить шаблон?',

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -1618,6 +1618,49 @@ void main() {
     expect(context.procedureKindsRepository.procedureKinds, isEmpty);
   });
 
+  testWidgets('procedure kind deletion is blocked by assigned procedures', (
+    tester,
+  ) async {
+    final context = _buildTestContext(
+      procedureKinds: [
+        ProcedureKind(
+          id: '1',
+          patternId: ProcedureKindPatterns.single.patternId,
+          name: 'Бег',
+          capacity: 1,
+          participantBusyTime: 20,
+        ),
+      ],
+      procedureSessions: [
+        ProcedureSessionRaw(
+          id: '2',
+          dayId: '1',
+          startTime: '10:00',
+          procedureKindId: '1',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await _openProcedureKindsDialog(tester);
+
+    await tester.tap(find.byKey(const Key('procedure_kind_delete_1')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Невозможно удалить процедуру'), findsOneWidget);
+    expect(find.textContaining('1 назначенная процедура'), findsOneWidget);
+    expect(find.text('Понятно'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(AlertDialog).last,
+        matching: find.text('Удалить'),
+      ),
+      findsNothing,
+    );
+    expect(context.procedureKindsRepository.procedureKinds, hasLength(1));
+  });
+
   testWidgets('procedure kind form uses compact two-column layout', (
     tester,
   ) async {
@@ -2345,8 +2388,10 @@ _TestContext _buildTestContext({
           CreateProcedureKindUseCase(procedureKindsRepository),
       updateProcedureKindUseCase:
           UpdateProcedureKindUseCase(procedureKindsRepository),
-      deleteProcedureKindUseCase:
-          DeleteProcedureKindUseCase(procedureKindsRepository),
+      deleteProcedureKindUseCase: DeleteProcedureKindUseCase(
+        procedureKindsRepository,
+        procedureSessionsRepository: procedureSessionsRepository,
+      ),
       listWorkdaysUseCase: ListWorkdaysUseCase(workdaysRepository),
       createWorkdayUseCase: CreateWorkdayUseCase(workdaysRepository),
       updateWorkdayUseCase: UpdateWorkdayUseCase(workdaysRepository),

--- a/packages/bochki_schedule_app/test/domain/procedure_kinds/procedure_kinds_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/procedure_kinds/procedure_kinds_use_cases_test.dart
@@ -182,8 +182,7 @@ void main() {
       expect(await repository.list(), isEmpty);
     });
 
-    test('delete is blocked and returns the active assignment count',
-        () async {
+    test('delete is blocked and returns the active assignment count', () async {
       final repository = _InMemoryProcedureKindsRepository(
         procedureKinds: [_procedureKind('1')],
       );

--- a/packages/bochki_schedule_app/test/domain/procedure_kinds/procedure_kinds_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/procedure_kinds/procedure_kinds_use_cases_test.dart
@@ -166,7 +166,143 @@ void main() {
         ),
       );
     });
+
+    test('delete removes a procedure kind without active assignments',
+        () async {
+      final repository = _InMemoryProcedureKindsRepository(
+        procedureKinds: [_procedureKind('1')],
+      );
+      final useCase = DeleteProcedureKindUseCase(
+        repository,
+        procedureSessionsRepository: _InMemoryProcedureSessionsRepository(),
+      );
+
+      await useCase.execute('1');
+
+      expect(await repository.list(), isEmpty);
+    });
+
+    test('delete is blocked and returns the active assignment count',
+        () async {
+      final repository = _InMemoryProcedureKindsRepository(
+        procedureKinds: [_procedureKind('1')],
+      );
+      final sessionsRepository = _InMemoryProcedureSessionsRepository(
+        entries: [_StoredSession(_session('1', procedureKindId: '1'), false)],
+      );
+      final useCase = DeleteProcedureKindUseCase(
+        repository,
+        procedureSessionsRepository: sessionsRepository,
+      );
+
+      expect(await useCase.countReferences('1'), 1);
+      await expectLater(
+        () => useCase.execute('1'),
+        throwsA(
+          isA<ProcedureKindInUseException>().having(
+            (error) => error.referencesCount,
+            'referencesCount',
+            1,
+          ),
+        ),
+      );
+      expect((await repository.list()).single.id, '1');
+    });
+
+    test('delete ignores logically deleted assignments', () async {
+      final repository = _InMemoryProcedureKindsRepository(
+        procedureKinds: [_procedureKind('1')],
+      );
+      final sessionsRepository = _InMemoryProcedureSessionsRepository(
+        entries: [_StoredSession(_session('1', procedureKindId: '1'), true)],
+      );
+      final useCase = DeleteProcedureKindUseCase(
+        repository,
+        procedureSessionsRepository: sessionsRepository,
+      );
+
+      expect(await useCase.countReferences('1'), 0);
+      await useCase.execute('1');
+
+      expect(await repository.list(), isEmpty);
+    });
+
+    test('delete validates the procedure kind id before counting references',
+        () async {
+      final useCase = DeleteProcedureKindUseCase(
+        _InMemoryProcedureKindsRepository(),
+        procedureSessionsRepository: _InMemoryProcedureSessionsRepository(),
+      );
+
+      await expectLater(
+        () => useCase.execute('  '),
+        throwsA(isA<ProcedureKindsValidationException>()),
+      );
+    });
   });
+}
+
+ProcedureKind _procedureKind(String id) => ProcedureKind(
+      id: id,
+      patternId: ProcedureKindPatterns.single.patternId,
+      name: 'Процедура $id',
+      capacity: 1,
+      participantBusyTime: 20,
+    );
+
+ProcedureSessionRaw _session(
+  String id, {
+  required String procedureKindId,
+}) =>
+    ProcedureSessionRaw(
+      id: id,
+      dayId: '1',
+      startTime: '10:00',
+      procedureKindId: procedureKindId,
+    );
+
+final class _InMemoryProcedureSessionsRepository
+    implements ProcedureSessionsRepository {
+  _InMemoryProcedureSessionsRepository({List<_StoredSession>? entries})
+      : _sessions = [...?entries];
+
+  final List<_StoredSession> _sessions;
+
+  @override
+  Future<ProcedureSessionRaw> create(ProcedureSessionRaw procedureSession) {
+    _sessions.add(_StoredSession(procedureSession, false));
+    return Future.value(procedureSession);
+  }
+
+  @override
+  Future<void> delete(String procedureSessionId) async {
+    final index = _sessions.indexWhere(
+      (entry) => entry.session.id == procedureSessionId,
+    );
+    if (index != -1) {
+      _sessions[index] = _sessions[index].copyWith(deleted: true);
+    }
+  }
+
+  @override
+  Future<List<ProcedureSessionRaw>> list() async => _sessions
+      .where((entry) => !entry.deleted)
+      .map((entry) => entry.session)
+      .toList(growable: false);
+
+  @override
+  Future<ProcedureSessionRaw> update(ProcedureSessionRaw procedureSession) =>
+      Future.value(procedureSession);
+}
+
+final class _StoredSession {
+  const _StoredSession(this.session, this.deleted);
+
+  final ProcedureSessionRaw session;
+  final bool deleted;
+
+  _StoredSession copyWith({bool? deleted}) =>
+      _StoredSession(session, deleted ?? this.deleted);
 }
 
 final class _InMemoryProcedureKindsRepository

--- a/packages/bochki_schedule_app/test/domain/procedure_kinds/procedure_kinds_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/procedure_kinds/procedure_kinds_use_cases_test.dart
@@ -284,6 +284,15 @@ final class _InMemoryProcedureSessionsRepository
   }
 
   @override
+  Future<int> clearAll() async {
+    final count = (await list()).length;
+    for (final session in await list()) {
+      await delete(session.id);
+    }
+    return count;
+  }
+
+  @override
   Future<List<ProcedureSessionRaw>> list() async => _sessions
       .where((entry) => !entry.deleted)
       .map((entry) => entry.session)
@@ -292,6 +301,13 @@ final class _InMemoryProcedureSessionsRepository
   @override
   Future<ProcedureSessionRaw> update(ProcedureSessionRaw procedureSession) =>
       Future.value(procedureSession);
+
+  @override
+  Future<void> updateMany(List<ProcedureSessionRaw> procedureSessions) async {
+    for (final procedureSession in procedureSessions) {
+      await update(procedureSession);
+    }
+  }
 }
 
 final class _StoredSession {

--- a/packages/bochki_schedule_app/test/features/procedure_kinds/procedure_kinds_dialog_test.dart
+++ b/packages/bochki_schedule_app/test/features/procedure_kinds/procedure_kinds_dialog_test.dart
@@ -3,14 +3,14 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('formats assigned procedure count with Russian declension', () {
-    expect(ProcedureKindsDialog.assignedProcedureWord(1),
-        'назначенная процедура');
-    expect(ProcedureKindsDialog.assignedProcedureWord(2),
-        'назначенные процедуры');
-    expect(ProcedureKindsDialog.assignedProcedureWord(5),
-        'назначенных процедур');
-    expect(ProcedureKindsDialog.assignedProcedureWord(11),
-        'назначенных процедур');
+    expect(
+        ProcedureKindsDialog.assignedProcedureWord(1), 'назначенная процедура');
+    expect(
+        ProcedureKindsDialog.assignedProcedureWord(2), 'назначенные процедуры');
+    expect(
+        ProcedureKindsDialog.assignedProcedureWord(5), 'назначенных процедур');
+    expect(
+        ProcedureKindsDialog.assignedProcedureWord(11), 'назначенных процедур');
     expect(ProcedureKindsDialog.assignedProcedureWord(21),
         'назначенная процедура');
   });

--- a/packages/bochki_schedule_app/test/features/procedure_kinds/procedure_kinds_dialog_test.dart
+++ b/packages/bochki_schedule_app/test/features/procedure_kinds/procedure_kinds_dialog_test.dart
@@ -1,0 +1,17 @@
+import 'package:bochki_schedule_app/bochki_schedule_app.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('formats assigned procedure count with Russian declension', () {
+    expect(ProcedureKindsDialog.assignedProcedureWord(1),
+        'назначенная процедура');
+    expect(ProcedureKindsDialog.assignedProcedureWord(2),
+        'назначенные процедуры');
+    expect(ProcedureKindsDialog.assignedProcedureWord(5),
+        'назначенных процедур');
+    expect(ProcedureKindsDialog.assignedProcedureWord(11),
+        'назначенных процедур');
+    expect(ProcedureKindsDialog.assignedProcedureWord(21),
+        'назначенная процедура');
+  });
+}

--- a/packages/bochki_schedule_app/test/features/procedure_kinds/procedure_kinds_view_model_test.dart
+++ b/packages/bochki_schedule_app/test/features/procedure_kinds/procedure_kinds_view_model_test.dart
@@ -152,11 +152,25 @@ final class _InMemoryProcedureSessionsRepository
   }
 
   @override
+  Future<int> clearAll() async {
+    final count = sessions.length;
+    sessions.clear();
+    return count;
+  }
+
+  @override
   Future<List<ProcedureSessionRaw>> list() async => [...sessions];
 
   @override
   Future<ProcedureSessionRaw> update(ProcedureSessionRaw procedureSession) =>
       Future.value(procedureSession);
+
+  @override
+  Future<void> updateMany(List<ProcedureSessionRaw> procedureSessions) async {
+    for (final procedureSession in procedureSessions) {
+      await update(procedureSession);
+    }
+  }
 }
 
 final class _InMemoryProcedureKindsRepository

--- a/packages/bochki_schedule_app/test/features/procedure_kinds/procedure_kinds_view_model_test.dart
+++ b/packages/bochki_schedule_app/test/features/procedure_kinds/procedure_kinds_view_model_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('ProcedureKindsViewModel', () {
     late _InMemoryProcedureKindsRepository repository;
+    late _InMemoryProcedureSessionsRepository sessionsRepository;
     late ProcedureKindsViewModel viewModel;
 
     setUp(() {
@@ -26,11 +27,15 @@ void main() {
           ),
         ],
       );
+      sessionsRepository = _InMemoryProcedureSessionsRepository();
       viewModel = ProcedureKindsViewModel(
         listProcedureKindsUseCase: ListProcedureKindsUseCase(repository),
         createProcedureKindUseCase: CreateProcedureKindUseCase(repository),
         updateProcedureKindUseCase: UpdateProcedureKindUseCase(repository),
-        deleteProcedureKindUseCase: DeleteProcedureKindUseCase(repository),
+        deleteProcedureKindUseCase: DeleteProcedureKindUseCase(
+          repository,
+          procedureSessionsRepository: sessionsRepository,
+        ),
       );
     });
 
@@ -106,7 +111,52 @@ void main() {
 
       expect(createdProcedureKind!.shortName, 'Бег');
     });
+
+    test('keeps the procedure kind when deletion is blocked by assignments',
+        () async {
+      sessionsRepository.sessions.add(
+        ProcedureSessionRaw(
+          id: '1',
+          dayId: '1',
+          startTime: '10:00',
+          procedureKindId: '1',
+        ),
+      );
+      await viewModel.loadProcedureKinds();
+
+      final result = await viewModel.deleteProcedureKind('1');
+
+      expect(result, isA<ProcedureKindDeletionBlocked>());
+      expect(
+        (result as ProcedureKindDeletionBlocked).referencesCount,
+        1,
+      );
+      expect(viewModel.procedureKinds.map((entry) => entry.id), contains('1'));
+    });
   });
+}
+
+final class _InMemoryProcedureSessionsRepository
+    implements ProcedureSessionsRepository {
+  final List<ProcedureSessionRaw> sessions = [];
+
+  @override
+  Future<ProcedureSessionRaw> create(ProcedureSessionRaw procedureSession) {
+    sessions.add(procedureSession);
+    return Future.value(procedureSession);
+  }
+
+  @override
+  Future<void> delete(String procedureSessionId) async {
+    sessions.removeWhere((session) => session.id == procedureSessionId);
+  }
+
+  @override
+  Future<List<ProcedureSessionRaw>> list() async => [...sessions];
+
+  @override
+  Future<ProcedureSessionRaw> update(ProcedureSessionRaw procedureSession) =>
+      Future.value(procedureSession);
 }
 
 final class _InMemoryProcedureKindsRepository

--- a/packages/bochki_schedule_app/test/presentation/desktop_windows_test.dart
+++ b/packages/bochki_schedule_app/test/presentation/desktop_windows_test.dart
@@ -1,4 +1,5 @@
 import 'package:bochki_schedule_app/src/presentation/desktop_windows.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -24,5 +25,53 @@ void main() {
     test('treats invalid arguments as the main window', () {
       expect(windowKindFromArguments('invalid'), DesktopWindowKind.main);
     });
+  });
+
+  testWidgets('free-time results scroll vertically while keeping a scrollbar',
+      (tester) async {
+    final gaps = List<Map<String, dynamic>>.generate(
+      20,
+      (index) => {
+        'day': {'id': 'day', 'name': 'День', 'date': '2026-08-25'},
+        'human': {
+          'id': 'human-$index',
+          'name': 'Человек $index',
+          'shortName': 'Ч.$index',
+          'isParticipant': true,
+          'isAssistant': false,
+        },
+        'start': '08:00',
+        'end': '09:00',
+        'duration': '1 ч',
+      },
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          height: 120,
+          child: FreeTimeResultsTable(
+            gaps: gaps,
+            onOccupy: (_) async {},
+          ),
+        ),
+      ),
+    ));
+
+    final scrollbar = tester.widget<Scrollbar>(find.byType(Scrollbar));
+    final verticalScrollView = tester
+        .widgetList<SingleChildScrollView>(find.byType(SingleChildScrollView))
+        .firstWhere((view) => view.scrollDirection == Axis.vertical);
+
+    expect(scrollbar.thumbVisibility, isTrue);
+    expect(
+      verticalScrollView.controller!.position.maxScrollExtent,
+      greaterThan(0),
+    );
+
+    verticalScrollView.controller!.jumpTo(50);
+    await tester.pump();
+
+    expect(verticalScrollView.controller!.offset, 50);
   });
 }


### PR DESCRIPTION
## Summary

- fix the free-time filter overflow and make results vertically scrollable
- prevent cancelled template selections from showing a replacement confirmation
- handle stale quick-reassignment values without a dropdown assertion
- prevent deletion of procedure kinds that are still assigned

Fixes #126
Fixes #128
Fixes #129
Fixes #132
Fixes #133