### PR TITLE
refactor(directory): share desktop directory behavior

### DIFF
--- a/packages/bochki_schedule_app/integration_test/app_shell_test.dart
+++ b/packages/bochki_schedule_app/integration_test/app_shell_test.dart
@@ -73,7 +73,10 @@ void main() {
       listWorkdaysUseCase: ListWorkdaysUseCase(workdaysRepository),
       createWorkdayUseCase: CreateWorkdayUseCase(workdaysRepository),
       updateWorkdayUseCase: UpdateWorkdayUseCase(workdaysRepository),
-      deleteWorkdayUseCase: DeleteWorkdayUseCase(workdaysRepository),
+      deleteWorkdayUseCase: DeleteWorkdayUseCase(
+        workdaysRepository,
+        procedureSessionsRepository: procedureSessionsRepository,
+      ),
       getPrintPresetParamsUseCase:
           GetPrintPresetParamsUseCase(printPresetParamsRepository),
       updatePrintPresetParamsUseCase:

--- a/packages/bochki_schedule_app/lib/bochki_schedule_app.dart
+++ b/packages/bochki_schedule_app/lib/bochki_schedule_app.dart
@@ -78,6 +78,7 @@ export 'src/domain/workdays/list_workdays_use_case.dart';
 export 'src/domain/workdays/update_workday_use_case.dart';
 export 'src/domain/workdays/workday.dart';
 export 'src/domain/workdays/workday_defaults.dart';
+export 'src/domain/workdays/workday_in_use_exception.dart';
 export 'src/domain/workdays/workdays_repository.dart';
 export 'src/domain/workdays/workdays_validation_exception.dart';
 export 'src/features/participants/participants_dialog.dart';

--- a/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
+++ b/packages/bochki_schedule_app/lib/src/app_bootstrap.dart
@@ -224,6 +224,7 @@ final class AppBootstrap {
     );
     final deleteWorkdayUseCase = DeleteWorkdayUseCase(
       workdaysRepository,
+      procedureSessionsRepository: procedureSessionsRepository,
     );
     final getProgramSettingsUseCase = GetProgramSettingsUseCase(
       programSettingsRepository,

--- a/packages/bochki_schedule_app/lib/src/domain/workdays/delete_workday_use_case.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/workdays/delete_workday_use_case.dart
@@ -1,13 +1,32 @@
 import 'workday_validator.dart';
 import 'workdays_repository.dart';
+import '../procedure_sessions/procedure_sessions_repository.dart';
+import 'workday_in_use_exception.dart';
 
 final class DeleteWorkdayUseCase {
-  const DeleteWorkdayUseCase(this._repository);
+  const DeleteWorkdayUseCase(
+    this._repository, {
+    required ProcedureSessionsRepository procedureSessionsRepository,
+  }) : _procedureSessionsRepository = procedureSessionsRepository;
 
   final WorkdaysRepository _repository;
+  final ProcedureSessionsRepository _procedureSessionsRepository;
+
+  Future<int> countReferences(String workdayId) async {
+    WorkdayValidator.validateId(workdayId);
+    final normalizedId = workdayId.trim();
+    return (await _procedureSessionsRepository.list())
+        .where((session) => session.dayId == normalizedId)
+        .length;
+  }
 
   Future<void> execute(String workdayId) async {
     WorkdayValidator.validateId(workdayId);
-    await _repository.delete(workdayId.trim());
+    final normalizedId = workdayId.trim();
+    final referencesCount = await countReferences(normalizedId);
+    if (referencesCount > 0) {
+      throw WorkdayInUseException(referencesCount);
+    }
+    await _repository.delete(normalizedId);
   }
 }

--- a/packages/bochki_schedule_app/lib/src/domain/workdays/workday_in_use_exception.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/workdays/workday_in_use_exception.dart
@@ -1,0 +1,9 @@
+final class WorkdayInUseException implements Exception {
+  const WorkdayInUseException(this.referencesCount);
+
+  final int referencesCount;
+
+  @override
+  String toString() =>
+      'Невозможно удалить день: найдено $referencesCount назначенных процедур.';
+}

--- a/packages/bochki_schedule_app/lib/src/features/directory/people_directory_table.dart
+++ b/packages/bochki_schedule_app/lib/src/features/directory/people_directory_table.dart
@@ -29,6 +29,7 @@ class PeopleDirectoryTable extends StatefulWidget {
     required this.type,
     required this.entries,
     required this.onMutate,
+    required this.onCountReferences,
     required this.onChanged,
     super.key,
   });
@@ -36,6 +37,7 @@ class PeopleDirectoryTable extends StatefulWidget {
   final PeopleDirectoryType type;
   final List<PeopleDirectoryEntry> entries;
   final PeopleDirectoryMutation onMutate;
+  final Future<int> Function(String entryId) onCountReferences;
   final Future<void> Function() onChanged;
 
   @override
@@ -152,6 +154,32 @@ class _PeopleDirectoryTableState extends State<PeopleDirectoryTable> {
       ),
     );
     if (confirmed != true || !mounted) return;
+    final referencesCount = await widget.onCountReferences(entry.id);
+    if (!mounted) return;
+    if (referencesCount > 0) {
+      final referencesConfirmed = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Удалить связанные назначения?'),
+          content: Text(
+            'Запись используется в $referencesCount '
+            '${_procedureWord(referencesCount)}. После удаления ссылки '
+            'будут очищены, а назначения помечены конфликтными.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Отмена'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('ОК'),
+            ),
+          ],
+        ),
+      );
+      if (referencesConfirmed != true || !mounted) return;
+    }
     setState(() => _saving = true);
     final error = await widget.onMutate('delete', id: entry.id);
     if (!mounted) return;
@@ -160,6 +188,17 @@ class _PeopleDirectoryTableState extends State<PeopleDirectoryTable> {
       _error = error;
     });
     if (error == null) await widget.onChanged();
