### PR TITLE
chore(release): v0.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.13.5
+
+Release date: 2026-09-01
+
+### Highlights
+
+- New assigned procedures reuse the values from the last successfully saved
+  assignment during the current application run.
+
+### Details
+
+- `feat(procedure-sessions): reuse last saved values (#165)`
+
 ## v0.13.4
 
 Release date: 2026-09-01

--- a/packages/bochki_schedule_app/pubspec.yaml
+++ b/packages/bochki_schedule_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_app
 description: Application package for the Bochki Schedule desktop app.
 publish_to: none
-version: 0.13.4
+version: 0.13.5
 
 environment:
   sdk: ^3.5.0

--- a/packages/bochki_schedule_domain/pubspec.yaml
+++ b/packages/bochki_schedule_domain/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_domain
 description: Domain package for Bochki Schedule.
 publish_to: none
-version: 0.13.4
+version: 0.13.5
 
 environment:
   sdk: ^3.5.0

--- a/packages/bochki_schedule_infra/pubspec.yaml
+++ b/packages/bochki_schedule_infra/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_infra
 description: Infrastructure package for Bochki Schedule.
 publish_to: none
-version: 0.13.4
+version: 0.13.5
 
 environment:
   sdk: ^3.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bochki_schedule_workspace
 publish_to: none
-version: 0.13.4
+version: 0.13.5
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
Prepare release v0.13.5.

- bump workspace package versions
- document #165 in the changelog