### PR TITLE
fix: add diagnostics for procedure session saves

### DIFF
--- a/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_session_dialog.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_session_dialog.dart
@@ -20,6 +20,7 @@ class ProcedureSessionDialog extends StatefulWidget {
     required this.assistants,
     required this.programSettings,
     required this.onSubmit,
+    this.onSavedAndRendered,
     this.onClose,
     this.isSaving = false,
     super.key,
@@ -35,6 +36,7 @@ class ProcedureSessionDialog extends StatefulWidget {
     ProcedureSessionRaw procedureSession,
     bool allowConflicts,
   ) onSubmit;
+  final Future<void> Function(int operationId)? onSavedAndRendered;
   final FutureOr<void> Function()? onClose;
   final bool isSaving;
 
@@ -277,7 +279,10 @@ class _ProcedureSessionDialogState extends State<ProcedureSessionDialog> {
       _formErrorText = result.errorMessage;
     });
 
-    if (result.didSave) await _close();
+    if (result.didSave) {
+      await widget.onSavedAndRendered?.call(result.operationId!);
+      await _close();
+    }
   }
 
   Future<void> _close() async {

--- a/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_session_submit_result.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_session_submit_result.dart
@@ -3,11 +3,13 @@ final class ProcedureSessionSubmitResult {
     required this.didSave,
     this.conflictMessages = const [],
     this.errorMessage,
+    this.operationId,
   });
 
-  const ProcedureSessionSubmitResult.saved()
+  const ProcedureSessionSubmitResult.saved(int operationId)
       : this._(
           didSave: true,
+          operationId: operationId,
         );
 
   const ProcedureSessionSubmitResult.conflicts(List<String> conflictMessages)
@@ -25,6 +27,7 @@ final class ProcedureSessionSubmitResult {
   final bool didSave;
   final List<String> conflictMessages;
   final String? errorMessage;
+  final int? operationId;
 
   bool get hasConflicts => conflictMessages.isNotEmpty;
 }

--- a/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_sessions_view_model.dart
+++ b/packages/bochki_schedule_app/lib/src/features/procedure_sessions/procedure_sessions_view_model.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:bochki_schedule_domain/bochki_schedule_domain.dart';
+import 'package:bochki_schedule_infra/bochki_schedule_infra.dart';
 
 import '../../domain/assistants/assistant.dart';
 import '../../domain/assistants/list_assistants_use_case.dart';
@@ -49,6 +52,7 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
     required ListProcedureKindsUseCase listProcedureKindsUseCase,
     required ListAssistantsUseCase listAssistantsUseCase,
     required GetProgramSettingsUseCase getProgramSettingsUseCase,
+    required AppLogger logger,
     ProcedureSessionConflictCalculator? conflictCalculator,
     ProcedureSessionConflictMessageFormatter? conflictMessageFormatter,
     ProcedureSessionRichFactory? richFactory,
@@ -62,6 +66,7 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
         _listProcedureKindsUseCase = listProcedureKindsUseCase,
         _listAssistantsUseCase = listAssistantsUseCase,
         _getProgramSettingsUseCase = getProgramSettingsUseCase,
+        _logger = logger,
         _conflictCalculator =
             conflictCalculator ?? const ProcedureSessionConflictCalculator(),
         _conflictMessageFormatter = conflictMessageFormatter ??
@@ -78,6 +83,7 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
   final ListProcedureKindsUseCase _listProcedureKindsUseCase;
   final ListAssistantsUseCase _listAssistantsUseCase;
   final GetProgramSettingsUseCase _getProgramSettingsUseCase;
+  final AppLogger _logger;
   final ProcedureSessionConflictCalculator _conflictCalculator;
   final ProcedureSessionConflictMessageFormatter _conflictMessageFormatter;
   final ProcedureSessionRichFactory _richFactory;
@@ -101,6 +107,7 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
   String? _selectedParticipantId;
   bool _showConflictsOnly = false;
   ProcedureSessionRaw? _lastSavedProcedureSession;
+  int _nextSaveOperationId = 1;
 
   List<ProcedureSessionWithConflicts> get entries => _applyFilters(_allEntries);
   List<Workday> get workdays => _workdays;