+  }
+
+  String _procedureWord(int count) {
+    final remainder100 = count % 100;
+    if (remainder100 >= 11 && remainder100 <= 14) {
+      return 'назначенных процедурах';
+    }
+    return switch (count % 10) {
+      1 => 'назначенной процедуре',
+      _ => 'назначенных процедурах',
+    };
   }
 
   bool _onKey(FocusNode _, KeyEvent event) {

--- a/packages/bochki_schedule_app/lib/src/features/procedure_statistics/procedure_statistics_content.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_statistics/procedure_statistics_content.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../domain/humans/human.dart';
 import '../../domain/procedure_kinds/procedure_kind.dart';
 import '../../domain/procedure_statistics/build_procedure_statistics_table_use_case.dart';
+import '../../domain/procedure_statistics/procedure_statistics_table.dart';
 import '../../domain/workdays/workday.dart';
 
 /// Shared statistics UI. Containers supply data and commands; this widget does
@@ -62,7 +63,8 @@ class ProcedureStatisticsContent extends StatelessWidget {
                 items: [
                   const DropdownMenuItem(value: null, child: Text('Все дни')),
                   ...workdays.map(
-                    (day) => DropdownMenuItem(value: day.id, child: Text(day.name)),
+                    (day) =>
+                        DropdownMenuItem(value: day.id, child: Text(day.name)),
                   ),
                 ],
                 onChanged: onDayChanged,
@@ -74,9 +76,15 @@ class ProcedureStatisticsContent extends StatelessWidget {
                 value: peopleFilter,
                 decoration: const InputDecoration(labelText: 'Участники'),
                 items: const [
-                  DropdownMenuItem(value: ProcedureStatisticsPeopleFilter.all, child: Text('Все')),
-                  DropdownMenuItem(value: ProcedureStatisticsPeopleFilter.participants, child: Text('Участники')),
-                  DropdownMenuItem(value: ProcedureStatisticsPeopleFilter.assistants, child: Text('Ассистенты')),
+                  DropdownMenuItem(
+                      value: ProcedureStatisticsPeopleFilter.all,
+                      child: Text('Все')),
+                  DropdownMenuItem(
+                      value: ProcedureStatisticsPeopleFilter.participants,
+                      child: Text('Участники')),
+                  DropdownMenuItem(
+                      value: ProcedureStatisticsPeopleFilter.assistants,
+                      child: Text('Ассистенты')),
                 ],
                 onChanged: (value) {
                   if (value != null) onPeopleChanged(value);
@@ -89,8 +97,12 @@ class ProcedureStatisticsContent extends StatelessWidget {
                 value: mode,
                 decoration: const InputDecoration(labelText: 'Режим'),
                 items: const [
-                  DropdownMenuItem(value: ProcedureStatisticsMode.participation, child: Text('Участие')),
-                  DropdownMenuItem(value: ProcedureStatisticsMode.assisting, child: Text('Ассистирование')),
+                  DropdownMenuItem(
+                      value: ProcedureStatisticsMode.participation,
+                      child: Text('Участие')),
+                  DropdownMenuItem(
+                      value: ProcedureStatisticsMode.assisting,
+                      child: Text('Ассистирование')),
                 ],
                 onChanged: (value) {
                   if (value != null) onModeChanged(value);
@@ -105,20 +117,23 @@ class ProcedureStatisticsContent extends StatelessWidget {
               : error != null
                   ? Center(child: Text(error!))
                   : people.isEmpty
-                      ? const Center(child: Text('Нет данных по выбранным фильтрам'))
+                      ? const Center(
+                          child: Text('Нет данных по выбранным фильтрам'))
                       : SingleChildScrollView(
                           scrollDirection: Axis.horizontal,
                           child: SingleChildScrollView(
                             child: DataTable(
                               columns: [
                                 const DataColumn(label: Text('Человек')),
-                                ...kinds.map((kind) => DataColumn(label: Text(kind.name))),
+                                ...kinds.map((kind) =>
+                                    DataColumn(label: Text(kind.name))),
                               ],
                               rows: [
                                 for (final person in people)
                                   DataRow(cells: [
                                     DataCell(Text(person.shortName)),
-                                    ...kinds.map((kind) => DataCell(Text('${countFor(person, kind)}'))),
+                                    ...kinds.map((kind) => DataCell(
+                                        Text('${countFor(person, kind)}'))),
                                   ]),
                               ],
                             ),

--- a/packages/bochki_schedule_app/lib/src/features/procedure_statistics/procedure_statistics_content.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_statistics/procedure_statistics_content.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import '../../domain/humans/human.dart';
 import '../../domain/procedure_kinds/procedure_kind.dart';
-import '../../domain/procedure_statistics/build_procedure_statistics_table_use_case.dart';
 import '../../domain/procedure_statistics/procedure_statistics_table.dart';
 import '../../domain/workdays/workday.dart';
 

--- a/packages/bochki_schedule_app/lib/src/features/procedure_statistics/procedure_statistics_content.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_statistics/procedure_statistics_content.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/humans/human.dart';
+import '../../domain/procedure_kinds/procedure_kind.dart';
+import '../../domain/procedure_statistics/build_procedure_statistics_table_use_case.dart';
+import '../../domain/workdays/workday.dart';
+
+/// Shared statistics UI. Containers supply data and commands; this widget does
+/// not know whether it is rendered in a dialog or a desktop child window.
+class ProcedureStatisticsContent extends StatelessWidget {
+  const ProcedureStatisticsContent({
+    required this.workdays,
+    required this.people,
+    required this.kinds,
+    required this.countFor,
+    required this.isLoading,
+    required this.error,
+    required this.dayId,
+    required this.peopleFilter,
+    required this.mode,
+    required this.onDayChanged,
+    required this.onPeopleChanged,
+    required this.onModeChanged,
+    required this.onAdd,
+    super.key,
+  });
+
+  final List<Workday> workdays;
+  final List<Human> people;
+  final List<ProcedureKind> kinds;
+  final int Function(Human person, ProcedureKind kind) countFor;
+  final bool isLoading;
+  final String? error;
+  final String? dayId;
+  final ProcedureStatisticsPeopleFilter peopleFilter;
+  final ProcedureStatisticsMode mode;
+  final ValueChanged<String?> onDayChanged;
+  final ValueChanged<ProcedureStatisticsPeopleFilter> onPeopleChanged;
+  final ValueChanged<ProcedureStatisticsMode> onModeChanged;
+  final Future<void> Function() onAdd;
+
+  @override
+  Widget build(BuildContext context) => Column(children: [
+        Container(
+          height: 56,
+          padding: const EdgeInsets.all(8),
+          color: const Color(0xFFE9EEF2),
+          alignment: Alignment.centerLeft,
+          child: FilledButton.tonal(
+            onPressed: onAdd,
+            child: const Text('Добавить запись'),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(children: [
+            Expanded(
+              child: DropdownButtonFormField<String?>(
+                key: const Key('procedure_statistics_day'),
+                value: dayId,
+                decoration: const InputDecoration(labelText: 'День'),
+                items: [
+                  const DropdownMenuItem(value: null, child: Text('Все дни')),
+                  ...workdays.map(
+                    (day) => DropdownMenuItem(value: day.id, child: Text(day.name)),
+                  ),
+                ],
+                onChanged: onDayChanged,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: DropdownButtonFormField(
+                value: peopleFilter,
+                decoration: const InputDecoration(labelText: 'Участники'),
+                items: const [
+                  DropdownMenuItem(value: ProcedureStatisticsPeopleFilter.all, child: Text('Все')),
+                  DropdownMenuItem(value: ProcedureStatisticsPeopleFilter.participants, child: Text('Участники')),
+                  DropdownMenuItem(value: ProcedureStatisticsPeopleFilter.assistants, child: Text('Ассистенты')),
+                ],
+                onChanged: (value) {
+                  if (value != null) onPeopleChanged(value);
+                },
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: DropdownButtonFormField(
+                value: mode,
+                decoration: const InputDecoration(labelText: 'Режим'),
+                items: const [
+                  DropdownMenuItem(value: ProcedureStatisticsMode.participation, child: Text('Участие')),
+                  DropdownMenuItem(value: ProcedureStatisticsMode.assisting, child: Text('Ассистирование')),
+                ],
+                onChanged: (value) {
+                  if (value != null) onModeChanged(value);
+                },
+              ),
+            ),
+          ]),
+        ),
+        Expanded(
+          child: isLoading
+              ? const Center(child: CircularProgressIndicator())
+              : error != null
+                  ? Center(child: Text(error!))
+                  : people.isEmpty
+                      ? const Center(child: Text('Нет данных по выбранным фильтрам'))
+                      : SingleChildScrollView(
+                          scrollDirection: Axis.horizontal,
+                          child: SingleChildScrollView(
+                            child: DataTable(
+                              columns: [
+                                const DataColumn(label: Text('Человек')),
+                                ...kinds.map((kind) => DataColumn(label: Text(kind.name))),
+                              ],
+                              rows: [
+                                for (final person in people)
+                                  DataRow(cells: [
+                                    DataCell(Text(person.shortName)),
+                                    ...kinds.map((kind) => DataCell(Text('${countFor(person, kind)}'))),
+                                  ]),
+                              ],
+                            ),
+                          ),
+                        ),
+        ),
+      ]);
+}

--- a/packages/bochki_schedule_app/lib/src/features/procedure_statistics/procedure_statistics_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_statistics/procedure_statistics_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '../../domain/procedure_statistics/procedure_statistics_table.dart';
+import 'procedure_statistics_content.dart';
 import 'procedure_statistics_view_model.dart';
 
 class ProcedureStatisticsDialog extends StatelessWidget {
@@ -16,103 +16,23 @@ class ProcedureStatisticsDialog extends StatelessWidget {
               animation: viewModel,
               builder: (context, _) {
                 final table = viewModel.table;
-                return Column(children: [
-                  Container(
-                      height: 56,
-                      padding: const EdgeInsets.all(8),
-                      color: const Color(0xFFE9EEF2),
-                      alignment: Alignment.centerLeft,
-                      child: FilledButton.tonal(
-                          onPressed: () async {
-                            await onAdd();
-                            await viewModel.load();
-                          },
-                          child: const Text('Добавить запись'))),
-                  Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Row(children: [
-                        Expanded(
-                            child: DropdownButtonFormField<String?>(
-                                key: const Key('procedure_statistics_day'),
-                                value: viewModel.dayId,
-                                decoration:
-                                    const InputDecoration(labelText: 'День'),
-                                items: [
-                                  const DropdownMenuItem(
-                                      value: null, child: Text('Все дни')),
-                                  ...viewModel.workdays.map((d) =>
-                                      DropdownMenuItem(
-                                          value: d.id, child: Text(d.name)))
-                                ],
-                                onChanged: (v) => viewModel.setDay(v))),
-                        const SizedBox(width: 12),
-                        Expanded(
-                            child: DropdownButtonFormField(
-                                value: viewModel.peopleFilter,
-                                decoration: const InputDecoration(
-                                    labelText: 'Участники'),
-                                items: const [
-                                  DropdownMenuItem(
-                                      value:
-                                          ProcedureStatisticsPeopleFilter.all,
-                                      child: Text('Все')),
-                                  DropdownMenuItem(
-                                      value: ProcedureStatisticsPeopleFilter
-                                          .participants,
-                                      child: Text('Участники')),
-                                  DropdownMenuItem(
-                                      value: ProcedureStatisticsPeopleFilter
-                                          .assistants,
-                                      child: Text('Ассистенты'))
-                                ],
-                                onChanged: (v) {
-                                  if (v != null) viewModel.setPeople(v);
-                                })),
-                        const SizedBox(width: 12),
-                        Expanded(
-                            child: DropdownButtonFormField(
-                                value: viewModel.mode,
-                                decoration:
-                                    const InputDecoration(labelText: 'Режим'),
-                                items: const [
-                                  DropdownMenuItem(
-                                      value:
-                                          ProcedureStatisticsMode.participation,
-                                      child: Text('Участие')),
-                                  DropdownMenuItem(
-                                      value: ProcedureStatisticsMode.assisting,
-                                      child: Text('Ассистирование'))
-                                ],
-                                onChanged: (v) {
-                                  if (v != null) viewModel.setMode(v);
-                                }))
-                      ])),
-                  Expanded(
-                      child: viewModel.isLoading
-                          ? const Center(child: CircularProgressIndicator())
-                          : viewModel.error != null
-                              ? Center(child: Text(viewModel.error!))
-                              : table == null || table.people.isEmpty
-                                  ? const Center(
-                                      child: Text(
-                                          'Нет данных по выбранным фильтрам'))
-                                  : SingleChildScrollView(
-                                      scrollDirection: Axis.horizontal,
-                                      child: SingleChildScrollView(
-                                          child: DataTable(columns: [
-                                        const DataColumn(
-                                            label: Text('Человек')),
-                                        ...table.kinds.map((k) =>
-                                            DataColumn(label: Text(k.name)))
-                                      ], rows: [
-                                        for (final human in table.people)
-                                          DataRow(cells: [
-                                            DataCell(Text(human.shortName)),
-                                            ...table.kinds.map((kind) =>
-                                                DataCell(Text(
-                                                    '${table.count(human, kind)}')))
-                                          ])
-                                      ]))))
-                ]);
+                return ProcedureStatisticsContent(
+                  workdays: viewModel.workdays,
+                  people: table?.people ?? const [],
+                  kinds: table?.kinds ?? const [],
+                  countFor: (person, kind) => table?.count(person, kind) ?? 0,
+                  isLoading: viewModel.isLoading,
+                  error: viewModel.error,
+                  dayId: viewModel.dayId,
+                  peopleFilter: viewModel.peopleFilter,
+                  mode: viewModel.mode,
+                  onDayChanged: viewModel.setDay,
+                  onPeopleChanged: viewModel.setPeople,
+                  onModeChanged: viewModel.setMode,
+                  onAdd: () async {
+                    await onAdd();
+                    await viewModel.load();
+                  },
+                );
               })));
 }

--- a/packages/bochki_schedule_app/lib/src/features/workdays/workdays_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/workdays/workdays_dialog.dart
@@ -117,17 +117,40 @@ class _WorkdaysDialogState extends State<WorkdaysDialog> {
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(false),
-              child: const Text('Отмена'),
+              child: const Text('Нет'),
             ),
             FilledButton(
               onPressed: () => Navigator.of(context).pop(true),
-              child: const Text('Удалить'),
+              child: const Text('Продолжить'),
             ),
           ],
         );
       },
     );
     if (confirmed != true) {
+      return;
+    }
+
+    final referencesCount = await widget.viewModel.countReferences(workday.id);
+    if (!mounted) return;
+    if (referencesCount > 0) {
+      await showDialog<void>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Невозможно удалить день'),
+          content: Text(
+            'День "${workday.name}" используется в $referencesCount '
+            '${_assignedProcedureWord(referencesCount)}. '
+            'Сначала удалите или переназначьте эти процедуры.',
+          ),
+          actions: [
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Понятно'),
+            ),
+          ],
+        ),
+      );
       return;
     }
 
@@ -141,6 +164,18 @@ class _WorkdaysDialogState extends State<WorkdaysDialog> {
         _selectedWorkdayId = null;
       }
     });
