### PR TITLE
fix(procedure-kinds): adapt dialog to narrow windows

### DIFF
--- a/packages/bochki_schedule_app/lib/src/features/procedure_kinds/procedure_kind_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_kinds/procedure_kind_dialog.dart
@@ -25,6 +25,7 @@ class ProcedureKindDialog extends StatefulWidget {
 
 class _ProcedureKindDialogState extends State<ProcedureKindDialog> {
   static const double _dialogWidth = 640;
+  static const double _wideLayoutMinWidth = 520;
   static const double _labelColumnWidth = 172;
   static const double _selectFieldWidth = 320;
   static const double _numericFieldWidth = 72;
@@ -182,6 +183,11 @@ class _ProcedureKindDialogState extends State<ProcedureKindDialog> {
     return AnimatedBuilder(
       animation: widget.viewModel,
       builder: (context, _) {
+        final contentWidth = (MediaQuery.sizeOf(context).width - 128)
+            .clamp(0.0, _dialogWidth)
+            .toDouble();
+        final isNarrowLayout = contentWidth < _wideLayoutMinWidth;
+
         return AlertDialog(
           key: Key(
             widget.isEditing
@@ -192,7 +198,7 @@ class _ProcedureKindDialogState extends State<ProcedureKindDialog> {
             widget.isEditing ? 'Редактирование процедуры' : 'Новая процедура',
           ),
           content: SizedBox(
-            width: _dialogWidth,
+            width: contentWidth,
             child: SingleChildScrollView(
               child: Column(
                 mainAxisSize: MainAxisSize.min,
@@ -201,6 +207,7 @@ class _ProcedureKindDialogState extends State<ProcedureKindDialog> {
                   _FormRow(
                     label: 'Тип процедуры',
                     labelWidth: _labelColumnWidth,
+                    isNarrowLayout: isNarrowLayout,
                     child: SizedBox(
                       width: _selectFieldWidth,
                       child: DropdownButtonFormField<String>(
@@ -223,6 +230,7 @@ class _ProcedureKindDialogState extends State<ProcedureKindDialog> {
                   _FormRow(
                     label: 'Название',
                     labelWidth: _labelColumnWidth,
+                    isNarrowLayout: isNarrowLayout,
                     child: TextField(
                       key: const Key('procedure_kind_name_field'),
                       controller: _nameController,
@@ -234,6 +242,7 @@ class _ProcedureKindDialogState extends State<ProcedureKindDialog> {
                   _FormRow(
                     label: 'Краткое название',
                     labelWidth: _labelColumnWidth,
+                    isNarrowLayout: isNarrowLayout,
                     child: TextField(
                       key: const Key('procedure_kind_short_name_field'),
                       controller: _shortNameController,
@@ -245,6 +254,7 @@ class _ProcedureKindDialogState extends State<ProcedureKindDialog> {
                   _FormRow(
                     label: 'Емкость',
                     labelWidth: _labelColumnWidth,
+                    isNarrowLayout: isNarrowLayout,
                     child: _NumericField(
                       fieldKey: const Key('procedure_kind_capacity_field'),
                       controller: _capacityController,
@@ -265,6 +275,7 @@ class _ProcedureKindDialogState extends State<ProcedureKindDialog> {
                   _FormRow(
                     label: 'Время участника (мин)',
                     labelWidth: _labelColumnWidth,
+                    isNarrowLayout: isNarrowLayout,
                     child: _NumericField(
                       fieldKey: const Key(
                         'procedure_kind_participant_busy_time_field',
@@ -295,6 +306,7 @@ class _ProcedureKindDialogState extends State<ProcedureKindDialog> {
                     _FormRow(
                       label: 'Время сопровождающего (мин)',
                       labelWidth: _labelColumnWidth,
+                      isNarrowLayout: isNarrowLayout,
                       child: _NumericField(
                         fieldKey: const Key(
                           'procedure_kind_assistant_busy_time_field',
@@ -324,6 +336,7 @@ class _ProcedureKindDialogState extends State<ProcedureKindDialog> {
                     _FormRow(
                       label: 'Время ресурса (мин)',
                       labelWidth: _labelColumnWidth,
+                      isNarrowLayout: isNarrowLayout,
                       child: _NumericField(
                         fieldKey: const Key(
                           'procedure_kind_resource_busy_time_field',
@@ -386,15 +399,28 @@ class _FormRow extends StatelessWidget {
   const _FormRow({
     required this.label,
     required this.labelWidth,
+    required this.isNarrowLayout,
     required this.child,
   });
 
   final String label;
   final double labelWidth;
+  final bool isNarrowLayout;
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
+    if (isNarrowLayout) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label),
+          const SizedBox(height: 4),
+          child,
+        ],
+      );
+    }
+
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -1726,6 +1726,29 @@ void main() {
     expect(capacityFieldWidth, equals(participantTimeFieldWidth));
   });
 
+  testWidgets('procedure kind form adapts to a narrow window', (tester) async {
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final context = _buildTestContext();
+
+    await tester.pumpWidget(BochkiScheduleApp(services: context.services));
+    await tester.pumpAndSettle();
+    await _openProcedureKindsDialog(tester);
+    await tester.tap(find.byKey(const Key('procedure_kind_add_button')));
+    await tester.pumpAndSettle();
+    await tester.binding.setSurfaceSize(const Size(480, 800));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('procedure_kind_assistant_busy_time_field')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('procedure_kind_resource_busy_time_field')),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('procedure kind create form defaults capacity to 1', (
     tester,
   ) async {


### PR DESCRIPTION
Closes #156

- adapts the procedure kind dialog to the available window width
- uses a one-column layout for narrow windows while retaining the compact two-column desktop layout
- adds a widget regression test for curated time fields in a narrow viewport

Local verification:
- `flutter analyze lib/src/features/procedure_kinds/procedure_kind_dialog.dart test/bochki_schedule_app_test.dart`
- `flutter test test/bochki_schedule_app_test.dart --plain-name "procedure kind form adapts to a narrow window"`