### PR TITLE
ci: add manual macos lifecycle workflow

### DIFF
--- a/.github/workflows/macos-lifecycle.yml
+++ b/.github/workflows/macos-lifecycle.yml
@@ -1,0 +1,57 @@
+name: macOS lifecycle debug
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-lifecycle-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos-lifecycle:
+    runs-on: macos-15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Read Flutter version from .fvmrc
+        run: |
+          FLUTTER_VERSION="$(python3 - <<'PY'
+          import json
+          print(json.load(open('.fvmrc'))['flutter'])
+          PY
+          )"
+          echo "FLUTTER_VERSION=$FLUTTER_VERSION" >> "$GITHUB_ENV"
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Enable macOS desktop
+        run: flutter config --enable-macos-desktop
+
+      - name: Install workspace dependencies
+        run: |
+          dart pub get
+          dart run melos bootstrap
+
+      - name: Run macOS multi-window lifecycle regression test
+        working-directory: packages/bochki_schedule_app
+        run: |
+          set -o pipefail
+          flutter test integration_test/multi_window_lifecycle_test.dart -d macos --dart-define=INTEGRATION_TEST=true -r expanded 2>&1 | tee multi-window-lifecycle.log
+          ! rg -n 'FlutterEngineOnVsync.*kInternalInconsistency|Unhandled platform error|WindowChannelException' multi-window-lifecycle.log
+
+      - name: Upload macOS lifecycle log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-multi-window-lifecycle-log
+          path: packages/bochki_schedule_app/multi-window-lifecycle.log
+          if-no-files-found: ignore


### PR DESCRIPTION
Adds the manual macOS-only lifecycle workflow described in #181. It is isolated from the release dispatch flow and does not alter the required PR CI jobs.