+  }
+
+  String _assignedProcedureWord(int count) {
+    final remainder100 = count % 100;
+    if (remainder100 >= 11 && remainder100 <= 14) {
+      return 'назначенных процедур';
+    }
+    return switch (count % 10) {
+      1 => 'назначенная процедура',
+      2 || 3 || 4 => 'назначенные процедуры',
+      _ => 'назначенных процедур',
+    };
   }
 
   @override

--- a/packages/bochki_schedule_app/lib/src/features/workdays/workdays_view_model.dart
+++ b/packages/bochki_schedule_app/lib/src/features/workdays/workdays_view_model.dart
@@ -58,6 +58,9 @@ final class WorkdaysViewModel extends ChangeNotifier {
 
   Workday suggestDraftWorkday() => _defaults.createDraft(_workdays);
 
+  Future<int> countReferences(String workdayId) =>
+      _deleteWorkdayUseCase.countReferences(workdayId);
+
   void clearFormError() {
     if (_formErrorMessage == null) {
       return;

--- a/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
@@ -484,10 +484,13 @@ final class DesktopWindowCoordinator {
     }
   }
 
-  Future<int> _directoryReferences(String directory, String id) => switch (directory) {
-        'participants' => _services.deleteParticipantUseCase.countReferences(id),
+  Future<int> _directoryReferences(String directory, String id) =>
+      switch (directory) {
+        'participants' =>
+          _services.deleteParticipantUseCase.countReferences(id),
         'assistants' => _services.deleteAssistantUseCase.countReferences(id),
-        'procedureKinds' => _services.deleteProcedureKindUseCase.countReferences(id),
+        'procedureKinds' =>
+          _services.deleteProcedureKindUseCase.countReferences(id),
         'workdays' => _services.deleteWorkdayUseCase.countReferences(id),
         _ => throw ArgumentError.value(directory, 'directory'),
       };
@@ -773,29 +776,29 @@ class _ProcedureStatisticsWindowState extends State<ProcedureStatisticsWindow> {
         debugShowCheckedModeBanner: false,
         home: Scaffold(
             body: ProcedureStatisticsContent(
-              workdays: _workdays,
-              people: _humans,
-              kinds: _kinds,
-              countFor: (person, kind) => _counts['${person.id}/${kind.id}'] ?? 0,
-              isLoading: _loading,
-              error: _error,
-              dayId: _dayId,
-              peopleFilter: _people,
-              mode: _mode,
-              onDayChanged: (value) {
-                _dayId = value;
-                _load();
-              },
-              onPeopleChanged: (value) {
-                _people = value;
-                _load();
-              },
-              onModeChanged: (value) {
-                _mode = value;
-                _load();
-              },
-              onAdd: () => _mainChannel.invokeMethod<void>('openProcedureSession'),
-            )),
+          workdays: _workdays,
+          people: _humans,
+          kinds: _kinds,
+          countFor: (person, kind) => _counts['${person.id}/${kind.id}'] ?? 0,
+          isLoading: _loading,
+          error: _error,
+          dayId: _dayId,
+          peopleFilter: _people,
+          mode: _mode,
+          onDayChanged: (value) {
+            _dayId = value;
+            _load();
+          },
+          onPeopleChanged: (value) {
+            _people = value;
+            _load();
+          },
+          onModeChanged: (value) {
+            _mode = value;
+            _load();
+          },
+          onAdd: () => _mainChannel.invokeMethod<void>('openProcedureSession'),
+        )),
       );
 }
 