@@ -304,14 +311,25 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
     ProcedureSessionRaw procedureSession, {
     required bool allowConflicts,
   }) async {
+    final operationId = _nextSaveOperationId++;
     _actionErrorMessage = null;
     _isSaving = true;
     notifyListeners();
 
     try {
+      await _logInfo(
+        operationId,
+        'Save requested. mode=${procedureSession.id == 'draft' ? 'create' : 'update'} '
+        'sessionId=${procedureSession.id} dayId=${procedureSession.dayId} '
+        'participantId=${procedureSession.participantId} '
+        'procedureKindId=${procedureSession.procedureKindId} '
+        'assistantAssigned=${procedureSession.assistantId != null} '
+        'startTime=${procedureSession.startTime} allowConflicts=$allowConflicts.',
+      );
       final candidateId = procedureSession.id == 'draft'
           ? draftConflictSessionId
           : procedureSession.id;
+      await _logInfo(operationId, 'Building projected schedule.');
       final projectedEntries =
           _buildProjectedEntries(procedureSession, candidateId: candidateId);
       final projectedConflicts = projectedEntries
@@ -319,19 +337,28 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
           .expand((entry) => entry.conflicts)
           .toList(growable: false);
       if (projectedConflicts.isNotEmpty && !allowConflicts) {
+        await _logInfo(
+          operationId,
+          'Conflicts require confirmation. count=${projectedConflicts.length}.',
+        );
         return ProcedureSessionSubmitResult.conflicts(
           _formatConflictMessages(projectedConflicts),
         );
       }
 
       if (procedureSession.id == 'draft') {
+        await _logInfo(operationId, 'Creating procedure session via use case.');
         final created = await _createProcedureSessionUseCase.execute(
           procedureSession,
         );
+        await _logInfo(
+            operationId, 'Procedure session created. id=${created.id}.');
+        await _logInfo(operationId, 'Reloading main list data.');
         await _reloadEntries();
         _selectedEntryId = created.id;
         _lastSavedProcedureSession = created;
       } else {
+        await _logInfo(operationId, 'Updating procedure session via use case.');
         final updated = await _updateProcedureSessionUseCase.execute(
           procedureSession,
         );
@@ -339,18 +366,64 @@ final class ProcedureSessionsViewModel extends ChangeNotifier {
         _selectedEntryId = procedureSession.id;
         _lastSavedProcedureSession = updated;
       }
-      return const ProcedureSessionSubmitResult.saved();
+      await _logInfo(
+        operationId,
+        'Main list data reloaded and selection assigned. '
+        'selectedEntryId=$_selectedEntryId.',
+      );
+      return ProcedureSessionSubmitResult.saved(operationId);
     } on ProcedureSessionsValidationException catch (error) {
       _actionErrorMessage = error.message;
+      await _logInfo(operationId, 'Validation rejected save: ${error.message}');
       return ProcedureSessionSubmitResult.error(error.message);
-    } catch (_) {
+    } catch (error, stackTrace) {
       _actionErrorMessage = 'Не удалось сохранить назначенную процедуру.';
-      return const ProcedureSessionSubmitResult.error(
-        'Не удалось сохранить назначенную процедуру.',
+      await _logErrorAndPreserveOriginal(
+        operationId,
+        'Unexpected procedure-session save failure.',
+        error,
+        stackTrace,
       );
+      Error.throwWithStackTrace(error, stackTrace);
     } finally {
       _isSaving = false;
       notifyListeners();
+    }
+  }
+
+  Future<void> logRenderedSave(int operationId) => _logInfo(
+        operationId,
+        'Updated main list has been rendered with selectedEntryId=$_selectedEntryId.',
+      );
+
+  Future<void> _logInfo(int operationId, String message) async {
+    try {
+      await _logger.info('[procedure-session-save#$operationId] $message');
+    } catch (error, stackTrace) {
+      stderr.writeln(
+        '[procedure-session-save#$operationId] Failed to write diagnostic log: '
+        '$error\n$stackTrace',
+      );
+    }
+  }
+
+  Future<void> _logErrorAndPreserveOriginal(
+    int operationId,
+    String message,
+    Object error,
+    StackTrace stackTrace,
+  ) async {
+    try {
+      await _logger.error(
+        '[procedure-session-save#$operationId] $message',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    } catch (loggingError, loggingStackTrace) {
+      stderr.writeln(
+        '[procedure-session-save#$operationId] Failed to write error log: '
+        '$loggingError\n$loggingStackTrace',
+      );
     }
   }
 

--- a/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/desktop_windows.dart
@@ -586,9 +586,15 @@ final class DesktopWindowCoordinator {
         }
         return {
           'didSave': result.didSave,
+          'operationId': result.operationId,
           'conflictMessages': result.conflictMessages,
           'errorMessage': result.errorMessage,
         };
+      case 'procedureSessionRendered':
+        final operationId = call.arguments as int;
+        await WidgetsBinding.instance.endOfFrame;
+        await _sessions.logRenderedSave(operationId);
+        return null;
       default:
         throw MissingPluginException(
             'Unknown main-window method ${call.method}');
@@ -1341,13 +1347,16 @@ class _ProcedureSessionWindowState extends State<ProcedureSessionWindow> {
             }
             final value = Map<String, dynamic>.from(response);
             return value['didSave'] as bool
-                ? const ProcedureSessionSubmitResult.saved()
+                ? ProcedureSessionSubmitResult.saved(
+                    value['operationId'] as int)
                 : (value['conflictMessages'] as List).isNotEmpty
                     ? ProcedureSessionSubmitResult.conflicts(
                         (value['conflictMessages'] as List).cast<String>())
                     : ProcedureSessionSubmitResult.error(
                         value['errorMessage'] as String);
           },
+          onSavedAndRendered: (operationId) => _mainChannel.invokeMethod<void>(
+              'procedureSessionRendered', operationId),
           onClose: closeCurrentDesktopWindow,
         ))));
   }

