### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.13.0
+
+Release date: 2026-08-25
+
+### Highlights
+
+- Improved the procedure-kind form and unified procedure roles for people.
+- Refined schedule reassignment, template loading, free-time results, and workday date selection.
+- Updated DOCX schedule exports to match the established print layout.
+
+### Details
+
+- `feat(print): match legacy DOCX layout (#139)`
+- `feat: improve procedure kind form (#131)`
+- `feat(domain): unify human procedure roles (#122)`
+- `fix(directories): clear procedure references on person deletion (#120)`
+- `fix(workdays): select calendar dates (#123)`
+- `fix(procedure-kinds): block deletion with assignments`
+- `fix(free-time): fit filters and scroll results`
+- `fix: handle cancelled template loads and stale quick assignments`
+- `fix: stabilize nested desktop windows (#138)`
+- `fix(ci): fail workspace tests on package errors (#136)`
+
 ## v0.12.0
 
 Release date: 2026-08-24

--- a/packages/bochki_schedule_app/pubspec.lock
+++ b/packages/bochki_schedule_app/pubspec.lock
@@ -23,14 +23,14 @@ packages:
       path: "../bochki_schedule_domain"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.13.0"
   bochki_schedule_infra:
     dependency: "direct main"
     description:
       path: "../bochki_schedule_infra"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.13.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/packages/bochki_schedule_app/pubspec.yaml
+++ b/packages/bochki_schedule_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_app
 description: Application package for the Bochki Schedule desktop app.
 publish_to: none
-version: 0.12.0
+version: 0.13.0
 
 environment:
   sdk: ^3.5.0

--- a/packages/bochki_schedule_domain/pubspec.yaml
+++ b/packages/bochki_schedule_domain/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_domain
 description: Domain package for Bochki Schedule.
 publish_to: none
-version: 0.12.0
+version: 0.13.0
 
 environment:
   sdk: ^3.5.0

--- a/packages/bochki_schedule_infra/pubspec.lock
+++ b/packages/bochki_schedule_infra/pubspec.lock
@@ -39,7 +39,7 @@ packages:
       path: "../bochki_schedule_domain"
       relative: true
     source: path
-    version: "0.12.0"
+    version: "0.13.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/packages/bochki_schedule_infra/pubspec.yaml
+++ b/packages/bochki_schedule_infra/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_infra
 description: Infrastructure package for Bochki Schedule.
 publish_to: none
-version: 0.12.0
+version: 0.13.0
 
 environment:
   sdk: ^3.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bochki_schedule_workspace
 publish_to: none
-version: 0.12.0
+version: 0.13.0
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
## Release v0.13.0\n\n- Bumps workspace packages to 0.13.0\n- Adds release notes for changes since v0.12.0\n\nCI will validate the release commit before merge.