### PR TITLE
feat(print): match legacy DOCX layout

### DIFF
--- a/packages/bochki_schedule_app/lib/src/data/print_schedule/docx_print_schedule_exporter.dart
+++ b/packages/bochki_schedule_app/lib/src/data/print_schedule/docx_print_schedule_exporter.dart
@@ -135,7 +135,8 @@ final class DocxPrintScheduleExporter implements PrintScheduleExporter {
     final paragraphProperties = properties.isEmpty
         ? ''
         : '<w:pPr>${properties.join()}</w:pPr>';
-    return '<w:p>$paragraphProperties${_runXml(text, fontSize: fontSize)}</w:p>';
+    return '<w:p>'
+        '$paragraphProperties${_runXml(text, fontSize: fontSize)}</w:p>';
   }
 
   String _runXml(String text, {required int fontSize}) {

--- a/packages/bochki_schedule_app/lib/src/data/print_schedule/docx_print_schedule_exporter.dart
+++ b/packages/bochki_schedule_app/lib/src/data/print_schedule/docx_print_schedule_exporter.dart
@@ -132,9 +132,8 @@ final class DocxPrintScheduleExporter implements PrintScheduleExporter {
       final after = spacingAfter == null ? '' : ' w:after="$spacingAfter"';
       properties.add('<w:spacing$before$after/>');
     }
-    final paragraphProperties = properties.isEmpty
-        ? ''
-        : '<w:pPr>${properties.join()}</w:pPr>';
+    final paragraphProperties =
+        properties.isEmpty ? '' : '<w:pPr>${properties.join()}</w:pPr>';
     return '<w:p>'
         '$paragraphProperties${_runXml(text, fontSize: fontSize)}</w:p>';
   }

