### PR TITLE
fix(windows): clean up child engines after native close

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,10 @@ jobs:
         working-directory: packages/bochki_schedule_app
         run: flutter build windows --release
 
+      - name: Run Windows native multi-window regression test
+        working-directory: packages/bochki_schedule_app
+        run: ctest --test-dir build/windows/x64/plugins/desktop_multi_window --build-config Release --output-on-failure
+
       - name: Archive Windows app release
         shell: pwsh
         working-directory: packages/bochki_schedule_app/build/windows/x64/runner/Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.13.4
+
+Release date: 2026-09-01
+
+### Highlights
+
+- Fixed the Windows child-window lifecycle to prevent Vsync errors and
+  intermittent crashes after closing desktop windows.
+
+### Details
+
+- `fix(windows): clean up child Flutter engines after native close (#164)`
+
 ## v0.13.3
 
 Release date: 2026-08-31

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,6 +34,20 @@ Use this checklist on the developer Windows machine after building or running th
 8. Verify that the participants dialog contains the participant name field and the add/edit/delete controls.
 9. Verify that the application stays responsive and does not crash during those actions.
 
+## Windows Window-Lifecycle Stress Checklist
+
+Run this check on a Windows machine with the application console visible.
+
+1. At least 50 times, open an `Назначенная процедура` window, save it, and
+   close it. Repeat the sequence using both the in-app close action and the
+   system `×` button.
+2. At least 50 times, open a `День` editor, change its date through the
+   calendar, and close it. Again use both the in-app close action and `×`.
+3. During and after each sequence, verify that the console contains neither
+   `FlutterEngineOnVsync ... kInternalInconsistency` nor a delayed
+   `Destroyed managed flutter window` printed only when the next child window
+   opens.
+
 ## Nested Windows Smoke Checklist
 
 Run this check on both Windows and macOS:

--- a/packages/bochki_schedule_app/pubspec.yaml
+++ b/packages/bochki_schedule_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_app
 description: Application package for the Bochki Schedule desktop app.
 publish_to: none
-version: 0.13.3
+version: 0.13.4
 
 environment:
   sdk: ^3.5.0

--- a/packages/bochki_schedule_app/windows/runner/main.cpp
+++ b/packages/bochki_schedule_app/windows/runner/main.cpp
@@ -4,6 +4,7 @@
 
 #include "flutter_window.h"
 #include "utils.h"
+#include "desktop_multi_window/desktop_multi_window_plugin.h"
 
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
@@ -36,6 +37,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   while (::GetMessage(&msg, nullptr, 0, 0)) {
     ::TranslateMessage(&msg);
     ::DispatchMessage(&msg);
+    DesktopMultiWindowCleanupClosedWindows();
   }
 
   ::CoUninitialize();

--- a/packages/bochki_schedule_domain/pubspec.yaml
+++ b/packages/bochki_schedule_domain/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_domain
 description: Domain package for Bochki Schedule.
 publish_to: none
-version: 0.13.3
+version: 0.13.4
 
 environment:
   sdk: ^3.5.0

--- a/packages/bochki_schedule_infra/pubspec.yaml
+++ b/packages/bochki_schedule_infra/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_infra
 description: Infrastructure package for Bochki Schedule.
 publish_to: none
-version: 0.13.3
+version: 0.13.4
 
 environment:
   sdk: ^3.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bochki_schedule_workspace
 publish_to: none
-version: 0.13.3
+version: 0.13.4
 
 environment:
   sdk: ^3.5.0

--- a/third_party/desktop_multi_window/PATCHES.md
+++ b/third_party/desktop_multi_window/PATCHES.md
@@ -10,3 +10,12 @@ window compositor until Dart explicitly calls `show()`. Upstream called
 default origin before the final size and position were configured.
 
 The Windows source documents the matching hidden-start contract.
+
+On Windows, closed child-window Flutter engines are removed after the current
+native message has finished dispatching. Previously they remained owned by the
+manager until another child window was created. That left an engine receiving
+Vsync after its native window had gone away, which could log
+`FlutterEngineOnVsync ... kInternalInconsistency` and occasionally crash the
+application. The deferred cleanup is drained by the application message loop;
+it is intentionally not performed from `WM_DESTROY`, where it would delete an
+object while its `OnDestroy` method is still running.

