### PR TITLE
fix(procedure-sessions): support grouped procedure leaders

### DIFF
--- a/packages/bochki_schedule_app/lib/src/data/procedure_kinds/project_document_procedure_kinds_repository.dart
+++ b/packages/bochki_schedule_app/lib/src/data/procedure_kinds/project_document_procedure_kinds_repository.dart
@@ -40,7 +40,12 @@ final class ProjectDocumentProcedureKindsRepository
         entry.toDomain(),
         deleted: entry.deleted,
       );
-      if (entry.toJson().toString() == normalized.toJson().toString()) {
+      final currentJson = entry.toJson();
+      final normalizedJson = normalized.toJson();
+      if (entry.patternId == 'grouped' && entry.assistantBusyTime == null) {
+        normalizedJson.remove('companionBusyTime');
+      }
+      if (currentJson.toString() == normalizedJson.toString()) {
         continue;
       }
 

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_kinds/procedure_kind.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_kinds/procedure_kind.dart
@@ -47,7 +47,11 @@ final class ProcedureKind {
 
   bool get isCurated => patternId == ProcedureKindPatterns.curated.patternId;
 
-  bool get usesAssistant => assistantBusyTime != null;
+  bool get isGrouped => patternId == ProcedureKindPatterns.grouped.patternId;
+
+  bool get requiresAssistant => isCurated || isGrouped;
+
+  bool get usesAssistant => requiresAssistant;
 
   static String normalizeName(String value) {
     return NamedDirectoryEntry.normalizeName(value);
@@ -65,6 +69,13 @@ final class ProcedureKind {
   ProcedureKind sanitizedForPersistence() {
     if (isCurated) {
       return this;
+    }
+
+    if (isGrouped) {
+      return copyWith(
+        assistantBusyTime: participantBusyTime,
+        resourceBusyTime: participantBusyTime,
+      );
     }
 
     return copyWith(

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_conflict_calculator.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_conflict_calculator.dart
@@ -169,6 +169,7 @@ final class ProcedureSessionConflictCalculator {
           timeFinish: assistantFinishTime,
           procedureSessionId: session.id,
           capacityAllowed: 1,
+          isGroupedLeader: procedureKind.isGrouped,
         ),
       );
     }
@@ -204,7 +205,7 @@ final class ProcedureSessionConflictCalculator {
       }
 
       final capacityAllowed = activeRecords.first.capacityAllowed;
-      final capacityRegistered = activeRecords.length;
+      final capacityRegistered = _effectiveCapacityRegistered(activeRecords);
       if (capacityRegistered <= capacityAllowed) {
         continue;
       }
@@ -231,6 +232,20 @@ final class ProcedureSessionConflictCalculator {
     }
 
     return conflicts;
+  }
+
+  int _effectiveCapacityRegistered(
+    List<ProcedureSessionOccupancyRecord> activeRecords,
+  ) {
+    final occupancyKeys = <String>{};
+    for (final record in activeRecords) {
+      occupancyKeys.add(
+        record.isGroupedLeader
+            ? 'grouped|${record.timeStart}'
+            : 'session|${record.procedureSessionId}',
+      );
+    }
+    return occupancyKeys.length;
   }
 
   List<ScheduleConflict> _mergeAdjacentConflicts(

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_occupancy_record.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_occupancy_record.dart
@@ -9,6 +9,7 @@ final class ProcedureSessionOccupancyRecord {
     required this.timeFinish,
     required this.procedureSessionId,
     required this.capacityAllowed,
+    this.isGroupedLeader = false,
   });
 
   final ConflictResourceType resourceType;
@@ -18,4 +19,5 @@ final class ProcedureSessionOccupancyRecord {
   final String timeFinish;
   final String procedureSessionId;
   final int capacityAllowed;
+  final bool isGroupedLeader;
 }

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_rich.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_rich.dart
@@ -28,7 +28,7 @@ final class ProcedureSessionRich {
   String get procedureKindId => raw.procedureKindId;
   String? get assistantId => raw.assistantId;
 
-  bool get requiresAssistant => procedureKind?.isCurated ?? false;
+  bool get requiresAssistant => procedureKind?.requiresAssistant ?? false;
 
   String? get finishTime {
     final kind = procedureKind;

--- a/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_validator.dart
+++ b/packages/bochki_schedule_app/lib/src/domain/procedure_sessions/procedure_session_validator.dart
@@ -37,7 +37,7 @@ abstract final class ProcedureSessionValidator {
       throw const ProcedureSessionsValidationException('Выберите процедуру.');
     }
 
-    if (procedureKind.isCurated) {
+    if (procedureKind.requiresAssistant) {
       if (procedureSession.assistantId == null) {
         throw const ProcedureSessionsValidationException(
           'Выберите ассистента.',

--- a/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_session_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_session_dialog.dart
@@ -81,7 +81,8 @@ class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
     return null;
   }
 
-  bool get requiresAssistant => _selectedProcedureKind?.isCurated ?? false;
+  bool get requiresAssistant =>
+      _selectedProcedureKind?.requiresAssistant ?? false;
   bool get _isBusy => widget.isSaving || _isSubmitting;
 
   List<String> get _hours {

--- a/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_sessions_view_model.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_sessions_view_model.dart
@@ -255,7 +255,7 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
           ? 'missing-procedure'
           : firstProcedureKind.id,
       assistantId: firstProcedureKind != null &&
-              firstProcedureKind.isCurated &&
+              firstProcedureKind.requiresAssistant &&
               _assistants.isNotEmpty
           ? _assistants.first.id
           : null,

--- a/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
+++ b/packages/bochki_schedule_app/test/bochki_schedule_app_test.dart
@@ -1608,7 +1608,7 @@ void main() {
     expect(
         context
             .procedureKindsRepository.procedureKinds.single.assistantBusyTime,
-        isNull);
+        30);
 
     await tester.tap(find.byKey(const Key('procedure_kind_delete_1')));
     await tester.pumpAndSettle();

--- a/packages/bochki_schedule_app/test/data/procedure_kinds/project_document_procedure_kinds_repository_test.dart
+++ b/packages/bochki_schedule_app/test/data/procedure_kinds/project_document_procedure_kinds_repository_test.dart
@@ -197,4 +197,32 @@ void main() {
       isTrue,
     );
   });
+
+  test('reads a legacy grouped kind with derived leader busy time', () async {
+    var changeNotifications = 0;
+    final repository = ProjectDocumentProcedureKindsRepository(
+      initialDocument: const ProjectDocument(
+        procedureKinds: <Map<String, Object?>>[
+          <String, Object?>{
+            'id': 1,
+            'patternId': 'grouped',
+            'name': 'Медитация',
+            'shortName': 'Медитация',
+            'capacity': 10,
+            'clientBusyTime': 40,
+            'resourceBusyTime': 40,
+            'deleted': false,
+          },
+        ],
+      ),
+      idAllocator: ProjectDocumentIdAllocator(nextId: 2, onChanged: () {}),
+      onChanged: () => changeNotifications += 1,
+    );
+
+    final procedureKind = (await repository.list()).single;
+
+    expect(procedureKind.assistantBusyTime, 40);
+    expect(await repository.normalizeLegacyProcedureKinds(), isFalse);
+    expect(changeNotifications, 0);
+  });
 }

--- a/packages/bochki_schedule_app/test/domain/procedure_sessions/procedure_sessions_use_cases_test.dart
+++ b/packages/bochki_schedule_app/test/domain/procedure_sessions/procedure_sessions_use_cases_test.dart
@@ -119,6 +119,36 @@ void main() {
       );
     });
 
+    test('grouped procedure kind requires assistant', () async {
+      final repository = _InMemoryProcedureSessionsRepository();
+
+      expect(
+        () => CreateProcedureSessionUseCase(
+          repository,
+          workdaysRepository: _InMemoryWorkdaysRepository(),
+          humansRepository: _InMemoryHumansRepository(),
+          procedureKindsRepository: _InMemoryProcedureKindsRepository(),
+          assistantsRepository: _InMemoryAssistantsRepository(),
+          programSettingsRepository: _InMemoryProgramSettingsRepository(),
+        ).execute(
+          ProcedureSessionRaw(
+            id: 'draft',
+            dayId: '1',
+            participantId: '1',
+            startTime: '09:30',
+            procedureKindId: '3',
+          ),
+        ),
+        throwsA(
+          isA<ProcedureSessionsValidationException>().having(
+            (error) => error.message,
+            'message',
+            'Выберите ассистента.',
+          ),
+        ),
+      );
+    });
+
     test('list sorts by dayId startTime procedureKindId and id', () async {
       final repository = _InMemoryProcedureSessionsRepository(
         sessions: [
@@ -329,6 +359,71 @@ void main() {
       ], programSettings: ProgramSettings.defaults);
 
       expect(noConflicts, isEmpty);
+    });
+
+    test('grouped sessions sharing a leader and start time do not conflict',
+        () {
+      const calculator = ProcedureSessionConflictCalculator();
+      final groupedKind = ProcedureKind(
+        id: '100',
+        patternId: ProcedureKindPatterns.grouped.patternId,
+        name: 'Медитация',
+        capacity: 2,
+        participantBusyTime: 30,
+      ).sanitizedForPersistence();
+
+      final conflicts = calculator.calculate([
+        _buildRichSession(
+          id: '1',
+          participantId: '10',
+          startTime: '10:00',
+          procedureKind: groupedKind,
+          assistantId: '20',
+        ),
+        _buildRichSession(
+          id: '2',
+          participantId: '11',
+          startTime: '10:00',
+          procedureKind: groupedKind,
+          assistantId: '20',
+        ),
+      ], programSettings: ProgramSettings.defaults);
+
+      expect(conflicts, isEmpty);
+    });
+
+    test('grouped sessions with a shared leader at different times conflict',
+        () {
+      const calculator = ProcedureSessionConflictCalculator();
+      final groupedKind = ProcedureKind(
+        id: '100',
+        patternId: ProcedureKindPatterns.grouped.patternId,
+        name: 'Медитация',
+        capacity: 2,
+        participantBusyTime: 30,
+      ).sanitizedForPersistence();
+
+      final conflicts = calculator.calculate([
+        _buildRichSession(
+          id: '1',
+          participantId: '10',
+          startTime: '10:00',
+          procedureKind: groupedKind,
+          assistantId: '20',
+        ),
+        _buildRichSession(
+          id: '2',
+          participantId: '11',
+          startTime: '10:15',
+          procedureKind: groupedKind,
+          assistantId: '20',
+        ),
+      ], programSettings: ProgramSettings.defaults);
+
+      expect(
+        conflicts.where((conflict) => conflict.humanId == '20'),
+        hasLength(2),
+      );
     });
 
     test('conflict calculator reports missing required assignments', () {
@@ -655,6 +750,13 @@ final class _InMemoryProcedureKindsRepository
           capacity: 2,
           participantBusyTime: 20,
         ),
+        ProcedureKind(
+          id: '3',
+          patternId: ProcedureKindPatterns.grouped.patternId,
+          name: 'Медитация',
+          capacity: 6,
+          participantBusyTime: 30,
+        ).sanitizedForPersistence(),
       ];
 
   @override

--- a/packages/bochki_schedule_app/test/features/procedure_kinds/procedure_kinds_view_model_test.dart
+++ b/packages/bochki_schedule_app/test/features/procedure_kinds/procedure_kinds_view_model_test.dart
@@ -65,8 +65,7 @@ void main() {
       expect(viewModel.formErrorMessage, 'Укажите емкость.');
     });
 
-    test('create clears hidden curated-only fields for grouped pattern',
-        () async {
+    test('create derives leader busy time for grouped pattern', () async {
       await viewModel.loadProcedureKinds();
 
       final createdProcedureKind = await viewModel.createProcedureKind(
@@ -79,7 +78,7 @@ void main() {
       );
 
       expect(createdProcedureKind, isNotNull);
-      expect(createdProcedureKind!.assistantBusyTime, isNull);
+      expect(createdProcedureKind!.assistantBusyTime, 40);
       expect(createdProcedureKind.resourceBusyTime, 40);
     });
 

--- a/packages/bochki_schedule_app/test/features/procedure_sessions/procedure_session_dialog_test.dart
+++ b/packages/bochki_schedule_app/test/features/procedure_sessions/procedure_session_dialog_test.dart
@@ -87,4 +87,61 @@ void main() {
 
     expect(find.text('Петр').last, findsOneWidget);
   });
+
+  testWidgets('grouped procedure requires an enabled assistant field', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ProcedureSessionDialog(
+            initialValue: ProcedureSessionRaw(
+              id: 'draft',
+              dayId: '1',
+              participantId: '1',
+              startTime: '10:00',
+              procedureKindId: '1',
+            ),
+            workdays: [
+              Workday(
+                id: '1',
+                name: 'День 1',
+                calendarDate: DateTime(2026, 7, 11),
+              ),
+            ],
+            humans: [
+              Human(
+                id: '1',
+                name: 'Иван',
+                isParticipant: true,
+                isAssistant: false,
+              ),
+            ],
+            procedureKinds: [
+              ProcedureKind(
+                id: '1',
+                patternId: ProcedureKindPatterns.grouped.patternId,
+                name: 'Медитация',
+                capacity: 6,
+                participantBusyTime: 30,
+              ).sanitizedForPersistence(),
+            ],
+            assistants: [
+              Assistant(id: '2', name: 'Петр'),
+            ],
+            programSettings: ProgramSettings.defaults,
+            onSubmit: (_, __) async =>
+                const ProcedureSessionSubmitResult.saved(),
+          ),
+        ),
+      ),
+    );
+
+    final field = tester.widget<DropdownButtonFormField<String>>(
+      find.byKey(const Key('procedure_session_assistant_field')),
+    );
+
+    expect(field.onChanged, isNotNull);
+    expect(find.text('Выберите ассистента'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Closes #153
Closes #158

- makes a leader mandatory for grouped procedures, both in the UI and domain validation
- derives a grouped leader’s busy time from the participant duration, including legacy data in memory
- permits same-start grouped appointments to share a leader while preserving all other scheduling conflicts
- adds domain, repository, and widget regression coverage

Local verification:
- `cd packages/bochki_schedule_app && dart analyze .`
- `cd packages/bochki_schedule_app && flutter test`