### PR TITLE
chore(release): v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.13.1
+
+Release date: 2026-08-25
+
+### Highlights
+
+- Unified shared statistics content between the fallback dialog and desktop window.
+- Completed the workday-directory delete confirmation and reference protection flow.
+
+### Details
+
+- `refactor(directory): share desktop directory behavior (#144)`
+- `fix(workdays): align desktop directory UX (#142)`
+
 ## v0.13.0
 
 Release date: 2026-08-25

--- a/packages/bochki_schedule_app/pubspec.yaml
+++ b/packages/bochki_schedule_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_app
 description: Application package for the Bochki Schedule desktop app.
 publish_to: none
-version: 0.13.0
+version: 0.13.1
 
 environment:
   sdk: ^3.5.0

--- a/packages/bochki_schedule_domain/pubspec.yaml
+++ b/packages/bochki_schedule_domain/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_domain
 description: Domain package for Bochki Schedule.
 publish_to: none
-version: 0.13.0
+version: 0.13.1
 
 environment:
   sdk: ^3.5.0

--- a/packages/bochki_schedule_infra/pubspec.yaml
+++ b/packages/bochki_schedule_infra/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_infra
 description: Infrastructure package for Bochki Schedule.
 publish_to: none
-version: 0.13.0
+version: 0.13.1
 
 environment:
   sdk: ^3.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bochki_schedule_workspace
 publish_to: none
-version: 0.13.0
+version: 0.13.1
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
Подготавливает patch-релиз v0.13.1: обновляет версии пакетов и changelog для #142 и #143.

Tag `v0.13.1` уже создан на этом commit; после merge commit станет частью main.