--- a/third_party/desktop_multi_window/windows/CMakeLists.txt
+++ b/third_party/desktop_multi_window/windows/CMakeLists.txt
@@ -22,6 +22,21 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin flutter_wrapper_app)
 target_link_libraries(${PLUGIN_NAME} PRIVATE "dwmapi.lib")
 
+include(CTest)
+if(BUILD_TESTING)
+  add_executable(desktop_multi_window_managed_window_removals_test
+    "test/managed_window_removals_test.cc"
+  )
+  target_compile_features(desktop_multi_window_managed_window_removals_test
+    PRIVATE cxx_std_17)
+  target_include_directories(desktop_multi_window_managed_window_removals_test
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+  add_test(
+    NAME desktop_multi_window_managed_window_removals_test
+    COMMAND desktop_multi_window_managed_window_removals_test
+  )
+endif()
+
 # List of absolute paths to libraries that should be bundled with the plugin
 set(desktop_multi_window_bundled_libraries
   ""

--- a/third_party/desktop_multi_window/windows/desktop_multi_window_plugin.cpp
+++ b/third_party/desktop_multi_window/windows/desktop_multi_window_plugin.cpp
@@ -106,6 +106,10 @@ void DesktopMultiWindowPluginRegisterWithRegistrar(
       GetAncestor(hwnd, GA_ROOT), registrar);
 }
 
+void DesktopMultiWindowCleanupClosedWindows() {
+  MultiWindowManager::Instance()->CleanupRemovedWindows();
+}
+
 void InternalMultiWindowPluginRegisterWithRegistrar(
     FlutterDesktopPluginRegistrarRef registrar,
     FlutterWindowWrapper* window) {

--- a/third_party/desktop_multi_window/windows/include/desktop_multi_window/desktop_multi_window_plugin.h
+++ b/third_party/desktop_multi_window/windows/include/desktop_multi_window/desktop_multi_window_plugin.h
@@ -20,6 +20,10 @@ FLUTTER_PLUGIN_EXPORT void DesktopMultiWindowPluginRegisterWithRegistrar(
 typedef void (*WindowCreatedCallback)(void *flutter_view_controller);
 FLUTTER_PLUGIN_EXPORT void DesktopMultiWindowSetWindowCreatedCallback(WindowCreatedCallback callback);
 
+// Destroys child-window engines queued during the preceding native message
+// dispatch. This must be called after DispatchMessage returns.
+FLUTTER_PLUGIN_EXPORT void DesktopMultiWindowCleanupClosedWindows();
+
 #if defined(__cplusplus)
 }  // extern "C"
 #endif

--- a/third_party/desktop_multi_window/windows/managed_window_removals.h
+++ b/third_party/desktop_multi_window/windows/managed_window_removals.h
@@ -1,0 +1,31 @@
+#ifndef DESKTOP_MULTI_WINDOW_WINDOWS_MANAGED_WINDOW_REMOVALS_H_
+#define DESKTOP_MULTI_WINDOW_WINDOWS_MANAGED_WINDOW_REMOVALS_H_
+
+#include <set>
+#include <string>
+#include <vector>
+
+/// Collects managed Flutter windows that must be destroyed after the current
+/// native window message has finished dispatching.
+///
+/// A FlutterWindow cannot remove its owning entry from MultiWindowManager in
+/// OnDestroy: OnDestroy runs inside WM_DESTROY, so that would delete the
+/// object while one of its methods is still executing. The application message
+/// loop drains this queue immediately after DispatchMessage returns.
+class ManagedWindowRemovals {
+ public:
+  void Schedule(const std::string& window_id) { pending_ids_.insert(window_id); }
+
+  std::vector<std::string> TakePending() {
+    std::vector<std::string> result(pending_ids_.begin(), pending_ids_.end());
+    pending_ids_.clear();
+    return result;
+  }
+
+  bool empty() const { return pending_ids_.empty(); }
+
+ private:
+  std::set<std::string> pending_ids_;
+};
+
+#endif  // DESKTOP_MULTI_WINDOW_WINDOWS_MANAGED_WINDOW_REMOVALS_H_

--- a/third_party/desktop_multi_window/windows/multi_window_manager.cc
+++ b/third_party/desktop_multi_window/windows/multi_window_manager.cc
@@ -155,19 +155,19 @@ void MultiWindowManager::RemoveWindow(const std::string& window_id) {
 
 void MultiWindowManager::RemoveManagedFlutterWindowLater(
     const std::string& window_id) {
-  pending_remove_ids_.push_back(window_id);
+  pending_removals_.Schedule(window_id);
 }
 
-// FIXME:maybe need a more robust way to cleanup removed windows
+// This runs after the native close message has returned to the application
+// message loop. Erasing earlier would delete FlutterWindow during OnDestroy.
 void MultiWindowManager::CleanupRemovedWindows() {
-  for (auto& id : pending_remove_ids_) {
+  for (const auto& id : pending_removals_.TakePending()) {
     auto it = managed_flutter_windows_.find(id);
     if (it != managed_flutter_windows_.end()) {
       std::cout << "Destroyed managed flutter window: " << id << std::endl;
       managed_flutter_windows_.erase(it);
     }
   }
-  pending_remove_ids_.clear();
 }
 
 void MultiWindowManager::NotifyWindowsChanged() {

--- a/third_party/desktop_multi_window/windows/multi_window_manager.h
+++ b/third_party/desktop_multi_window/windows/multi_window_manager.h
@@ -8,6 +8,7 @@
 #include "flutter_plugin_registrar.h"
 #include "flutter_window.h"
 #include "flutter_window_wrapper.h"
+#include "managed_window_removals.h"
 
 class MultiWindowManager {
  public:
@@ -26,6 +27,10 @@ class MultiWindowManager {
 
   void RemoveManagedFlutterWindowLater(const std::string& window_id);
 
+  /// Destroys windows queued during the preceding native message dispatch.
+  /// Call this only after DispatchMessage has returned.
+  void CleanupRemovedWindows();
+
   flutter::EncodableList GetAllWindows();
 
   std::vector<std::string> GetAllWindowIds();
@@ -33,12 +38,10 @@ class MultiWindowManager {
  private:
   void NotifyWindowsChanged();
 
-  void CleanupRemovedWindows();
-
   std::map<std::string, std::unique_ptr<FlutterWindowWrapper>> windows_;
   std::map<std::string, std::unique_ptr<FlutterWindow>>
       managed_flutter_windows_;
-  std::vector<std::string> pending_remove_ids_;
+  ManagedWindowRemovals pending_removals_;
 };
 
 #endif  // DESKTOP_MULTI_WINDOW_WINDOWS_MULTI_WINDOW_MANAGER_H_

--- a/third_party/desktop_multi_window/windows/test/managed_window_removals_test.cc
+++ b/third_party/desktop_multi_window/windows/test/managed_window_removals_test.cc
@@ -1,0 +1,43 @@
+#include "managed_window_removals.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+bool Expect(bool condition, const char* message) {
+  if (condition) return true;
+  std::cerr << "Expectation failed: " << message << std::endl;
+  return false;
+}
+
+}  // namespace
+
+int main() {
+  ManagedWindowRemovals removals;
+
+  removals.Schedule("procedure-session");
+  removals.Schedule("procedure-session");
+  removals.Schedule("workday-editor");
+
+  if (!Expect(!removals.empty(), "scheduled removals must be retained")) {
+    return 1;
+  }
+
+  const auto pending = removals.TakePending();
+  if (!Expect(pending == std::vector<std::string>{"procedure-session",
+                                                   "workday-editor"},
+              "duplicate closes must produce one removal per window")) {
+    return 1;
+  }
+  if (!Expect(removals.empty(), "draining removals must clear the queue")) {
+    return 1;
+  }
+  if (!Expect(removals.TakePending().empty(),
+              "a second drain must not repeat a removal")) {
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Closes #164

## What changed

- cleans up closed Windows child Flutter engines after the current native message dispatch instead of waiting for a subsequent window creation;
- adds a native C++ regression test and runs it in the Windows CI job;
- documents the lifecycle regression checklist and releases v0.13.4.

## Verification

- `g++ -std=c++17 -Wall -Wextra -Werror ...managed_window_removals_test.cc`
- `flutter test test/presentation/desktop_windows_test.dart -r expanded`
- full workspace tests passed locally; Linux desktop integration requires Xvfb, which is unavailable locally and remains covered by CI.