@@ -1469,8 +1472,9 @@ class _DirectoryChildWindowState extends State<DirectoryChildWindow> {
             .toList(growable: false),
         onMutate: _mutatePeople,
         onCountReferences: (id) => _mainChannel.invokeMethod<int>(
-              'directoryReferences', {'directory': _directory, 'id': id},
-            ).then((value) => value ?? 0),
+          'directoryReferences',
+          {'directory': _directory, 'id': id},
+        ).then((value) => value ?? 0),
         onChanged: _load,
       );
     }
@@ -1747,12 +1751,11 @@ class _DirectoryChildWindowState extends State<DirectoryChildWindow> {
                                 },
                           child: const Text('Изменить')),
                       TextButton(
-                          onPressed:
-                              _saving
-                                  ? null
-                                  : _kind == DesktopWindowKind.procedureKinds
-                                      ? () => _deleteProcedureKind(entry)
-                                      : () => _mutate('delete', id: id),
+                          onPressed: _saving
+                              ? null
+                              : _kind == DesktopWindowKind.procedureKinds
+                                  ? () => _deleteProcedureKind(entry)
+                                  : () => _mutate('delete', id: id),
                           child: const Text('Удалить')),
                     ]),
                   );
@@ -1770,7 +1773,8 @@ class _DirectoryChildWindowState extends State<DirectoryChildWindow> {
   Future<void> _deleteProcedureKind(Map<String, dynamic> entry) async {
     final id = entry['id'] as String;
     final referencesCount = await _mainChannel.invokeMethod<int>(
-          'directoryReferences', {'directory': 'procedureKinds', 'id': id},
+          'directoryReferences',
+          {'directory': 'procedureKinds', 'id': id},
         ) ??
         0;
     if (!mounted) return;

--- a/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
 import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter/services.dart';
 import 'package:screen_retriever/screen_retriever.dart';
 import 'package:window_manager/window_manager.dart';
@@ -376,6 +377,9 @@ final class DesktopWindowCoordinator {
       case 'directoryMutate':
         return _directoryMutate(
             Map<String, dynamic>.from(call.arguments as Map));
+      case 'workdayReferences':
+        return _services.deleteWorkdayUseCase
+            .countReferences(call.arguments as String);
       case 'openDirectoryEditor':
         final values = Map<String, dynamic>.from(call.arguments as Map);
         await openDirectoryEditor(
@@ -520,15 +524,18 @@ final class DesktopWindowCoordinator {
             await _services.updateProcedureKindUseCase.execute(kind);
           break;
         case 'workdays':
-          final day = _workdayFromMap(
-              {...entry, 'id': values['id'] as String? ?? 'new'});
-          if (action == 'delete')
+          if (action == 'delete') {
             await _services.deleteWorkdayUseCase
                 .execute(values['id'] as String);
-          if (action == 'create')
+          } else if (action == 'create') {
+            final day = _workdayFromMap({...entry, 'id': 'new'});
             await _services.createWorkdayUseCase.execute(day);
-          if (action == 'update')
+          } else if (action == 'update') {
+            final day = _workdayFromMap(
+              {...entry, 'id': values['id'] as String},
+            );
             await _services.updateWorkdayUseCase.execute(day);
+          }
           break;
         default:
           throw ArgumentError.value(directory, 'directory');
@@ -1244,6 +1251,14 @@ String _formatCalendarDate(DateTime value) {
   return '$year-$month-$day';
 }
 
+String _formatWorkdayDate(String value) {
+  final date = DateTime.tryParse(value);
+  if (date == null) return value;
+  final day = date.day.toString().padLeft(2, '0');
+  final month = date.month.toString().padLeft(2, '0');
+  return '$day.$month.${date.year}';
+}
+
 Map<String, dynamic> _kindMap(ProcedureKind k) => {
       'id': k.id,
       'patternId': k.patternId,
@@ -1312,6 +1327,7 @@ class _DirectoryChildWindowState extends State<DirectoryChildWindow> {
   bool get _isPeopleDirectory =>
       _kind == DesktopWindowKind.participants ||
       _kind == DesktopWindowKind.assistants;
+  bool get _isWorkdaysDirectory => _kind == DesktopWindowKind.workdays;
   String get _directory => switch (_kind) {
         DesktopWindowKind.participants => 'participants',
         DesktopWindowKind.assistants => 'assistants',
@@ -1400,7 +1416,8 @@ class _DirectoryChildWindowState extends State<DirectoryChildWindow> {
   void _fillEditor(Map<String, dynamic>? entry) {
     _name.text = entry?['name'] as String? ?? '';
     _shortName.text = entry?['shortName'] as String? ?? '';
-    _date.text = entry?['date'] as String? ?? '';
+    _date.text = entry?['date'] as String? ??
+        (_kind == DesktopWindowKind.workdayEditor ? _nextWorkdayDate() : '');
     _capacity.text = '${entry?['capacity'] ?? 1}';
     _participantTime.text = '${entry?['participantBusyTime'] ?? ''}';
     _patternId = entry?['patternId'] as String? ?? 'curated';
@@ -1463,6 +1480,9 @@ class _DirectoryChildWindowState extends State<DirectoryChildWindow> {
           home: Scaffold(body: Center(child: CircularProgressIndicator())));
     return MaterialApp(
       debugShowCheckedModeBanner: false,
+      locale: const Locale('ru', 'RU'),
+      supportedLocales: const [Locale('ru', 'RU')],
+      localizationsDelegates: GlobalMaterialLocalizations.delegates,
       theme: ThemeData(useMaterial3: true),
       home: Scaffold(
         appBar: AppBar(title: Text(_title)),
@@ -1508,7 +1528,190 @@ class _DirectoryChildWindowState extends State<DirectoryChildWindow> {
         onChanged: _load,
       );
     }
+    if (_isWorkdaysDirectory) return _workdaysList();
     return _legacyDirectoryList();
+  }
+
+  Widget _workdaysList() => Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Align(
+            alignment: Alignment.centerLeft,
+            child: FilledButton.tonal(
+              onPressed: _saving
+                  ? null
+                  : () => _openEditor(DesktopWindowKind.workdayEditor.name),
+              child: const Text('Создать'),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Expanded(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                border: Border.all(color: const Color(0xFFD0D7DE)),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Column(
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                    child: Row(children: [
+                      Expanded(flex: 3, child: Text('Название')),
+                      Expanded(flex: 2, child: Text('Дата')),
+                      SizedBox(width: 180),
+                    ]),
+                  ),
+                  const Divider(height: 1),
+                  Expanded(
+                    child: ListView.separated(
+                      itemCount: _entries.length,
+                      separatorBuilder: (_, __) => const Divider(height: 1),
+                      itemBuilder: (_, index) {
+                        final entry = _entries[index];
+                        final id = entry['id'] as String;
+                        return InkWell(
+                          onTap: () => setState(() => _selectedId = id),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 12,
+                              vertical: 8,
+                            ),
+                            child: Row(children: [
+                              Expanded(
+                                flex: 3,
+                                child: Text(entry['name'] as String),
+                              ),
+                              Expanded(
+                                flex: 2,
+                                child: Text(
+                                  _formatWorkdayDate(entry['date'] as String),
+                                ),
+                              ),
+                              SizedBox(
+                                width: 180,
+                                child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.end,
+                                  children: [
+                                    TextButton(
+                                      onPressed: _saving
+                                          ? null
+                                          : () => _openEditor(
+                                                DesktopWindowKind
+                                                    .workdayEditor.name,
+                                                id,
+                                              ),
+                                      child: const Text('Изменить'),
+                                    ),
+                                    TextButton(
+                                      onPressed: _saving
+                                          ? null
+                                          : () => _deleteWorkday(entry),
+                                      child: const Text('Удалить'),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ]),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      );
+
+  Future<void> _deleteWorkday(Map<String, dynamic> entry) async {
+    final name = entry['name'] as String;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Удалить день?'),
+        content: Text('День "$name" будет скрыт из списка.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Нет'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Продолжить'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    final referencesCount = await _mainChannel.invokeMethod<int>(
+          'workdayReferences',
+          entry['id'] as String,
+        ) ??
+        0;
+    if (!mounted) return;
+    if (referencesCount > 0) {
+      await showDialog<void>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Невозможно удалить день'),
+          content: Text(
+            'День "$name" используется в $referencesCount '
+            '${_assignedProcedureWord(referencesCount)}. '
+            'Сначала удалите или переназначьте эти процедуры.',
+          ),
+          actions: [
+            FilledButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Понятно'),
+            ),
+          ],
+        ),
+      );
+      return;
+    }
+    await _mutate('delete', id: entry['id'] as String);
+  }
+
+  Future<void> _selectWorkdayDate() async {
+    if (_saving) return;
+    final initialDate = DateTime.tryParse(_date.text) ?? DateTime.now();
+    final selectedDate = await showDatePicker(
+      context: context,
+      initialDate: initialDate,
+      firstDate: DateTime(1900),
+      lastDate: DateTime(2100, 12, 31),
+    );
+    if (selectedDate == null || !mounted) return;
+    setState(() => _date.text = _formatCalendarDate(selectedDate));
+  }
+
+  String _nextWorkdayDate() {
+    final dates = _entries
+        .map((entry) => DateTime.tryParse(entry['date'] as String? ?? ''))
+        .whereType<DateTime>();
+    if (dates.isEmpty) {
+      return _formatCalendarDate(
+        DateTime.now().add(const Duration(days: 1)),
+      );
+    }
+    final latest = dates.reduce(
+      (left, right) => left.isAfter(right) ? left : right,
+    );
+    return _formatCalendarDate(latest.add(const Duration(days: 1)));
+  }
+
+  String _assignedProcedureWord(int count) {
+    final remainder100 = count % 100;
+    if (remainder100 >= 11 && remainder100 <= 14) {
+      return 'назначенных процедур';
+    }
+    return switch (count % 10) {
+      1 => 'назначенная процедура',
+      2 || 3 || 4 => 'назначенные процедуры',
+      _ => 'назначенных процедур',
+    };
   }
 
   Future<String?> _mutatePeople(
@@ -1691,11 +1894,19 @@ class _DirectoryChildWindowState extends State<DirectoryChildWindow> {
               keyboardType: TextInputType.number,
               decoration:
                   const InputDecoration(labelText: 'Время участника, мин')),
-        ] else
-          TextField(
-              controller: _date,
-              enabled: !_saving,
-              decoration: const InputDecoration(labelText: 'Дата (ISO 8601)')),
+        ] else ...[
+          const Text('Дата'),
+          const SizedBox(height: 4),
+          OutlinedButton.icon(
+            onPressed: _saving ? null : _selectWorkdayDate,
+            icon: const Icon(Icons.calendar_month),
+            label: Text(
+              _date.text.isEmpty
+                  ? 'Выберите дату'
+                  : _formatWorkdayDate(_date.text),
+            ),
+          ),
+        ],
         if (_error != null)
           Padding(
               padding: const EdgeInsets.only(top: 12),

--- a/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
@@ -23,6 +23,7 @@ import '../features/procedure_sessions/procedure_session_dialog.dart';
 import '../features/procedure_sessions/procedure_session_submit_result.dart';
 import '../features/procedure_sessions/procedure_sessions_view_model.dart';
 import '../features/directory/people_directory_table.dart';
+import '../features/procedure_statistics/procedure_statistics_content.dart';
 
 enum DesktopWindowKind {
   main,
@@ -380,6 +381,12 @@ final class DesktopWindowCoordinator {
       case 'workdayReferences':
         return _services.deleteWorkdayUseCase
             .countReferences(call.arguments as String);
+      case 'directoryReferences':
+        final values = Map<String, dynamic>.from(call.arguments as Map);
+        return _directoryReferences(
+          values['directory'] as String,
+          values['id'] as String,
+        );
       case 'openDirectoryEditor':
         final values = Map<String, dynamic>.from(call.arguments as Map);
         await openDirectoryEditor(
@@ -476,6 +483,14 @@ final class DesktopWindowCoordinator {
         throw ArgumentError.value(directory, 'directory');
     }
   }
+
+  Future<int> _directoryReferences(String directory, String id) => switch (directory) {
+        'participants' => _services.deleteParticipantUseCase.countReferences(id),
+        'assistants' => _services.deleteAssistantUseCase.countReferences(id),
+        'procedureKinds' => _services.deleteProcedureKindUseCase.countReferences(id),
+        'workdays' => _services.deleteWorkdayUseCase.countReferences(id),
+        _ => throw ArgumentError.value(directory, 'directory'),
+      };
 
   Future<Map<String, dynamic>> _directoryMutate(
       Map<String, dynamic> values) async {
@@ -757,102 +772,30 @@ class _ProcedureStatisticsWindowState extends State<ProcedureStatisticsWindow> {
   Widget build(BuildContext context) => MaterialApp(
         debugShowCheckedModeBanner: false,
         home: Scaffold(
-            body: Column(children: [
-          Container(
-              height: 56,
-              color: const Color(0xFFE9EEF2),
-              alignment: Alignment.centerLeft,
-              padding: const EdgeInsets.all(8),
-              child: FilledButton.tonal(
-                onPressed: () =>
-                    _mainChannel.invokeMethod<void>('openProcedureSession'),
-                child: const Text('Добавить запись'),
-              )),
-          Padding(
-              padding: const EdgeInsets.all(16),
-              child: Row(children: [
-                Expanded(
-                    child: DropdownButtonFormField<String?>(
-                        value: _dayId,
-                        decoration: const InputDecoration(labelText: 'День'),
-                        items: [
-                          const DropdownMenuItem(
-                              value: null, child: Text('Все дни')),
-                          ..._workdays.map((d) => DropdownMenuItem(
-                              value: d.id, child: Text(d.name)))
-                        ],
-                        onChanged: (v) {
-                          _dayId = v;
-                          _load();
-                        })),
-                const SizedBox(width: 12),
-                Expanded(
-                    child: DropdownButtonFormField(
-                        value: _people,
-                        decoration:
-                            const InputDecoration(labelText: 'Участники'),
-                        items: const [
-                          DropdownMenuItem(
-                              value: ProcedureStatisticsPeopleFilter.all,
-                              child: Text('Все')),
-                          DropdownMenuItem(
-                              value:
-                                  ProcedureStatisticsPeopleFilter.participants,
-                              child: Text('Участники')),
-                          DropdownMenuItem(
-                              value: ProcedureStatisticsPeopleFilter.assistants,
-                              child: Text('Ассистенты'))
-                        ],
-                        onChanged: (v) {
-                          if (v != null) {
-                            _people = v;
-                            _load();
-                          }
-                        })),
-                const SizedBox(width: 12),
-                Expanded(
-                    child: DropdownButtonFormField(
-                        value: _mode,
-                        decoration: const InputDecoration(labelText: 'Режим'),
-                        items: const [
-                          DropdownMenuItem(
-                              value: ProcedureStatisticsMode.participation,
-                              child: Text('Участие')),
-                          DropdownMenuItem(
-                              value: ProcedureStatisticsMode.assisting,
-                              child: Text('Ассистирование'))
-                        ],
-                        onChanged: (v) {
-                          if (v != null) {
-                            _mode = v;
-                            _load();
-                          }
-                        })),
-              ])),
-          Expanded(
-              child: _loading
-                  ? const Center(child: CircularProgressIndicator())
-                  : _error != null
-                      ? Center(child: Text(_error!))
-                      : _humans.isEmpty
-                          ? const Center(
-                              child: Text('Нет данных по выбранным фильтрам'))
-                          : SingleChildScrollView(
-                              scrollDirection: Axis.horizontal,
-                              child: SingleChildScrollView(
-                                  child: DataTable(columns: [
-                                const DataColumn(label: Text('Человек')),
-                                ..._kinds
-                                    .map((k) => DataColumn(label: Text(k.name)))
-                              ], rows: [
-                                for (final human in _humans)
-                                  DataRow(cells: [
-                                    DataCell(Text(human.shortName)),
-                                    ..._kinds.map((kind) => DataCell(Text(
-                                        '${_counts['${human.id}/${kind.id}'] ?? 0}')))
-                                  ])
-                              ])))),
-        ])),
+            body: ProcedureStatisticsContent(
+              workdays: _workdays,
+              people: _humans,
+              kinds: _kinds,
+              countFor: (person, kind) => _counts['${person.id}/${kind.id}'] ?? 0,
+              isLoading: _loading,
+              error: _error,
+              dayId: _dayId,
+              peopleFilter: _people,
+              mode: _mode,
+              onDayChanged: (value) {
+                _dayId = value;
+                _load();
+              },
+              onPeopleChanged: (value) {
+                _people = value;
+                _load();
+              },
+              onModeChanged: (value) {
+                _mode = value;
+                _load();
+              },
+              onAdd: () => _mainChannel.invokeMethod<void>('openProcedureSession'),
+            )),
       );
 }
 
@@ -1525,6 +1468,9 @@ class _DirectoryChildWindowState extends State<DirectoryChildWindow> {
             )
             .toList(growable: false),
         onMutate: _mutatePeople,
+        onCountReferences: (id) => _mainChannel.invokeMethod<int>(
+              'directoryReferences', {'directory': _directory, 'id': id},
+            ).then((value) => value ?? 0),
         onChanged: _load,
       );
     }
@@ -1802,7 +1748,11 @@ class _DirectoryChildWindowState extends State<DirectoryChildWindow> {
                           child: const Text('Изменить')),
                       TextButton(
                           onPressed:
-                              _saving ? null : () => _mutate('delete', id: id),
+                              _saving
+                                  ? null
+                                  : _kind == DesktopWindowKind.procedureKinds
+                                      ? () => _deleteProcedureKind(entry)
+                                      : () => _mutate('delete', id: id),
                           child: const Text('Удалить')),
                     ]),
                   );
@@ -1816,6 +1766,36 @@ class _DirectoryChildWindowState extends State<DirectoryChildWindow> {
         DesktopWindowKind.workdays => entry['date'] as String,
         _ => '',
       };
+
+  Future<void> _deleteProcedureKind(Map<String, dynamic> entry) async {
+    final id = entry['id'] as String;
+    final referencesCount = await _mainChannel.invokeMethod<int>(
+          'directoryReferences', {'directory': 'procedureKinds', 'id': id},
+        ) ??
+        0;
+    if (!mounted) return;
+    if (referencesCount > 0) {
+      await showDialog<void>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Невозможно удалить процедуру'),
+          content: Text(
+            'Процедура используется в $referencesCount '
+            '${_assignedProcedureWord(referencesCount)}. '
+            'Сначала удалите эти назначения.',
+          ),
+          actions: [
+            FilledButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Понятно'),
+            ),
+          ],
+        ),
+      );
+      return;
+    }
+    await _mutate('delete', id: id);
+  }
 
   Future<void> _showInlineEditor() async {
     await showDialog<void>(

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -1451,7 +1451,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.text('Delete'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Удалить').last);
+    await tester.tap(find.text('Продолжить'));
     await tester.pumpAndSettle();
 
     expect(

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -2349,7 +2349,10 @@ _TestContext _buildTestContext({
       listWorkdaysUseCase: ListWorkdaysUseCase(workdaysRepository),
       createWorkdayUseCase: CreateWorkdayUseCase(workdaysRepository),
       updateWorkdayUseCase: UpdateWorkdayUseCase(workdaysRepository),
-      deleteWorkdayUseCase: DeleteWorkdayUseCase(workdaysRepository),
+      deleteWorkdayUseCase: DeleteWorkdayUseCase(
+        workdaysRepository,
+        procedureSessionsRepository: procedureSessionsRepository,
+      ),
       getPrintPresetParamsUseCase:
           GetPrintPresetParamsUseCase(printPresetParamsRepository),
       updatePrintPresetParamsUseCase:

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -1451,7 +1451,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.text('Delete'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Продолжить'));
+    await tester.tap(find.text('Удалить').last);
     await tester.pumpAndSettle();
 
     expect(
@@ -1889,7 +1889,7 @@ void main() {
 
     await tester.tap(find.byKey(const Key('workday_delete_2')));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Удалить').last);
+    await tester.tap(find.text('Продолжить'));
     await tester.pumpAndSettle();
 
     expect(

--- a/packages/bochki_schedule_app/test/domain/workdays/workdays_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/workdays/workdays_use_cases_test.dart
@@ -89,6 +89,44 @@ void main() {
       expect(draft.name, 'День 1');
       expect(draft.calendarDate, DateTime(2026, 7, 11));
     });
+
+    test('delete is blocked when active procedures reference the workday',
+        () async {
+      final repository = _InMemoryWorkdaysRepository(
+        workdays: [
+          Workday(
+            id: '1',
+            name: 'День 1',
+            calendarDate: DateTime(2026, 7, 11),
+          ),
+        ],
+      );
+      final sessions = _ProcedureSessionsRepository([
+        ProcedureSessionRaw(
+          id: '2',
+          dayId: '1',
+          startTime: '10:00',
+          procedureKindId: '3',
+        ),
+      ]);
+      final useCase = DeleteWorkdayUseCase(
+        repository,
+        procedureSessionsRepository: sessions,
+      );
+
+      expect(await useCase.countReferences('1'), 1);
+      await expectLater(
+        useCase.execute('1'),
+        throwsA(
+          isA<WorkdayInUseException>().having(
+            (error) => error.referencesCount,
+            'referencesCount',
+            1,
+          ),
+        ),
+      );
+      expect((await repository.list()).single.id, '1');
+    });
   });
 }
 
@@ -137,5 +175,33 @@ final class _InMemoryWorkdaysRepository implements WorkdaysRepository {
       _workdays[index] = workday;
     }
     return workday;
+  }
+}
+
+final class _ProcedureSessionsRepository
+    implements ProcedureSessionsRepository {
+  _ProcedureSessionsRepository(this._sessions);
+
+  final List<ProcedureSessionRaw> _sessions;
+
+  @override
+  Future<ProcedureSessionRaw> create(ProcedureSessionRaw procedureSession) {
+    _sessions.add(procedureSession);
+    return Future.value(procedureSession);
+  }
+
+  @override
+  Future<void> delete(String procedureSessionId) async {
+    _sessions.removeWhere((session) => session.id == procedureSessionId);
+  }
+
+  @override
+  Future<List<ProcedureSessionRaw>> list() async => [..._sessions];
+
+  @override
+  Future<ProcedureSessionRaw> update(ProcedureSessionRaw procedureSession) {
+    final index = _sessions.indexWhere((entry) => entry.id == procedureSession.id);
+    if (index != -1) _sessions[index] = procedureSession;
+    return Future.value(procedureSession);
   }
 }

--- a/packages/bochki_schedule_app/test/domain/workdays/workdays_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/workdays/workdays_use_cases_test.dart
@@ -200,7 +200,8 @@ final class _ProcedureSessionsRepository
 
   @override
   Future<ProcedureSessionRaw> update(ProcedureSessionRaw procedureSession) {
-    final index = _sessions.indexWhere((entry) => entry.id == procedureSession.id);
+    final index =
+        _sessions.indexWhere((entry) => entry.id == procedureSession.id);
     if (index != -1) _sessions[index] = procedureSession;
     return Future.value(procedureSession);
   }

--- a/packages/bochki_schedule_app/test/domain/workdays/workdays_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/workdays/workdays_use_cases_test.dart
@@ -205,4 +205,18 @@ final class _ProcedureSessionsRepository
     if (index != -1) _sessions[index] = procedureSession;
     return Future.value(procedureSession);
   }
+
+  @override
+  Future<void> updateMany(List<ProcedureSessionRaw> procedureSessions) async {
+    for (final session in procedureSessions) {
+      await update(session);
+    }
+  }
+
+  @override
+  Future<int> clearAll() async {
+    final count = _sessions.length;
+    _sessions.clear();
+    return count;
+  }
 }

--- a/packages/bochki_schedule_app/test/features/directory/people_directory_table_test.dart
+++ b/packages/bochki_schedule_app/test/features/directory/people_directory_table_test.dart
@@ -71,6 +71,7 @@ Widget _table({
             PeopleDirectoryEntry(id: '1', name: 'Анна', shortName: 'Анна'),
           ],
           onMutate: onMutate,
+          onCountReferences: (_) async => 0,
           onChanged: () async {},
         ),
       ),


### PR DESCRIPTION
Closes #143

- renders statistics through a shared content component in both the fallback dialog and desktop window;
- adds the reference-aware delete flow to the desktop people table via IPC;
- exposes day reference counting to the dialog path and blocks the same delete flow;
- makes the desktop procedure delete path check references before mutation.

Local Flutter/Dart SDK is unavailable in this environment; GitHub Actions is the authoritative validation.