### PR TITLE
fix(procedure-sessions): use desktop window for editing

### DIFF
--- a/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_session_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_session_dialog.dart
@@ -20,6 +20,7 @@ class ProcedureSessionDialog extends StatefulWidget {
     required this.assistants,
     required this.programSettings,
     required this.onSubmit,
+    this.onClose,
     this.isSaving = false,
     super.key,
   });
@@ -34,6 +35,7 @@ class ProcedureSessionDialog extends StatefulWidget {
     ProcedureSessionRaw procedureSession,
     bool allowConflicts,
   ) onSubmit;
+  final FutureOr<void> Function()? onClose;
   final bool isSaving;
 
   bool get isEditing => initialValue.id != 'draft';
@@ -275,9 +277,16 @@ class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
       _formErrorText = result.errorMessage;
     });
 
-    if (result.didSave) {
-      Navigator.of(context).pop();
+    if (result.didSave) await _close();
+  }
+
+  Future<void> _close() async {
+    final onClose = widget.onClose;
+    if (onClose != null) {
+      await onClose();
+      return;
     }
+    if (mounted) Navigator.of(context).pop();
   }
 
   void _clearError() {
@@ -575,7 +584,7 @@ class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
       ),
       actions: [
         TextButton(
-          onPressed: _isBusy ? null : () => Navigator.of(context).pop(),
+          onPressed: _isBusy ? null : () => unawaited(_close()),
           child: const Text('Отмена'),
         ),
         FilledButton(

--- a/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
@@ -354,9 +354,9 @@ final class DesktopWindowCoordinator {
     await _open(DesktopWindowKind.procedureStatistics);
   }
 
-  Future<void> openSession({ProcedureSessionRaw? draft}) async {
+  Future<void> openSession({ProcedureSessionRaw? initialValue}) async {
     await _sessions.load();
-    _sessionDraft = draft;
+    _sessionDraft = initialValue;
     await _open(DesktopWindowKind.procedureSession);
   }
 
@@ -437,7 +437,7 @@ final class DesktopWindowCoordinator {
       case 'openProcedureSession':
         final values = call.arguments as Map?;
         await openSession(
-          draft: values == null
+          initialValue: values == null
               ? null
               : _sessions.createDraft().copyWith(
                     dayId: values['dayId'] as String,
@@ -673,7 +673,7 @@ Future<void> configureChildWindow(DesktopWindowKind kind) async {
   final title = switch (kind) {
     DesktopWindowKind.procedureStatistics => 'Статистика процедур',
     DesktopWindowKind.freeTime => 'Свободное время',
-    DesktopWindowKind.procedureSession => 'Назначить процедуру',
+    DesktopWindowKind.procedureSession => 'Назначенная процедура',
     DesktopWindowKind.participants => 'Участники',
     DesktopWindowKind.assistants => 'Ассистенты',
     DesktopWindowKind.procedureKinds => 'Процедуры',
@@ -1234,9 +1234,6 @@ class _ProcedureSessionWindowState extends State<ProcedureSessionWindow> {
                   'Не удалось сохранить назначенную процедуру.');
             }
             final value = Map<String, dynamic>.from(response);
-            if (value['didSave'] as bool) {
-              await closeCurrentDesktopWindow();
-            }
             return value['didSave'] as bool
                 ? const ProcedureSessionSubmitResult.saved()
                 : (value['conflictMessages'] as List).isNotEmpty
@@ -1245,6 +1242,7 @@ class _ProcedureSessionWindowState extends State<ProcedureSessionWindow> {
                     : ProcedureSessionSubmitResult.error(
                         value['errorMessage'] as String);
           },
+          onClose: closeCurrentDesktopWindow,
         ))));
   }
 }

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -809,23 +809,22 @@ class _BochkiShellState extends State<BochkiShell> {
     required bool isEditing,
     String? procedureSessionId,
   }) async {
-    if (!isEditing) {
-      final coordinator = _desktopWindows;
-      if (coordinator != null) {
-        try {
-          await coordinator.openSession();
-          return;
-        } catch (_) {
-          // Multi-window APIs are unavailable in widget tests and unsupported
-          // targets. Fall back to the in-process dialog in those environments.
-        }
-      }
-    }
     final initialValue = isEditing
         ? _procedureSessionsViewModel.entries
             .firstWhere((entry) => entry.id == procedureSessionId!)
             .raw
         : _procedureSessionsViewModel.createDraft();
+    final coordinator = _desktopWindows;
+    if (coordinator != null) {
+      try {
+        await coordinator.openSession(initialValue: initialValue);
+      } catch (_) {
+        if (mounted) {
+          _showError('Не удалось открыть окно назначенной процедуры.');
+        }
+      }
+      return;
+    }
     await showDialog<void>(
       context: context,
       barrierDismissible: false,

--- a/packages/bochki_schedule_app/test/features/procedure_sessions/procedure_session_dialog_test.dart
+++ b/packages/bochki_schedule_app/test/features/procedure_sessions/procedure_session_dialog_test.dart
@@ -144,4 +144,68 @@ void main() {
     expect(field.onChanged, isNotNull);
     expect(find.text('Выберите ассистента'), findsOneWidget);
   });
+
+  testWidgets('cancel delegates closing to the dialog owner', (tester) async {
+    var closeRequests = 0;
+    var submitRequests = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ProcedureSessionDialog(
+            initialValue: ProcedureSessionRaw(
+              id: 'draft',
+              dayId: '1',
+              participantId: '1',
+              startTime: '10:00',
+              procedureKindId: '1',
+            ),
+            workdays: [
+              Workday(
+                id: '1',
+                name: 'День 1',
+                calendarDate: DateTime(2026, 7, 11),
+              ),
+            ],
+            humans: [
+              Human(
+                id: '1',
+                name: 'Иван',
+                isParticipant: true,
+                isAssistant: false,
+              ),
+            ],
+            procedureKinds: [
+              ProcedureKind(
+                id: '1',
+                patternId: ProcedureKindPatterns.curated.patternId,
+                name: 'Бочка',
+                capacity: 6,
+                participantBusyTime: 30,
+              ),
+            ],
+            assistants: const [],
+            programSettings: ProgramSettings.defaults,
+            onSubmit: (_, __) async {
+              submitRequests += 1;
+              return const ProcedureSessionSubmitResult.saved();
+            },
+            onClose: () {
+              closeRequests += 1;
+            },
+          ),
+        ),
+      ),
+    );
+
+    final cancel = tester.widget<TextButton>(find.widgetWithText(
+      TextButton,
+      'Отмена',
+    ));
+    cancel.onPressed!();
+    await tester.pump();
+
+    expect(closeRequests, 1);
+    expect(submitRequests, 0);
+  });
 }


### PR DESCRIPTION
Closes #159

- Open create and edit flows for procedure sessions in the native desktop child window.
- Delegate dialog closure to its owner, so Cancel and successful save close the native child window instead of leaving a blank Flutter window.
- Add a regression test for cancellation delegation.