--- a/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
+++ b/packages/bochki_schedule_app/lib/src/presentation/shell/bochki_shell.dart
@@ -108,6 +108,7 @@ class _BochkiShellState extends State<BochkiShell> {
       listProcedureKindsUseCase: widget.services.listProcedureKindsUseCase,
       listAssistantsUseCase: widget.services.listAssistantsUseCase,
       getProgramSettingsUseCase: widget.services.getProgramSettingsUseCase,
+      logger: widget.services.logger,
     );
     final statistics = widget.services.buildProcedureStatisticsTableUseCase;
     final scheduleGaps = widget.services.buildScheduleGapsUseCase;
@@ -842,10 +843,16 @@ class _BochkiShellState extends State<BochkiShell> {
               allowConflicts: allowConflicts,
             );
           },
+          onSavedAndRendered: _confirmProcedureSessionRendered,
           isSaving: _procedureSessionsViewModel.isSaving,
         );
       },
     );
+  }
+
+  Future<void> _confirmProcedureSessionRendered(int operationId) async {
+    await WidgetsBinding.instance.endOfFrame;
+    await _procedureSessionsViewModel.logRenderedSave(operationId);
   }
 
   Future<void> _confirmDeleteProcedureSession(String procedureSessionId) async {

--- a/packages/bochki_schedule_app/test/features/procedure_sessions/procedure_session_dialog_test.dart
+++ b/packages/bochki_schedule_app/test/features/procedure_sessions/procedure_session_dialog_test.dart
@@ -60,7 +60,7 @@ void main() {
               maximumTime: ProgramSettingsTime(hour: 12, minute: 0),
             ),
             onSubmit: (_, __) async =>
-                const ProcedureSessionSubmitResult.saved(),
+                const ProcedureSessionSubmitResult.saved(1),
           ),
         ),
       ),
@@ -131,7 +131,7 @@ void main() {
             ],
             programSettings: ProgramSettings.defaults,
             onSubmit: (_, __) async =>
-                const ProcedureSessionSubmitResult.saved(),
+                const ProcedureSessionSubmitResult.saved(1),
           ),
         ),
       ),
@@ -188,7 +188,7 @@ void main() {
             programSettings: ProgramSettings.defaults,
             onSubmit: (_, __) async {
               submitRequests += 1;
-              return const ProcedureSessionSubmitResult.saved();
+              return const ProcedureSessionSubmitResult.saved(1);
             },
             onClose: () {
               closeRequests += 1;

--- a/packages/bochki_schedule_infra/lib/src/file_app_logger.dart
+++ b/packages/bochki_schedule_infra/lib/src/file_app_logger.dart
@@ -42,10 +42,12 @@ final class FileAppLogger implements AppLogger {
   }
 
   Future<void> _writeLine(String level, String message) async {
-    await logFile.parent.create(recursive: true);
     final timestamp = _clock().toUtc().toIso8601String();
+    final line = '[$timestamp] $level $message';
+    stdout.writeln(line);
+    await logFile.parent.create(recursive: true);
     await logFile.writeAsString(
-      '[$timestamp] $level $message\n',
+      '$line\n',
       mode: FileMode.append,
       flush: true,
     );


### PR DESCRIPTION
Closes #171

## Что изменено
- добавлен инкрементный `operationId` для операций сохранения назначенной процедуры;
- логируются ключевые этапы сохранения, IPC Windows и подтверждённая отрисовка с выделением записи;
- журнал теперь дублируется в консоль процесса и файл с flush;
- непредвиденные ошибки фиксируются с исходным stack trace и повторно пробрасываются;
- дочернее окно закрывается только после подтверждения отрисовки главного списка.

## Проверка
- `flutter analyze` (без новых ошибок; есть существующие предупреждения);
- релевантные widget/unit-тесты проходят;
- полный локальный `flutter test` блокируется двумя существующими падениями SDK при загрузке `shaders/ink_sparkle.frag`.