--- a/packages/bochki_schedule_app/lib/src/data/print_schedule/docx_print_schedule_exporter.dart
+++ b/packages/bochki_schedule_app/lib/src/data/print_schedule/docx_print_schedule_exporter.dart
@@ -60,15 +60,15 @@ final class DocxPrintScheduleExporter implements PrintScheduleExporter {
 
   String _buildDocumentXml(PrintScheduleDocument document) {
     final sections = <String>[
-      _paragraphXml(document.title, bold: true),
+      _paragraphXml(
+        document.title,
+        fontSize: 36,
+        alignment: 'center',
+      ),
     ];
-    if (document.textBefore.trim().isNotEmpty) {
-      sections.add(_paragraphXml(document.textBefore));
-    }
+    sections.addAll(_textBeforeParagraphsXml(document.textBefore));
     sections.add(_tableXml(document));
-    if (document.textAfter.trim().isNotEmpty) {
-      sections.add(_paragraphXml(document.textAfter));
-    }
+    sections.addAll(_textAfterParagraphsXml(document.textAfter));
     sections.add(_sectionPropertiesXml);
 
     return '''
@@ -96,12 +96,59 @@ final class DocxPrintScheduleExporter implements PrintScheduleExporter {
 ''';
   }
 
-  String _paragraphXml(String text, {bool bold = false}) {
-    final runs = [
+  List<String> _textBeforeParagraphsXml(String text) {
+    if (text.trim().isEmpty) {
+      return const [];
+    }
+    return [
       for (final line in text.split('\n'))
-        '<w:r>${bold ? '<w:rPr><w:b/></w:rPr>' : ''}<w:t xml:space="preserve">${_escapeXml(line)}</w:t></w:r>',
+        _paragraphXml(line, fontSize: 34, spacingAfter: 360),
     ];
-    return '<w:p>${runs.join('<w:r><w:br/></w:r>')}</w:p>';
+  }
+
+  List<String> _textAfterParagraphsXml(String text) {
+    if (text.trim().isEmpty) {
+      return const [];
+    }
+    return [
+      for (final line in text.split('\n'))
+        _paragraphXml(line, fontSize: 34, spacingBefore: 360),
+    ];
+  }
+
+  String _paragraphXml(
+    String text, {
+    required int fontSize,
+    String? alignment,
+    int? spacingBefore,
+    int? spacingAfter,
+  }) {
+    final properties = <String>[];
+    if (alignment != null) {
+      properties.add('<w:jc w:val="$alignment"/>');
+    }
+    if (spacingBefore != null || spacingAfter != null) {
+      final before = spacingBefore == null ? '' : ' w:before="$spacingBefore"';
+      final after = spacingAfter == null ? '' : ' w:after="$spacingAfter"';
+      properties.add('<w:spacing$before$after/>');
+    }
+    final paragraphProperties = properties.isEmpty
+        ? ''
+        : '<w:pPr>${properties.join()}</w:pPr>';
+    return '<w:p>$paragraphProperties${_runXml(text, fontSize: fontSize)}</w:p>';
+  }
+
+  String _runXml(String text, {required int fontSize}) {
+    return '''
+<w:r>
+  <w:rPr>
+    <w:rFonts w:ascii="Calibri" w:hAnsi="Calibri" w:cs="Calibri"/>
+    <w:b/>
+    <w:sz w:val="$fontSize"/>
+    <w:szCs w:val="$fontSize"/>
+  </w:rPr>
+  <w:t xml:space="preserve">${_escapeXml(text)}</w:t>
+</w:r>''';
   }
 
   String _tableXml(PrintScheduleDocument document) {
@@ -113,7 +160,7 @@ final class DocxPrintScheduleExporter implements PrintScheduleExporter {
       for (final row in document.rows)
         _tableRowXml([
           row.participantName,
-          row.startTime,
+          _formatTimeRange(row.startTime, row.finishTime),
           row.procedureName,
           row.assistantName,
         ]),
@@ -121,21 +168,20 @@ final class DocxPrintScheduleExporter implements PrintScheduleExporter {
     return '''
 <w:tbl>
   <w:tblPr>
-    <w:tblW w:w="0" w:type="auto"/>
-    <w:tblBorders>
-      <w:top w:val="single" w:sz="8" w:space="0" w:color="000000"/>
-      <w:left w:val="single" w:sz="8" w:space="0" w:color="000000"/>
-      <w:bottom w:val="single" w:sz="8" w:space="0" w:color="000000"/>
-      <w:right w:val="single" w:sz="8" w:space="0" w:color="000000"/>
-      <w:insideH w:val="single" w:sz="8" w:space="0" w:color="000000"/>
-      <w:insideV w:val="single" w:sz="8" w:space="0" w:color="000000"/>
-    </w:tblBorders>
+    <w:tblStyle w:val="TableGrid"/>
+    <w:tblInd w:w="108" w:type="dxa"/>
+    <w:tblW w:w="10897" w:type="dxa"/>
+    <w:tblCellMar>
+      <w:left w:w="108" w:type="dxa"/>
+      <w:right w:w="108" w:type="dxa"/>
+    </w:tblCellMar>
+    <w:tblLayout w:type="fixed"/>
   </w:tblPr>
   <w:tblGrid>
-    <w:gridCol w:w="3600"/>
-    <w:gridCol w:w="1200"/>
-    <w:gridCol w:w="3600"/>
-    <w:gridCol w:w="2600"/>
+    <w:gridCol w:w="3067"/>
+    <w:gridCol w:w="2160"/>
+    <w:gridCol w:w="2610"/>
+    <w:gridCol w:w="3060"/>
   </w:tblGrid>
   ${rows.join('\n  ')}
 </w:tbl>
@@ -143,20 +189,37 @@ final class DocxPrintScheduleExporter implements PrintScheduleExporter {
   }
 
   String _tableRowXml(List<String> cells, {bool isHeader = false}) {
-    final cellsXml = cells.map((cell) => _tableCellXml(cell, isHeader)).join();
-    return '<w:tr>$cellsXml</w:tr>';
+    final cellsXml = [
+      for (var index = 0; index < cells.length; index++)
+        _tableCellXml(cells[index], isHeader, _columnWidths[index]),
+    ].join();
+    return '<w:tr><w:trPr><w:cantSplit/></w:trPr>$cellsXml</w:tr>';
   }
 
-  String _tableCellXml(String text, bool isHeader) {
-    final paragraph = _paragraphXml(text, bold: isHeader);
+  String _tableCellXml(String text, bool isHeader, int width) {
+    final paragraph = _paragraphXml(
+      text,
+      fontSize: 34,
+      alignment: isHeader ? 'center' : null,
+    );
     return '''
 <w:tc>
   <w:tcPr>
-    <w:tcW w:w="0" w:type="auto"/>
+    <w:tcW w:w="$width" w:type="dxa"/>
+    ${isHeader ? '<w:vAlign w:val="center"/>' : ''}
   </w:tcPr>
   $paragraph
 </w:tc>
 ''';
+  }
+
+  static const List<int> _columnWidths = [3067, 2160, 2610, 3060];
+
+  String _formatTimeRange(String startTime, String? finishTime) {
+    if (finishTime == null || finishTime.isEmpty) {
+      return startTime;
+    }
+    return '$startTime - $finishTime';
   }
 
   String _escapeXml(String value) {
@@ -200,9 +263,29 @@ const String _documentRelsXml = '''
 const String _stylesXml = '''
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:docDefaults>
+    <w:rPrDefault>
+      <w:rPr>
+        <w:rFonts w:ascii="Calibri" w:hAnsi="Calibri" w:cs="Calibri"/>
+      </w:rPr>
+    </w:rPrDefault>
+  </w:docDefaults>
   <w:style w:type="paragraph" w:default="1" w:styleId="Normal">
     <w:name w:val="Normal"/>
     <w:qFormat/>
+  </w:style>
+  <w:style w:type="table" w:styleId="TableGrid">
+    <w:name w:val="Table Grid"/>
+    <w:tblPr>
+      <w:tblBorders>
+        <w:top w:val="single" w:color="auto" w:sz="4" w:space="0"/>
+        <w:left w:val="single" w:color="auto" w:sz="4" w:space="0"/>
+        <w:bottom w:val="single" w:color="auto" w:sz="4" w:space="0"/>
+        <w:right w:val="single" w:color="auto" w:sz="4" w:space="0"/>
+        <w:insideH w:val="single" w:color="auto" w:sz="4" w:space="0"/>
+        <w:insideV w:val="single" w:color="auto" w:sz="4" w:space="0"/>
+      </w:tblBorders>
+    </w:tblPr>
   </w:style>
 </w:styles>
 ''';
@@ -229,7 +312,9 @@ const String _appXml = '''
 
 const String _sectionPropertiesXml = '''
 <w:sectPr>
-  <w:pgSz w:w="11906" w:h="16838"/>
-  <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="708" w:footer="708" w:gutter="0"/>
+  <w:pgSz w:w="12240" w:h="15840"/>
+  <w:pgMar w:top="1138" w:right="720" w:bottom="1138" w:left="720" w:header="720" w:footer="720" w:gutter="0"/>
+  <w:cols w:space="720"/>
+  <w:docGrid w:linePitch="360"/>
 </w:sectPr>
 ''';

--- a/packages/bochki_schedule_app/lib/src/domain/print_schedule/build_print_schedule_document_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/print_schedule/build_print_schedule_document_use_case.dart
@@ -60,6 +60,7 @@ final class BuildPrintScheduleDocumentUseCase {
               participantName: session.participant?.name ??
                   (session.participantId == null ? 'Не назначен' : 'Не найден'),
               startTime: session.startTime,
+              finishTime: session.finishTime,
               procedureName: session.procedureKind?.name ?? 'Не найдено',
               assistantName: session.assistant?.name ??
                   (session.requiresAssistant && session.assistantId == null

--- a/packages/bochki_schedule_app/lib/src/domain/print_schedule/print_schedule_row.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/print_schedule/print_schedule_row.dart
@@ -2,12 +2,14 @@ final class PrintScheduleRow {
   const PrintScheduleRow({
     required this.participantName,
     required this.startTime,
+    required this.finishTime,
     required this.procedureName,
     required this.assistantName,
   });
 
   final String participantName;
   final String startTime;
+  final String? finishTime;
   final String procedureName;
   final String assistantName;
 }

--- a/packages/bochki_schedule_app/test/data/print_schedule/docx_print_schedule_exporter_test.dart
+++ b/packages/bochki_schedule_app/test/data/print_schedule/docx_print_schedule_exporter_test.dart
@@ -8,7 +8,7 @@ import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('exports docx with expected file name and content', () async {
+  test('exports DOCX using the approved print layout', () async {
     final tempDirectory =
         await Directory.systemTemp.createTemp('bochki_docx_export_test');
     addTearDown(() => tempDirectory.delete(recursive: true));
@@ -25,11 +25,12 @@ void main() {
         ),
         groupBy: PrintScheduleGroupBy.byNames,
         title: 'Дата расписания 17.07.2026',
-        textBefore: 'До таблицы',
+        textBefore: 'До таблицы\n\nВторая строка',
         rows: const [
           PrintScheduleRow(
             participantName: 'Иванов Иван',
             startTime: '09:00',
+            finishTime: '10:30',
             procedureName: 'Бочка',
             assistantName: '',
           ),
@@ -53,6 +54,75 @@ void main() {
     expect(documentXmlString, contains('Дата расписания 17.07.2026'));
     expect(documentXmlString, contains('Участник'));
     expect(documentXmlString, contains('Иванов Иван'));
+    expect(documentXmlString, contains('09:00 - 10:30'));
     expect(documentXmlString, contains('После таблицы'));
+    expect(
+      documentXmlString,
+      contains('<w:pgSz w:w="12240" w:h="15840"/>'),
+    );
+    expect(
+      documentXmlString,
+      contains(
+        '<w:pgMar w:top="1138" w:right="720" w:bottom="1138" w:left="720"',
+      ),
+    );
+    expect(documentXmlString, contains('<w:tblStyle w:val="TableGrid"/>'));
+    expect(documentXmlString, contains('<w:tblW w:w="10897" w:type="dxa"/>'));
+    expect(documentXmlString, contains('<w:gridCol w:w="3067"/>'));
+    expect(documentXmlString, contains('<w:gridCol w:w="2160"/>'));
+    expect(documentXmlString, contains('<w:gridCol w:w="2610"/>'));
+    expect(documentXmlString, contains('<w:gridCol w:w="3060"/>'));
+    expect(documentXmlString, contains('<w:cantSplit/>'));
+    expect(documentXmlString, isNot(contains('<w:tblHeader/>')));
+    expect(documentXmlString, contains('<w:jc w:val="center"/>'));
+    expect(documentXmlString, contains('<w:sz w:val="36"/>'));
+    expect(documentXmlString, contains('<w:sz w:val="34"/>'));
+    expect(documentXmlString, contains('<w:rFonts w:ascii="Calibri"'));
+
+    final firstTextIndex = documentXmlString.indexOf('До таблицы');
+    final secondTextIndex = documentXmlString.indexOf('Вторая строка');
+    expect(firstTextIndex, greaterThanOrEqualTo(0));
+    expect(secondTextIndex, greaterThan(firstTextIndex));
+    expect(
+      documentXmlString.substring(firstTextIndex, secondTextIndex),
+      isNot(contains('<w:br/>')),
+    );
+  });
+
+  test('exports only the start time when the finish time is unknown', () async {
+    final tempDirectory =
+        await Directory.systemTemp.createTemp('bochki_docx_export_test');
+    addTearDown(() => tempDirectory.delete(recursive: true));
+    final file = await DocxPrintScheduleExporter(
+      safeFileWriter: const AtomicFileWriter(),
+    ).export(
+      document: PrintScheduleDocument(
+        workday: Workday(
+          id: '1',
+          name: 'Пятница',
+          calendarDate: DateTime(2026, 7, 17),
+        ),
+        groupBy: PrintScheduleGroupBy.byTime,
+        title: 'Дата расписания 17.07.2026',
+        textBefore: '',
+        rows: const [
+          PrintScheduleRow(
+            participantName: 'Иванов Иван',
+            startTime: '09:00',
+            finishTime: null,
+            procedureName: 'Не найдено',
+            assistantName: '',
+          ),
+        ],
+        textAfter: '',
+      ),
+      outputDirectory: tempDirectory,
+    );
+
+    final archive = ZipDecoder().decodeBytes(await file.readAsBytes());
+    final documentXml = archive.files
+        .firstWhere((entry) => entry.name == 'word/document.xml')
+        .content as List<int>;
+    expect(utf8.decode(documentXml), contains('>09:00</w:t>'));
   });
 }

--- a/packages/bochki_schedule_app/test/domain/print_schedule/print_schedule_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/print_schedule/print_schedule_use_cases_test.dart
@@ -61,6 +61,10 @@ void main() {
         document.rows.map((row) => row.participantName).toList(),
         ['Иванов Иван', 'Петров Петр'],
       );
+      expect(
+        document.rows.map((row) => row.finishTime).toList(),
+        ['10:30', '09:30'],
+      );
     });
 
     test('builds rows sorted by time and fills missing values', () async {
@@ -105,6 +109,7 @@ void main() {
       );
       expect(document.rows.first.participantName, 'Не найден');
       expect(document.rows.first.procedureName, 'Не найдено');
+      expect(document.rows.first.finishTime, isNull);
       expect(document.rows.first.assistantName, isEmpty);
     });
   });


### PR DESCRIPTION
Closes #139

## Что сделано
- Оформил DOCX распечатки под образец старой программы: Letter, книжная ориентация, поля, шрифты, интервалы и фиксированная таблица.
- Добавил интервал времени процедуры и корректный fallback, когда окончание неизвестно.
- Запретил разрывать строку таблицы между страницами и отключил повторение шапки для склейки распечатанных листов.
- Расширил unit-тесты параметрами вёрстки и временем.