### PR TITLE
chore(release): v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.14.1
+
+Release date: 2026-09-04
+
+### Highlights
+
+- Stabilized desktop child-window creation and lifecycle handling on macOS and
+  Windows.
+- Updated multi-window compatibility for Flutter 3.24.
+
+### Details
+
+- `fix(windows): adapt multi-window 0.3.1 to Flutter 3.24 (#188)`
+- `refactor(desktop): route child creation through platform adapter (#188)`
+
 ## v0.13.5
 
 Release date: 2026-09-01

--- a/packages/bochki_schedule_app/pubspec.yaml
+++ b/packages/bochki_schedule_app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_app
 description: Application package for the Bochki Schedule desktop app.
 publish_to: none
-version: 0.13.5
+version: 0.14.1
 
 environment:
   sdk: ^3.5.0

--- a/packages/bochki_schedule_domain/pubspec.yaml
+++ b/packages/bochki_schedule_domain/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_domain
 description: Domain package for Bochki Schedule.
 publish_to: none
-version: 0.13.5
+version: 0.14.1
 
 environment:
   sdk: ^3.5.0

--- a/packages/bochki_schedule_infra/pubspec.yaml
+++ b/packages/bochki_schedule_infra/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bochki_schedule_infra
 description: Infrastructure package for Bochki Schedule.
 publish_to: none
-version: 0.13.5
+version: 0.14.1
 
 environment:
   sdk: ^3.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bochki_schedule_workspace
 publish_to: none
-version: 0.13.5
+version: 0.14.1
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
Prepare release v0.14.1.

- bump workspace package versions
- document desktop child-window lifecycle stabilization and Flutter 3.24 compatibility