### PR TITLE
chore(release): v0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.13.2
+
+Release date: 2026-08-26
+
+### Highlights
+
+- Stabilized desktop child-window behavior during close and initialization.
+
+### Details
+
+- `fix(windows): use localized child content context (#147)`
+- `fix: prevent child window close race (#149)`
+- `fix(windows): route close events to the correct window (#150)`
+
 ## v0.13.1
 
 Release date: 2026-08-25

--- a/packages/bochki_schedule_app/pubspec.yaml
+++ b/packages/bochki_schedule_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_app
 description: Application package for the Bochki Schedule desktop app.
 publish_to: none
-version: 0.13.1
+version: 0.13.2
 
 environment:
   sdk: ^3.5.0

--- a/packages/bochki_schedule_domain/pubspec.yaml
+++ b/packages/bochki_schedule_domain/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_domain
 description: Domain package for Bochki Schedule.
 publish_to: none
-version: 0.13.1
+version: 0.13.2
 
 environment:
   sdk: ^3.5.0

--- a/packages/bochki_schedule_infra/pubspec.yaml
+++ b/packages/bochki_schedule_infra/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_infra
 description: Infrastructure package for Bochki Schedule.
 publish_to: none
-version: 0.13.1
+version: 0.13.2
 
 environment:
   sdk: ^3.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bochki_schedule_workspace
 publish_to: none
-version: 0.13.1
+version: 0.13.2
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
Подготавливает patch-релиз v0.13.2: обновляет версии пакетов и changelog для #147, #149 и #150.

Tag `v0.13.2` уже создан на этом commit; после merge commit станет частью main.

## How It Was Verified

- `dart run melos run format-check`
- `dart run melos run analyze`
- `dart run melos run test`